### PR TITLE
Renaming policy_question to action_to_authorize

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -87,10 +87,10 @@ module Sipity
 
     # Exposing a custom AuthorizationFailureError
     class AuthorizationFailureError < RuntimeError
-      attr_reader :user, :policy_question, :entity
-      def initialize(user:, policy_question:, entity:)
-        @user, @policy_question, @entity = user, policy_question, entity
-        super("#{user} not allowed to #{policy_question} this #{entity}")
+      attr_reader :user, :action_to_authorize, :entity
+      def initialize(user:, action_to_authorize:, entity:)
+        @user, @action_to_authorize, @entity = user, action_to_authorize, entity
+        super("#{user} not allowed to #{action_to_authorize} this #{entity}")
       end
     end
 

--- a/app/policies/sipity/policies.rb
+++ b/app/policies/sipity/policies.rb
@@ -25,9 +25,9 @@ module Sipity
   module Policies
     module_function
 
-    def authorized_for?(user:, policy_question:, entity:)
+    def authorized_for?(user:, action_to_authorize:, entity:)
       policy_enforcer = find_policy_enforcer_for(entity: entity)
-      policy_enforcer.call(user: user, entity: entity, policy_question: policy_question)
+      policy_enforcer.call(user: user, entity: entity, action_to_authorize: action_to_authorize)
     end
 
     def find_policy_enforcer_for(entity:)

--- a/app/policies/sipity/policies/base_policy.rb
+++ b/app/policies/sipity/policies/base_policy.rb
@@ -2,7 +2,7 @@ module Sipity
   module Policies
     # At its core a policy must implement the following API
     #
-    # * .call(user:, entity:, policy_question:)
+    # * .call(user:, entity:, action_to_authorize:)
     # * #initialize(user, entity)
     class BasePolicy
       # Exposed as a convenience method and the public interface into the Policy
@@ -10,25 +10,25 @@ module Sipity
       #
       # @param user [User]
       # @param entity [#persisted?]
-      # @param policy_question [Symbol] In the general case this will be :show?,
+      # @param action_to_authorize [Symbol] In the general case this will be :show?,
       #   :create?, :update?, or :destroy?; However in other cases that may not
       #   be the correct answer.
       #
       # @return [Boolean] If the user can take the action, then return true.
       #   otherwise return false.
-      def self.call(user:, entity:, policy_question:)
-        new(user, entity).public_send(policy_question)
+      def self.call(user:, entity:, action_to_authorize:)
+        new(user, entity).public_send(action_to_authorize)
       end
 
-      class_attribute :registered_policy_questions, instance_writer: false
-      self.registered_policy_questions = Set.new
-      private :registered_policy_questions, :registered_policy_questions?
+      class_attribute :registered_action_to_authorizes, instance_writer: false
+      self.registered_action_to_authorizes = Set.new
+      private :registered_action_to_authorizes, :registered_action_to_authorizes?
 
-      def self.define_policy_question(method_name, &block)
-        self.registered_policy_questions += [method_name]
+      def self.define_action_to_authorize(method_name, &block)
+        self.registered_action_to_authorizes += [method_name]
         define_method(method_name, &block)
       end
-      private_class_method :define_policy_question
+      private_class_method :define_action_to_authorize
 
       def initialize(user, entity)
         self.user = user
@@ -38,7 +38,7 @@ module Sipity
       private :user, :user=, :entity=, :entity
 
       def available_actions_by_policy
-        registered_policy_questions.each_with_object([]) do |question, mem|
+        registered_action_to_authorizes.each_with_object([]) do |question, mem|
           mem << question if public_send(question)
           mem
         end

--- a/app/policies/sipity/policies/enrich_sip_by_form_submission_policy.rb
+++ b/app/policies/sipity/policies/enrich_sip_by_form_submission_policy.rb
@@ -13,7 +13,7 @@ module Sipity
         @sip_policy = options.fetch(:sip_policy) { default_sip_policy }
       end
 
-      define_policy_question :submit? do
+      define_action_to_authorize :submit? do
         return false unless user.present?
         return false unless entity.sip.persisted?
         sip_policy.update?

--- a/app/policies/sipity/policies/sip_policy.rb
+++ b/app/policies/sipity/policies/sip_policy.rb
@@ -15,25 +15,25 @@ module Sipity
       attr_reader :permission_query_service, :original_entity
       private :permission_query_service, :original_entity
 
