### PR TITLE
Adding conversion method for entity type

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_polymorphic_type.rb
+++ b/app/conversions/sipity/conversions/convert_to_polymorphic_type.rb
@@ -1,0 +1,29 @@
+module Sipity
+  module Conversions
+    # Exposes a conversion method to take an input and transform it into a
+    # year.
+    module ConvertToPolymorphicType
+      # A convenience method so that you don't need to include the conversion
+      # module in your base class.
+      def self.call(input)
+        convert_to_polymorphic_type(input)
+      end
+
+      # Does its best to convert the input into a year.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Integer
+      def convert_to_polymorphic_type(input)
+        return input.to_polymorphic_type if input.respond_to?(:to_polymorphic_type)
+        return input.base_class if input.respond_to?(:base_class)
+        return input.class.base_class if input.is_a?(ActiveRecord::Base)
+        fail Exceptions::EntityTypeConversionError, input
+      end
+
+      module_function :convert_to_polymorphic_type
+      private_class_method :convert_to_polymorphic_type
+      private :convert_to_polymorphic_type
+    end
+  end
+end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -44,6 +44,13 @@ module Sipity
       end
     end
 
+    # Unable to convert the given object into a permanent URI
+    class EntityTypeConversionError < RuntimeError
+      def initialize(attempted_conversion_object)
+        super("Unable to convert #{attempted_conversion_object.inspect} to an Entity Type")
+      end
+    end
+
     # As you are looking up something by name, within a given container.
     class ConceptNotFoundError < RuntimeError
       def initialize(name:, container:)

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -24,30 +24,34 @@ module Sipity
       #
       # @note Welcome to the land of AREL.
       # @see https://github.com/rails/arel AREL - A Relational Algebra
-      def scope_users_by_entity_and_roles(roles:, entity:, user_class: User, group_class: Models::Group)
-        user_table = user_class.arel_table
+      def scope_users_by_entity_and_roles(roles:, entity:)
+        user_table = User.arel_table
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
         entity_id = entity.to_param
 
+        entity_polymorphic_type = Conversions::ConvertToPolymorphicType.call(entity)
+        group_polymorphic_type = Conversions::ConvertToPolymorphicType.call(Models::Group)
+        user_polymorphic_type = Conversions::ConvertToPolymorphicType.call(User)
+
         subqyery_user_relation_entity = perm_table.project(perm_table[:actor_id]).where(
-          perm_table[:actor_type].eq(user_class.base_class).
+          perm_table[:actor_type].eq(user_polymorphic_type).
           and(perm_table[:role].in(roles)).
-          and(perm_table[:entity_type].eq(entity.class.base_class)).
+          and(perm_table[:entity_type].eq(entity_polymorphic_type)).
           and(perm_table[:entity_id].eq(entity_id))
         )
 
         subquery_user_relation_to_entity_by_group_membership = memb_table.project(memb_table[:user_id]).where(
           memb_table[:user_id].in(
             perm_table.project(perm_table[:actor_id]).where(
-              perm_table[:actor_type].eq(group_class.base_class).
+              perm_table[:actor_type].eq(group_polymorphic_type).
               and(perm_table[:role].in(roles)).
-              and(perm_table[:entity_type].eq(entity.class.base_class)).
+              and(perm_table[:entity_type].eq(entity_polymorphic_type)).
               and(perm_table[:entity_id].eq(entity_id))
             )
           )
         )
