### PR TITLE
Removing deprecation warning

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
Following the instructions of the warning:

DEPRECATION WARNING: The configuration option
`config.serve_static_assets` has been renamed to
`config.serve_static_files` to clarify its role (it merely enables
serving everything in the `public` folder and is unrelated to the
asset pipeline). The `serve_static_assets` alias will be removed in
Rails 5.0. Please migrate your configuration files accordingly.
(called from block in <top (required)> at
./sipity/config/environments/test.rb:16)