-      define_policy_question :show? do
+      define_action_to_authorize :show? do
         return false unless user.present?
         return false unless entity.persisted?
         permission_query_service.call(user: user, entity: entity, roles: [Models::Permission::CREATING_USER])
       end
 
-      define_policy_question :update? do
+      define_action_to_authorize :update? do
         return false unless user.present?
         return false unless entity.persisted?
         permission_query_service.call(user: user, entity: entity, roles: [Models::Permission::CREATING_USER])
       end
 
-      define_policy_question :create? do
+      define_action_to_authorize :create? do
         return false unless user.present?
         return false if entity.persisted?
         true
       end
 
-      define_policy_question :destroy? do
+      define_action_to_authorize :destroy? do
         return false unless user.present?
         return false unless entity.persisted?
         permission_query_service.call(user: user, entity: entity, roles: [Models::Permission::CREATING_USER])

--- a/app/services/sipity/services/authorization_layer.rb
+++ b/app/services/sipity/services/authorization_layer.rb
@@ -12,26 +12,26 @@ module Sipity
       attr_reader :user, :context, :policy_authorizer
       private :user, :context, :policy_authorizer
 
-      # Responsible for enforcing policies on the :policy_questions_and_entity_pairs.
+      # Responsible for enforcing policies on the :action_to_authorizes_and_entity_pairs.
       #
-      # @param policy_questions_and_entity_pairs [Hash<Symbol,Object>, #each] Yield two elements a
-      #   :policy_question and an :entity
+      # @param action_to_authorizes_and_entity_pairs [Hash<Symbol,Object>, #each] Yield two elements a
+      #   :action_to_authorize and an :entity
       #
-      # @yield Returns control to the caller if all :policy_questions_and_entity_pairs
+      # @yield Returns control to the caller if all :action_to_authorizes_and_entity_pairs
       #   are authorized.
       #
       # @raise [Exceptions::AuthorizationFailureError] if one of the
-      #   policy_question/entity pairs fail to authorize.
+      #   action_to_authorize/entity pairs fail to authorize.
       #
       # @note If the context implements #callbacks, that will be called.
       #
       # @todo Would it be helpful to include in the exception the policy_enforcer
       #   that was found?
-      def enforce!(policy_questions_and_entity_pairs = {})
-        policy_questions_and_entity_pairs.each do |policy_question, entity|
-          next if policy_authorizer.call(user: user, policy_question: policy_question, entity: entity)
+      def enforce!(action_to_authorizes_and_entity_pairs = {})
+        action_to_authorizes_and_entity_pairs.each do |action_to_authorize, entity|
+          next if policy_authorizer.call(user: user, action_to_authorize: action_to_authorize, entity: entity)
           context.callback(:unauthorized) if context.respond_to?(:callback)
-          fail Exceptions::AuthorizationFailureError, user: user, policy_question: policy_question, entity: entity
+          fail Exceptions::AuthorizationFailureError, user: user, action_to_authorize: action_to_authorize, entity: entity
         end
         yield
       end

--- a/app/state_machines/sipity/state_machines/etd_student_submission.rb
+++ b/app/state_machines/sipity/state_machines/etd_student_submission.rb
@@ -11,7 +11,7 @@ module Sipity
       # TODO: Extract policy questions into separate class; There is a
       # relationship, but is this necessary.
       #