-        user_class.where(
+        User.where(
           user_table[:id].in(subquery_user_relation_to_entity_by_group_membership).
           or(user_table[:id].in(subqyery_user_relation_entity))
         )
@@ -71,20 +75,22 @@ module Sipity
       def scope_entities_for_user_and_roles_and_entity_type(entity_type:, user:, roles:)
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
-        group_class =  Models::Group
         actor_id = user.to_param
+        entity_polymorphic_type = Conversions::ConvertToPolymorphicType.call(entity_type)
+        group_polymorphic_type = Conversions::ConvertToPolymorphicType.call(Models::Group)
+        user_polymorphic_type = Conversions::ConvertToPolymorphicType.call(user)
 
         subquery_entity_relation_to_user = perm_table.project(perm_table[:entity_id]).where(
           perm_table[:actor_id].eq(actor_id).
-          and(perm_table[:actor_type].eq(user.class.base_class)).
+          and(perm_table[:actor_type].eq(user_polymorphic_type)).
           and(perm_table[:role].in(roles)).
-          and(perm_table[:entity_type].eq(entity_type.base_class))
+          and(perm_table[:entity_type].eq(entity_polymorphic_type))
         )
 
         subquery_entity_relation_to_user_by_group_membership = perm_table.project(perm_table[:entity_id]).where(
           perm_table[:role].in(roles).
-          and(perm_table[:entity_type].eq(entity_type.base_class)).
-          and(perm_table[:actor_type].eq(group_class.base_class)).
+          and(perm_table[:entity_type].eq(entity_polymorphic_type)).
+          and(perm_table[:actor_type].eq(group_polymorphic_type)).
           and(perm_table[:actor_id].in(memb_table.project(memb_table[:group_id]).where(memb_table[:user_id].eq(actor_id))))
         )
 

--- a/spec/conversions/sipity/conversions/convert_to_polymorphic_type_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_polymorphic_type_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToPolymorphicType do
+      include ::Sipity::Conversions::ConvertToPolymorphicType
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          object = double(to_polymorphic_type: 'Hello')
+          expect(described_class.call(object)).to eq(object.to_polymorphic_type)
+        end
+      end
+
+      context '.convert_to_polymorphic_type' do
+        it 'will be private' do
+          object = double
+          expect { described_class.convert_to_polymorphic_type(object) }.
+            to raise_error(NoMethodError, /private method `convert_to_polymorphic_type'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_polymorphic_type' do
+        it "will return the object to_polymorphic_type" do
+          object = double(to_polymorphic_type: 'Hello')
+          expect(convert_to_polymorphic_type(object)).to eq('Hello')
+        end
+
+        it "will return an ActiveRecord::Base object's base_class" do
+          object = Models::Sip.new
+          expect(convert_to_polymorphic_type(object)).to eq(Models::Sip)
+        end
+
+        it "will return the base class of a class that extends ActiveRecord::Base" do
+          object = Models::Sip
+          expect(convert_to_polymorphic_type(object)).to eq(Models::Sip)
+        end
+
+        it "will raise an error on any old object" do
+          object = Object.new
+          expect { convert_to_polymorphic_type(object) }.to raise_error(Exceptions::EntityTypeConversionError)
+        end
+      end
+    end
+  end
+end

--- a/spec/repositories/sipity/queries/permission_queries_spec.rb
+++ b/spec/repositories/sipity/queries/permission_queries_spec.rb
@@ -38,7 +38,7 @@ module Sipity
 
         it 'will return an empty result if there are no roles' do
           Models::Permission.create!(entity: entity, actor: user, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: [], entity_type: entity.class.base_class)).
+          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: [], entity_type: entity.class)).
             to_not include(entity)
         end
         it 'will return the entity for the creating user' do
@@ -47,12 +47,12 @@ module Sipity
           # TODO: I have knowledge of the applicable ROLE, this should be passed to the
           #   resolver.
           Models::Permission.create!(entity: entity, actor: user, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class.base_class)).
+          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
             to include(entity)
         end
 
         it 'will exclude the entity for a non creating user' do
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class.base_class)).
+          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
             to_not include(entity)
         end
 
@@ -63,13 +63,13 @@ module Sipity
           # TODO: I have knowledge of the applicable ROLE, this should be passed to the
           #   resolver.
           Models::Permission.create!(entity: entity, actor: group, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class.base_class)).
+          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
             to include(entity)
         end
 
         it 'will exclude the entity for which the user is not part of the group' do
           Models::Permission.create!(entity: entity, actor: group, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class.base_class)).
+          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
             to_not include(entity)
         end
       end


### PR DESCRIPTION
As I'm making assumptions about deriving an object's polymorphic type
from an ActiveRecord::Base object, I want to encode that logic and
meaning. It provides a convenience method to explain to newcomers the
information that is part of Rails's conventions/idioms.

As the second commit, I'm replacing the opaque `class.base_class` with a more
explicit method call, stating what is happening.