### PR TITLE
Removing deprecation warning

### DIFF
--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -14,7 +14,7 @@ module Sipity
         let(:entity) { Models::Sip.new }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
-          described_class.confirmation_of_entity_submitted_for_review(entity: entity, to: to).deliver
+          described_class.confirmation_of_entity_submitted_for_review(entity: entity, to: to).deliver_now
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end


### PR DESCRIPTION
DEPRECATION WARNING: `#deliver` is deprecated and will be removed in
Rails 5. Use `#deliver_now` to deliver immediately or `#deliver_later`
 to deliver through Active Job. (called from block (3 levels) in
 <module:Mailers> at ./sipity/spec/mailers/sipity/mailers/email_notifier_spec.rb:17)