-      # { state => { policy_question => roles } }
+      # { state => { action_to_authorize => roles } }
       STATE_POLICY_QUESTION_ROLE_MAP =
       {
         'new' => {
@@ -38,9 +38,9 @@ module Sipity
       attr_reader :entity, :state_machine, :user, :repository
       private :entity, :state_machine, :user, :repository
 
-      def roles_for_policy_question(policy_question)
+      def roles_for_action_to_authorize(action_to_authorize)
         # @TODO - Catch invalid state look up
-        STATE_POLICY_QUESTION_ROLE_MAP.fetch(entity.processing_state.to_s).fetch(policy_question, [])
+        STATE_POLICY_QUESTION_ROLE_MAP.fetch(entity.processing_state.to_s).fetch(action_to_authorize, [])
       rescue KeyError
         raise Exceptions::StatePolicyQuestionRoleMapError, state: entity.processing_state, context: self
       end

--- a/spec/policies/sipity/policies/base_policy_spec.rb
+++ b/spec/policies/sipity/policies/base_policy_spec.rb
@@ -9,16 +9,16 @@ module Sipity
       it 'exposes a .call function for convenience' do
         allow(BasePolicy).to receive(:new).with(user, entity).and_return(policy)
         expect(policy).to receive(:show?)
-        BasePolicy.call(user: user, entity: entity, policy_question: :show?)
+        BasePolicy.call(user: user, entity: entity, action_to_authorize: :show?)
       end
 
-      context '.define_policy_question declaration' do
+      context '.define_action_to_authorize declaration' do
         before do
           class TestPolicy < BasePolicy
-            define_policy_question :create? do
+            define_action_to_authorize :create? do
               !entity.persisted?
             end
-            define_policy_question :update? do
+            define_action_to_authorize :update? do
               entity.persisted?
             end
           end
@@ -33,7 +33,7 @@ module Sipity
         end
 
         it 'will requester the given policy question' do
-          expect(subject.class.registered_policy_questions.to_a).to eq([:create?, :update?])
+          expect(subject.class.registered_action_to_authorizes.to_a).to eq([:create?, :update?])
         end
 
         it 'will expose available_actions_by_policy' do

--- a/spec/policies/sipity/policies_spec.rb
+++ b/spec/policies/sipity/policies_spec.rb
@@ -6,14 +6,14 @@ module Sipity
     subject { described_class }
     let(:user) { double('User') }
     let(:policy_enforcer) { double('Policy Enforcer', call: true) }
-    let(:policy_question) { :show? }
+    let(:action_to_authorize) { :show? }
     let(:entity) { double('Entity', policy_enforcer: policy_enforcer) }
 
     context '#authorized_for?' do
       it 'will use the found policy_enforcer' do
         allow(subject).to receive(:find_policy_enforcer_for).with(entity: entity).and_return(policy_enforcer)
-        expect(policy_enforcer).to receive(:call).with(user: user, entity: entity, policy_question: policy_question)
-        subject.authorized_for?(user: user, policy_question: policy_question, entity: entity)
+        expect(policy_enforcer).to receive(:call).with(user: user, entity: entity, action_to_authorize: action_to_authorize)
+        subject.authorized_for?(user: user, action_to_authorize: action_to_authorize, entity: entity)
       end
     end
 

--- a/spec/runners/sipity/runners/base_runner_spec.rb
+++ b/spec/runners/sipity/runners/base_runner_spec.rb
@@ -68,8 +68,8 @@ module Sipity
           let(:entity) { double('Entity') }
           before do
             MyRunner = Class.new(BaseRunner) do
-              def run(entity:, policy_question:)
-                authorization_layer.enforce!(policy_question, entity) do
+              def run(entity:, action_to_authorize:)
+                authorization_layer.enforce!(action_to_authorize, entity) do
                   callback(:success, entity)
                 end
               end
@@ -85,7 +85,7 @@ module Sipity
           end
           it 'will enforce! the policy then yield control to the runner' do
             expect(enforcer).to receive(:enforce!).with(:show?, entity).and_yield
-            response = subject.run(entity: entity, policy_question: :show?)
+            response = subject.run(entity: entity, action_to_authorize: :show?)
             expect(handler).to have_received(:invoked).with('SUCCESS', entity)
             expect(response).to eq([:success, entity])
           end

--- a/spec/services/sipity/services/authorization_layer_spec.rb
+++ b/spec/services/sipity/services/authorization_layer_spec.rb
@@ -6,7 +6,7 @@ module Sipity
       subject { described_class.new(context, policy_authorizer: policy_authorizer) }
       let(:entity) { Models::Sip.new(id: '2') }
       let(:context) { double(current_user: User.new(id: '1')) }
-      let(:policy_question) { :create? }
+      let(:action_to_authorize) { :create? }
       let(:policy_authorizer) { double('PolicyAuthorizer', call: :called) }
 
       it 'will have a default policy_authorizer' do
@@ -29,9 +29,9 @@ module Sipity
           before { allow(policy_authorizer).to receive(:call).and_return(false) }
           it 'will raise an exception and not yield to the caller' do
             allow(policy_authorizer).to receive(:call).
-              with(user: context.current_user, policy_question: :create?, entity: entity).and_return(true)
+              with(user: context.current_user, action_to_authorize: :create?, entity: entity).and_return(true)
             allow(policy_authorizer).to receive(:call).
-              with(user: context.current_user, policy_question: :show?, entity: entity).and_return(false)
+              with(user: context.current_user, action_to_authorize: :show?, entity: entity).and_return(false)
             expect do |b|
               expect do
                 subject.enforce!(create?: entity, show?: entity, &b)

--- a/spec/state_machines/sipity/state_machines/etd_student_submission_spec.rb
+++ b/spec/state_machines/sipity/state_machines/etd_student_submission_spec.rb
@@ -25,120 +25,120 @@ module Sipity
         its(:repository) { should respond_to :submit_ingest_etd }
       end
 
-      context '.roles_for_policy_question' do
+      context '.roles_for_action_to_authorize' do
         let(:initial_processing_state) { 'unknown' }
         it 'will raise an exception if the processing_state is unknown' do
-          expect { subject.roles_for_policy_question(:update?) }.to raise_error(Exceptions::StatePolicyQuestionRoleMapError)
+          expect { subject.roles_for_action_to_authorize(:update?) }.to raise_error(Exceptions::StatePolicyQuestionRoleMapError)
         end
         context 'for :new' do
           let(:initial_processing_state) { 'new' }
           it 'will allow :update? for [:creating_user, :advisor]' do
-            expect(subject.roles_for_policy_question(:update?)).to eq(['creating_user', 'advisor'])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq(['creating_user', 'advisor'])
           end
           it 'will allow :delete? for [:creating_user]' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq(['creating_user'])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq(['creating_user'])
           end
           it 'will allow :show? for [:creating_user, :advisor]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor'])
           end
           it 'will allow :submit_for_review? for [:creating_user]'do
