### PR TITLE
Adding work_type to Sip

### DIFF
--- a/app/models/sipity/models/sip.rb
+++ b/app/models/sipity/models/sip.rb
@@ -40,8 +40,19 @@ module Sipity
         }
       )
 
+      attr_reader :work_type
+
       def possible_work_publication_strategies
         self.class.work_publication_strategies
+      end
+
+      def work_type=(work_type)
+        fail ArgumentError unless Sip.work_types.key?(work_type)
+        @work_type = Sip.work_types.fetch(work_type)
+      end
+
+      def self.work_types
+        { 'ETD' => 'ETD' }
       end
     end
   end

--- a/spec/models/sipity/models/sip_spec.rb
+++ b/spec/models/sipity/models/sip_spec.rb
@@ -21,7 +21,7 @@ module Sipity
         end
 
         it 'accepts "ETD" as an acceptable work_type' do
-          expect { subject.work_type = 'ETD' }.to_not raise_error(ArgumentError)
+          expect { subject.work_type = 'ETD' }.to_not raise_error
         end
       end
 

--- a/spec/models/sipity/models/sip_spec.rb
+++ b/spec/models/sipity/models/sip_spec.rb
@@ -8,6 +8,23 @@ module Sipity
       it { should respond_to :processing_state }
       it { should respond_to :processing_state= }
 
+      context '.work_types' do
+        it 'is a Hash of keys that equal their values' do
+          expect(Sip.work_types.keys).
+            to eq(Sip.work_types.values)
+        end
+      end
+
+      context '#work_type' do
+        it 'will raise an ArgumentError if you provide an invalid work_type' do
+          expect { subject.work_type = '__incorrect_work_type__' }.to raise_error(ArgumentError)
+        end
+
+        it 'accepts "ETD" as an acceptable work_type' do
+          expect { subject.work_type = 'ETD' }.to_not raise_error(ArgumentError)
+        end
+      end
+
       its(:possible_work_publication_strategies) { should eq(subject.class.work_publication_strategies) }
 
       context '.work_publication_strategies' do


### PR DESCRIPTION
At this point, the system is being built with ETDs in mind. However,
other work types (i.e. Senior Thesis) may very well enter into the
application. I want to begin laying the ground work for that.

At present, I'm envisioning an enum, as that is the quickest thing to
implement. If Sipity is to become an application for everyone, its
going to get more complicated as we proceed. But that is a problem for
tomorrow.