### PR TITLE
Persisting Sip#work_type

### DIFF
--- a/app/models/sipity/models/sip.rb
+++ b/app/models/sipity/models/sip.rb
@@ -26,6 +26,8 @@ module Sipity
       GOING_TO_PUBLISH = 'going_to_publish'.freeze
       DO_NOT_KNOW = 'do_not_know'.freeze
 
+      ETD_WORK_TYPE = 'ETD'.freeze
+
       # While this make look ridiculous, if I use an Array, the enum declaration
       # insists on persisting the value as the index instead of the key. While
       # this might make more sense from a storage standpoint, it is not as clear
@@ -37,22 +39,25 @@ module Sipity
           ALREADY_PUBLISHED => ALREADY_PUBLISHED,
           GOING_TO_PUBLISH => GOING_TO_PUBLISH,
           DO_NOT_KNOW => DO_NOT_KNOW
+        },
+        work_type:
+        {
+          ETD_WORK_TYPE => ETD_WORK_TYPE
         }
       )
-
-      attr_reader :work_type
 
       def possible_work_publication_strategies
         self.class.work_publication_strategies
       end
 
-      def work_type=(work_type)
-        fail ArgumentError unless Sip.work_types.key?(work_type)
-        @work_type = Sip.work_types.fetch(work_type)
-      end
+      after_initialize :set_default_work_type, if:  :new_record?
 
-      def self.work_types
-        { 'ETD' => 'ETD' }
+      private
+
+      def set_default_work_type
+        # HACK: Given that we are first working on the ETD submission, this
+        # is an acceptable hack. However, as we move forward, it may not be.
+        self.work_type ||= ETD_WORK_TYPE
       end
     end
   end

--- a/db/migrate/20150108164454_add_work_type_to_sip.rb
+++ b/db/migrate/20150108164454_add_work_type_to_sip.rb
@@ -1,0 +1,7 @@
+class AddWorkTypeToSip < ActiveRecord::Migration
+  def change
+    add_column :sipity_sips, :work_type, :string
+    add_index :sipity_sips, :work_type
+    change_column_null :sipity_sips, :work_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150108151201) do
+ActiveRecord::Schema.define(version: 20150108164454) do
 
   create_table "sipity_account_placeholders", force: :cascade do |t|
     t.string   "identifier",                                     null: false
@@ -139,9 +139,11 @@ ActiveRecord::Schema.define(version: 20150108151201) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "processing_state",          limit: 64, default: "new", null: false
+    t.string   "work_type",                                            null: false
   end
 
   add_index "sipity_sips", ["processing_state"], name: "index_sipity_sips_on_processing_state"
+  add_index "sipity_sips", ["work_type"], name: "index_sipity_sips_on_work_type"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/spec/models/sipity/models/sip_spec.rb
+++ b/spec/models/sipity/models/sip_spec.rb
@@ -5,8 +5,13 @@ module Sipity
     RSpec.describe Sip, type: :model do
       subject { Sip.new }
 
-      it { should respond_to :processing_state }
-      it { should respond_to :processing_state= }
+      context 'database columns' do
+        subject { Sip }
+        its(:column_names) { should include('processing_state') }
+        its(:column_names) { should include('work_type') }
+        its(:column_names) { should include('work_publication_strategy') }
+        its(:column_names) { should include('title') }
+      end
 
       context '.work_types' do
         it 'is a Hash of keys that equal their values' do


### PR DESCRIPTION
Following on sipity@e0e1a8a, I want to make sure that we are capturing
work_type and persisting it. The current implementation is naive in
that it assumes only one work type. However, we will certainly be
adding additional ones over the coming weeks.