-            expect(subject.roles_for_policy_question(:submit_for_review?)).to eq(['creating_user'])
+            expect(subject.roles_for_action_to_authorize(:submit_for_review?)).to eq(['creating_user'])
           end
         end
 
         context 'for :under_review' do
           let(:initial_processing_state) { 'under_review' }
           it 'will allow :update? for [:etd_reviewer]' do
-            expect(subject.roles_for_policy_question(:update?)).to eq(['etd_reviewer'])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq(['etd_reviewer'])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
           end
           it 'will allow :request_revisions? for [:etd_reviewer]' do
-            expect(subject.roles_for_policy_question(:request_revisions?)).to eq(['etd_reviewer'])
+            expect(subject.roles_for_action_to_authorize(:request_revisions?)).to eq(['etd_reviewer'])
           end
           it 'will allow :approve_for_ingest? for [:etd_reviewer]' do
-            expect(subject.roles_for_policy_question(:approve_for_ingest?)).to eq(['etd_reviewer'])
+            expect(subject.roles_for_action_to_authorize(:approve_for_ingest?)).to eq(['etd_reviewer'])
           end
         end
 
         context 'for :ready_for_ingest' do
           let(:initial_processing_state) { 'ready_for_ingest' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_policy_question(:update?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_policy_question(:ingest?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:ingest?)).to eq([])
           end
         end
 
         context 'for :ingested' do
           let(:initial_processing_state) { 'ingested' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_policy_question(:update?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_policy_question(:ingest_completed?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:ingest_completed?)).to eq([])
           end
         end
 
         context 'for :ready_for_cataloging' do
           let(:initial_processing_state) { 'ready_for_cataloging' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_policy_question(:update?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer, :cataloger]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_policy_question(:finish_cataloging?)).to eq(['cataloger'])
+            expect(subject.roles_for_action_to_authorize(:finish_cataloging?)).to eq(['cataloger'])
           end
         end
 
         context 'for :cataloged' do
           let(:initial_processing_state) { 'cataloged' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_policy_question(:update?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer, :cataloger]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_policy_question(:mark_as_done?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:mark_as_done?)).to eq([])
           end
         end
 
         context 'for :done' do
           let(:initial_processing_state) { 'done' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_policy_question(:update?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_policy_question(:delete?)).to eq([])
+            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer, :cataloger]' do
-            expect(subject.roles_for_policy_question(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
+            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
           end
         end
       end


### PR DESCRIPTION
As I'm working on the `./artifacts/permission_model.md` I added
glossary items for PolicyQuestion and Action; They were aliases. So I
am instead prefering to use the more explicit :action_to_authorize.