### PR TITLE
Renaming role to acting_as

### DIFF
--- a/app/repositories/sipity/commands/notification_commands.rb
+++ b/app/repositories/sipity/commands/notification_commands.rb
@@ -6,12 +6,12 @@ module Sipity
       # Responsible for delivering notifications (i.e., email)
       # @param notification [String] Name of the notification
       # @param entity [String] The entity that is the "subject" of the notification
-      # @param to_roles [Array<String>]
+      # @param acting_as [Array<String>]
       # @return [void]
-      def send_notification_for_entity_trigger(notification:, entity:, to_roles:)
+      def send_notification_for_entity_trigger(notification:, entity:, acting_as:)
         # These instance variables are not needed; But to appeas Rubocop I'm
         # using them.
-        to_emails = Queries::PermissionQueries.emails_for_associated_users(entity: entity, roles: to_roles)
+        to_emails = Queries::PermissionQueries.emails_for_associated_users(entity: entity, acting_as: acting_as)
         # TODO: Will we want to be logging this as an event?
         Services::Notifier.deliver(notification: notification, to: to_emails, entity: entity)
       end

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -13,35 +13,37 @@ module Sipity
     module PermissionCommands
       module_function
 
-      # Responsible for finding the groups that are assigned the given role for
+      # Responsible for finding the groups that are assigned the given acting_as for
       # the given entity's sip type.
       #
-      # @raise Exception if for any of the given roles, no group could be found
-      def grant_groups_permission_to_entity_for_role!(entity:, roles:)
-        # TODO: Extract this map of roles to groups; Will we need roles by
+      # @raise Exception if for any of the given acting_as, no group could be found
+      def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
+        # TODO: Extract this map of acting_as to groups; Will we need acting_as by
         #   sip type?
         map = { 'etd_reviewer' => 'graduate_school', 'cataloger' => 'library_cataloging' }
-        Array.wrap(roles).each do |role|
-          group_names = map.fetch(role.to_s)
+        Array.wrap(acting_as).each do |an_acting_as|
+          group_names = map.fetch(an_acting_as.to_s)
           Array.wrap(group_names).each do |group_name|
             group = Models::Group.find_or_create_by!(name: group_name)
-            grant_permission_for!(entity: entity, role: role, actors: group)
+            grant_permission_for!(entity: entity, acting_as: an_acting_as, actors: group)
           end
         end
       end
-      public :grant_groups_permission_to_entity_for_role!
+      public :grant_groups_permission_to_entity_for_acting_as!
 
       def grant_creating_user_permission_for!(entity:, user: nil, group: nil, actor: nil)
         # REVIEW: Does the constant even make sense on the data structure? Or
         #   is it more relevant here?
-        role = Models::Permission::CREATING_USER
+        acting_as = Models::Permission::CREATING_USER
         actors = [user, group, actor]
-        grant_permission_for!(entity: entity, actors: actors, role: role)
+        grant_permission_for!(entity: entity, actors: actors, acting_as: acting_as)
       end
       public :grant_creating_user_permission_for!
 
-      def grant_permission_for!(entity:, actors:, role:)
-        Array.wrap(actors).flatten.compact.each { |an_actor| Models::Permission.create!(entity: entity, actor: an_actor, role: role) }
+      def grant_permission_for!(entity:, actors:, acting_as:)
+        Array.wrap(actors).flatten.compact.each do |an_actor|
+          Models::Permission.create!(entity: entity, actor: an_actor, acting_as: acting_as)
+        end
       end
       private :grant_permission_for!
       private_class_method :grant_permission_for!

--- a/db/migrate/20141204154424_create_sipity_permissions.rb
+++ b/db/migrate/20141204154424_create_sipity_permissions.rb
@@ -3,20 +3,20 @@ class CreateSipityPermissions < ActiveRecord::Migration
     create_table :sipity_permissions, id: false do |t|
       t.integer :actor_id, index: true
       t.string :actor_type, index: true, limit: 64
+      t.string :acting_as, index: true, limit: 32
       t.integer :entity_id, index: true
       t.string :entity_type, index: true, limit: 64
-      t.string :role, index: true, limit: 32
 
       t.timestamps
     end
     add_index :sipity_permissions, [:actor_id, :actor_type, :entity_id, :entity_type], name: :sipity_permissions_actor_subject
-    add_index :sipity_permissions, [:entity_id, :entity_type, :role], name: :sipity_permissions_entity_role
-    add_index :sipity_permissions, [:actor_id, :actor_type, :role], name: :sipity_permissions_actor_role
+    add_index :sipity_permissions, [:entity_id, :entity_type, :acting_as], name: :sipity_permissions_entity_acting_as
+    add_index :sipity_permissions, [:actor_id, :actor_type, :acting_as], name: :sipity_permissions_actor_acting_as
 
     change_column_null :sipity_permissions, :actor_id, false
     change_column_null :sipity_permissions, :actor_type, false
     change_column_null :sipity_permissions, :entity_id, false
     change_column_null :sipity_permissions, :entity_type, false
-    change_column_null :sipity_permissions, :role, false
+    change_column_null :sipity_permissions, :acting_as, false
   end
 end

--- a/db/migrate/20150108151201_create_sipity_models_actor_for_permission_assignments.rb
+++ b/db/migrate/20150108151201_create_sipity_models_actor_for_permission_assignments.rb
@@ -3,7 +3,7 @@ class CreateSipityModelsActorForPermissionAssignments < ActiveRecord::Migration
     create_table :sipity_actor_for_permission_assignments do |t|
       t.integer :actor_id, index: true
       t.string :actor_type, index: true
-      t.string :role, index: true
+      t.string :acting_as, index: true
       t.string :work_type
 
       t.timestamps null: false
@@ -11,19 +11,19 @@ class CreateSipityModelsActorForPermissionAssignments < ActiveRecord::Migration
 
     add_index(
       :sipity_actor_for_permission_assignments,
-      [:actor_id, :actor_type, :role, :work_type],
+      [:actor_id, :actor_type, :acting_as, :work_type],
       name: :sipity_actor_for_permission_assignments_composite,
       unique: true
     )
     add_index(
       :sipity_actor_for_permission_assignments,
-      [:role, :work_type],
-      name: :sipity_actor_for_permission_assignments_by_role_work_type
+      [:acting_as, :work_type],
+      name: :sipity_actor_for_permission_assignments_by_acting_as_work_type
     )
 
     change_column_null :sipity_actor_for_permission_assignments, :actor_id, false
     change_column_null :sipity_actor_for_permission_assignments, :actor_type, false
     change_column_null :sipity_actor_for_permission_assignments, :work_type, false
-    change_column_null :sipity_actor_for_permission_assignments, :role, false
+    change_column_null :sipity_actor_for_permission_assignments, :acting_as, false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,17 +30,17 @@ ActiveRecord::Schema.define(version: 20150108164454) do
   create_table "sipity_actor_for_permission_assignments", force: :cascade do |t|
     t.integer  "actor_id",   null: false
     t.string   "actor_type", null: false
-    t.string   "role",       null: false
+    t.string   "acting_as",  null: false
     t.string   "work_type",  null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "sipity_actor_for_permission_assignments", ["actor_id", "actor_type", "role", "work_type"], name: "sipity_actor_for_permission_assignments_composite", unique: true
+  add_index "sipity_actor_for_permission_assignments", ["acting_as", "work_type"], name: "sipity_actor_for_permission_assignments_by_acting_as_work_type"
+  add_index "sipity_actor_for_permission_assignments", ["acting_as"], name: "index_sipity_actor_for_permission_assignments_on_acting_as"
+  add_index "sipity_actor_for_permission_assignments", ["actor_id", "actor_type", "acting_as", "work_type"], name: "sipity_actor_for_permission_assignments_composite", unique: true
   add_index "sipity_actor_for_permission_assignments", ["actor_id"], name: "index_sipity_actor_for_permission_assignments_on_actor_id"
   add_index "sipity_actor_for_permission_assignments", ["actor_type"], name: "index_sipity_actor_for_permission_assignments_on_actor_type"
-  add_index "sipity_actor_for_permission_assignments", ["role", "work_type"], name: "sipity_actor_for_permission_assignments_by_role_work_type"
-  add_index "sipity_actor_for_permission_assignments", ["role"], name: "index_sipity_actor_for_permission_assignments_on_role"
 
   create_table "sipity_additional_attributes", force: :cascade do |t|
     t.integer  "sip_id",     null: false
@@ -117,21 +117,21 @@ ActiveRecord::Schema.define(version: 20150108164454) do
   create_table "sipity_permissions", id: false, force: :cascade do |t|
     t.integer  "actor_id",               null: false
     t.string   "actor_type",  limit: 64, null: false
+    t.string   "acting_as",   limit: 32, null: false
     t.integer  "entity_id",              null: false
     t.string   "entity_type", limit: 64, null: false
-    t.string   "role",        limit: 32, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
+  add_index "sipity_permissions", ["acting_as"], name: "index_sipity_permissions_on_acting_as"
+  add_index "sipity_permissions", ["actor_id", "actor_type", "acting_as"], name: "sipity_permissions_actor_acting_as"
   add_index "sipity_permissions", ["actor_id", "actor_type", "entity_id", "entity_type"], name: "sipity_permissions_actor_subject"
-  add_index "sipity_permissions", ["actor_id", "actor_type", "role"], name: "sipity_permissions_actor_role"
   add_index "sipity_permissions", ["actor_id"], name: "index_sipity_permissions_on_actor_id"
   add_index "sipity_permissions", ["actor_type"], name: "index_sipity_permissions_on_actor_type"
-  add_index "sipity_permissions", ["entity_id", "entity_type", "role"], name: "sipity_permissions_entity_role"
+  add_index "sipity_permissions", ["entity_id", "entity_type", "acting_as"], name: "sipity_permissions_entity_acting_as"
   add_index "sipity_permissions", ["entity_id"], name: "index_sipity_permissions_on_entity_id"
   add_index "sipity_permissions", ["entity_type"], name: "index_sipity_permissions_on_entity_type"
-  add_index "sipity_permissions", ["role"], name: "index_sipity_permissions_on_role"
 
   create_table "sipity_sips", force: :cascade do |t|
     t.string   "work_publication_strategy"

--- a/spec/models/sipity/models/permission_spec.rb
+++ b/spec/models/sipity/models/permission_spec.rb
@@ -13,11 +13,11 @@ module Sipity
           to be_a(ActiveRecord::Reflection::AssociationReflection)
       end
 
-      it 'relies on the database to enforce the requirement of an :role' do
+      it 'relies on the database to enforce the requirement of an :acting_as' do
         user = User.new(id: 1)
         entity = Models::Sip.new(id: 1)
         expect { Permission.create!(actor: user, entity: entity) }.
-          to raise_error(ActiveRecord::StatementInvalid, /role may not be NULL/)
+          to raise_error(ActiveRecord::StatementInvalid, /acting_as may not be NULL/)
       end
     end
   end

--- a/spec/policies/sipity/policies/sip_policy_spec.rb
+++ b/spec/policies/sipity/policies/sip_policy_spec.rb
@@ -11,7 +11,7 @@ module Sipity
       it 'has a default permission query service' do
         policy = SipPolicy.new(user, sip)
         service = policy.send(:permission_query_service)
-        expect(service.call(user: user, entity: sip, roles: ['hello_world'])).to eq(false)
+        expect(service.call(user: user, entity: sip, acting_as: ['hello_world'])).to eq(false)
       end
 
       context 'for a non-authenticated user' do
@@ -36,7 +36,7 @@ module Sipity
           end
           before do
             allow(query_service).to receive(:call).
-              with(user: user, entity: sip, roles: [Models::Permission::CREATING_USER]).
+              with(user: user, entity: sip, acting_as: [Models::Permission::CREATING_USER]).
               and_return(is_creating_user)
           end
           context 'that was created by the user' do
@@ -61,8 +61,8 @@ module Sipity
       let(:user) { User.new(id: 1234) }
       let(:entity) { Models::Sip.new(id: 5678) }
       context '.resolve' do
-        it 'will use the scope_entities_for_user_and_roles_and_entity_type' do
-          allow(Queries::PermissionQueries).to receive(:scope_entities_for_user_and_roles_and_entity_type)
+        it 'will use the scope_entities_for_entity_type_and_user_acting_as' do
+          allow(Queries::PermissionQueries).to receive(:scope_entities_for_entity_type_and_user_acting_as)
           described_class.resolve(user: user)
         end
       end

--- a/spec/repositories/sipity/commands/notification_commands_spec.rb
+++ b/spec/repositories/sipity/commands/notification_commands_spec.rb
@@ -6,13 +6,13 @@ module Sipity
       context '#send_notification_for_entity_trigger' do
         let(:notification) { double }
         let(:entity) { double }
-        let(:to_roles) { double }
+        let(:acting_as) { double }
         let(:emails) { ['test@hello.com'] }
 
         it 'is a placeholder' do
           allow(Queries::PermissionQueries).to receive(:emails_for_associated_users).and_return(emails)
           allow(Services::Notifier).to receive(:deliver).with(notification: notification, to: emails, entity: entity)
-          test_repository.send_notification_for_entity_trigger(notification: notification, entity: entity, to_roles: to_roles)
+          test_repository.send_notification_for_entity_trigger(notification: notification, entity: entity, acting_as: acting_as)
         end
       end
     end

--- a/spec/repositories/sipity/commands/permission_commands_spec.rb
+++ b/spec/repositories/sipity/commands/permission_commands_spec.rb
@@ -5,18 +5,18 @@ module Sipity
     RSpec.describe PermissionCommands, type: :repository_methods do
       subject { test_repository }
 
-      context '#grant_groups_permission_to_entity_for_role!' do
+      context '#grant_groups_permission_to_entity_for_acting_as!' do
         let(:entity) { Models::Sip.new(id: 1) }
-        context 'with a role' do
+        context 'with a acting_as' do
           context 'that has one (or more) groups associated by header type' do
             it 'will assign that group permission to the given header' do
-              expect { subject.grant_groups_permission_to_entity_for_role!(entity: entity, roles: 'etd_reviewer') }.
+              expect { subject.grant_groups_permission_to_entity_for_acting_as!(entity: entity, acting_as: 'etd_reviewer') }.
                 to change { Models::Permission.count }.by(1)
             end
           end
           context 'that has NO groups associated' do
             it 'will raise an exception' do
-              expect { subject.grant_groups_permission_to_entity_for_role!(entity: entity, roles: '__missing__') }.
+              expect { subject.grant_groups_permission_to_entity_for_acting_as!(entity: entity, acting_as: '__missing__') }.
                 to raise_error(KeyError)
             end
           end

--- a/spec/repositories/sipity/commands/sip_commands_spec.rb
+++ b/spec/repositories/sipity/commands/sip_commands_spec.rb
@@ -51,7 +51,7 @@ module Sipity
             expect(Models::Sip.count).to eq(1)
             expect(response.additional_attributes.count).to eq(1)
             expect(Models::Collaborator.count).to eq(1)
-            expect(Models::Permission.where(actor: user, role: Models::Permission::CREATING_USER).count).to eq(1)
+            expect(Models::Permission.where(actor: user, acting_as: Models::Permission::CREATING_USER).count).to eq(1)
             expect(Models::EventLog.where(user: user, event_name: 'submit_create_sip_form').count).to eq(1)
           end
         end

--- a/spec/repositories/sipity/queries/permission_queries_spec.rb
+++ b/spec/repositories/sipity/queries/permission_queries_spec.rb
@@ -9,36 +9,36 @@ module Sipity
         let(:associated_user) { Sipity::Factories.create_user(email: 'associated@hotmail.com') }
         let(:associated_by_group_user) { Sipity::Factories.create_user(email: 'group_associated@hotmail.com') }
         let(:not_associated_user) { Sipity::Factories.create_user(email: 'not_associated@hotmail.com') }
-        let(:user_with_wrong_role) { Sipity::Factories.create_user(email: 'wrong_role@hotmail.com') }
+        let(:user_with_wrong_acting_as) { Sipity::Factories.create_user(email: 'wrong_acting_as@hotmail.com') }
         let(:associated_group) { Models::Group.create!(name: 'associated') }
-        let(:role) { 'arbitrary' }
-        let(:wrong_role) { 'wrong_role' }
+        let(:acting_as) { 'arbitrary' }
+        let(:wrong_acting_as) { 'wrong_acting_as' }
 
         before do
           # REVIEW: Should I be using Repository services?
           Models::GroupMembership.create!(group: associated_group, user: associated_by_group_user)
 
-          Models::Permission.create!(actor: user_with_wrong_role, role: wrong_role, entity: entity)
-          Models::Permission.create!(actor: associated_group, role: role, entity: entity)
-          Models::Permission.create!(actor: associated_user, role: role, entity: entity)
+          Models::Permission.create!(actor: user_with_wrong_acting_as, acting_as: wrong_acting_as, entity: entity)
+          Models::Permission.create!(actor: associated_group, acting_as: acting_as, entity: entity)
+          Models::Permission.create!(actor: associated_user, acting_as: acting_as, entity: entity)
         end
 
         it 'will return emails from users directly associated with the entity' do
-          results = test_repository.emails_for_associated_users(roles: role, entity: entity)
+          results = test_repository.emails_for_associated_users(acting_as: acting_as, entity: entity)
           expect(results.sort).to eq(['associated@hotmail.com', 'group_associated@hotmail.com'])
         end
       end
 
-      context '#scope_entities_for_user_and_roles_and_entity_type' do
+      context '#scope_entities_for_entity_type_and_user_acting_as' do
         let(:user) { User.new(id: 1234) }
         let(:group) { Models::Group.new(id: 5678) }
         let(:entity) { Models::Sip.create! }
-        let(:role) { Models::Permission::CREATING_USER }
+        let(:acting_as) { Models::Permission::CREATING_USER }
         subject { test_repository }
 
-        it 'will return an empty result if there are no roles' do
-          Models::Permission.create!(entity: entity, actor: user, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: [], entity_type: entity.class)).
+        it 'will return an empty result if there are no acting_as' do
+          Models::Permission.create!(entity: entity, actor: user, acting_as: acting_as)
+          expect(subject.scope_entities_for_entity_type_and_user_acting_as(user: user, acting_as: [], entity_type: entity.class)).
             to_not include(entity)
         end
         it 'will return the entity for the creating user' do
@@ -46,13 +46,13 @@ module Sipity
           #   leverage.
           # TODO: I have knowledge of the applicable ROLE, this should be passed to the
           #   resolver.
-          Models::Permission.create!(entity: entity, actor: user, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
+          Models::Permission.create!(entity: entity, actor: user, acting_as: acting_as)
+          expect(subject.scope_entities_for_entity_type_and_user_acting_as(user: user, acting_as: acting_as, entity_type: entity.class)).
             to include(entity)
         end
 
         it 'will exclude the entity for a non creating user' do
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
+          expect(subject.scope_entities_for_entity_type_and_user_acting_as(user: user, acting_as: acting_as, entity_type: entity.class)).
             to_not include(entity)
         end
 
@@ -62,14 +62,14 @@ module Sipity
           #   leverage.
           # TODO: I have knowledge of the applicable ROLE, this should be passed to the
           #   resolver.
-          Models::Permission.create!(entity: entity, actor: group, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
+          Models::Permission.create!(entity: entity, actor: group, acting_as: acting_as)
+          expect(subject.scope_entities_for_entity_type_and_user_acting_as(user: user, acting_as: acting_as, entity_type: entity.class)).
             to include(entity)
         end
 
         it 'will exclude the entity for which the user is not part of the group' do
-          Models::Permission.create!(entity: entity, actor: group, role: role)
-          expect(subject.scope_entities_for_user_and_roles_and_entity_type(user: user, roles: role, entity_type: entity.class)).
+          Models::Permission.create!(entity: entity, actor: group, acting_as: acting_as)
+          expect(subject.scope_entities_for_entity_type_and_user_acting_as(user: user, acting_as: acting_as, entity_type: entity.class)).
             to_not include(entity)
         end
       end

--- a/spec/state_machines/sipity/state_machines/etd_student_submission_spec.rb
+++ b/spec/state_machines/sipity/state_machines/etd_student_submission_spec.rb
@@ -10,7 +10,7 @@ module Sipity
         double(
           'Repository',
           update_processing_state!: true, log_event!: true, submit_etd_student_submission_trigger!: true,
-          grant_groups_permission_to_entity_for_role!: true, send_notification_for_entity_trigger: true, submit_ingest_etd: true
+          grant_groups_permission_to_entity_for_acting_as!: true, send_notification_for_entity_trigger: true, submit_ingest_etd: true
         )
       end
       subject { described_class.new(entity: entity, user: user, repository: repository) }
@@ -20,125 +20,125 @@ module Sipity
         its(:repository) { should respond_to :log_event! }
         its(:repository) { should respond_to :update_processing_state! }
         its(:repository) { should respond_to :submit_etd_student_submission_trigger! }
-        its(:repository) { should respond_to :grant_groups_permission_to_entity_for_role! }
+        its(:repository) { should respond_to :grant_groups_permission_to_entity_for_acting_as! }
         its(:repository) { should respond_to :send_notification_for_entity_trigger }
         its(:repository) { should respond_to :submit_ingest_etd }
       end
 
-      context '.roles_for_action_to_authorize' do
+      context '.authorized_acting_as_for_action' do
         let(:initial_processing_state) { 'unknown' }
         it 'will raise an exception if the processing_state is unknown' do
-          expect { subject.roles_for_action_to_authorize(:update?) }.to raise_error(Exceptions::StatePolicyQuestionRoleMapError)
+          expect { subject.authorized_acting_as_for_action(:update?) }.to raise_error(Exceptions::StatePolicyQuestionRoleMapError)
         end
         context 'for :new' do
           let(:initial_processing_state) { 'new' }
           it 'will allow :update? for [:creating_user, :advisor]' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq(['creating_user', 'advisor'])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq(['creating_user', 'advisor'])
           end
           it 'will allow :delete? for [:creating_user]' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq(['creating_user'])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq(['creating_user'])
           end
           it 'will allow :show? for [:creating_user, :advisor]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor'])
           end
           it 'will allow :submit_for_review? for [:creating_user]'do
-            expect(subject.roles_for_action_to_authorize(:submit_for_review?)).to eq(['creating_user'])
+            expect(subject.authorized_acting_as_for_action(:submit_for_review?)).to eq(['creating_user'])
           end
         end
 
         context 'for :under_review' do
           let(:initial_processing_state) { 'under_review' }
           it 'will allow :update? for [:etd_reviewer]' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq(['etd_reviewer'])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq(['etd_reviewer'])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
           end
           it 'will allow :request_revisions? for [:etd_reviewer]' do
-            expect(subject.roles_for_action_to_authorize(:request_revisions?)).to eq(['etd_reviewer'])
+            expect(subject.authorized_acting_as_for_action(:request_revisions?)).to eq(['etd_reviewer'])
           end
           it 'will allow :approve_for_ingest? for [:etd_reviewer]' do
-            expect(subject.roles_for_action_to_authorize(:approve_for_ingest?)).to eq(['etd_reviewer'])
+            expect(subject.authorized_acting_as_for_action(:approve_for_ingest?)).to eq(['etd_reviewer'])
           end
         end
 
         context 'for :ready_for_ingest' do
           let(:initial_processing_state) { 'ready_for_ingest' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_action_to_authorize(:ingest?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:ingest?)).to eq([])
           end
         end
 
         context 'for :ingested' do
           let(:initial_processing_state) { 'ingested' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_action_to_authorize(:ingest_completed?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:ingest_completed?)).to eq([])
           end
         end
 
         context 'for :ready_for_cataloging' do
           let(:initial_processing_state) { 'ready_for_cataloging' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer, :cataloger]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_action_to_authorize(:finish_cataloging?)).to eq(['cataloger'])
+            expect(subject.authorized_acting_as_for_action(:finish_cataloging?)).to eq(['cataloger'])
           end
         end
 
         context 'for :cataloged' do
           let(:initial_processing_state) { 'cataloged' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer, :cataloger]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
           end
           it 'will allow :ingest? for []' do
-            expect(subject.roles_for_action_to_authorize(:mark_as_done?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:mark_as_done?)).to eq([])
           end
         end
 
         context 'for :done' do
           let(:initial_processing_state) { 'done' }
           it 'will allow :update? for []' do
-            expect(subject.roles_for_action_to_authorize(:update?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:update?)).to eq([])
           end
           it 'will allow :delete? for []' do
-            expect(subject.roles_for_action_to_authorize(:delete?)).to eq([])
+            expect(subject.authorized_acting_as_for_action(:delete?)).to eq([])
           end
           it 'will allow :show? for [:creating_user, :advisor, :etd_reviewer, :cataloger]' do
-            expect(subject.roles_for_action_to_authorize(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
+            expect(subject.authorized_acting_as_for_action(:show?)).to eq(['creating_user', 'advisor', 'etd_reviewer', 'cataloger'])
           end
         end
       end
@@ -154,15 +154,15 @@ module Sipity
           let(:event) { :submit_for_review }
           it 'will send an email notification to the grad school' do
             expect(repository).to have_received(:send_notification_for_entity_trigger).
-              with(notification: "entity_ready_for_review", entity: entity, to_roles: 'etd_reviewer')
+              with(notification: "entity_ready_for_review", entity: entity, acting_as: 'etd_reviewer')
           end
           it 'will send an email confirmation to the student with a URL to that item' do
             expect(repository).to have_received(:send_notification_for_entity_trigger).
-              with(notification: "confirmation_of_entity_submitted_for_review", entity: entity, to_roles: 'creating_user')
+              with(notification: "confirmation_of_entity_submitted_for_review", entity: entity, acting_as: 'creating_user')
           end
           it 'will add permission entries for the etd reviewers for the given ETD' do
-            expect(repository).to have_received(:grant_groups_permission_to_entity_for_role!).
-              with(entity: entity, roles: 'etd_reviewer')
+            expect(repository).to have_received(:grant_groups_permission_to_entity_for_acting_as!).
+              with(entity: entity, acting_as: 'etd_reviewer')
           end
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
@@ -185,7 +185,7 @@ module Sipity
           it 'will send an email notification to the student with a URL to edit the item and reviewer provided comments' do
             expect(repository).to(
               have_received(:send_notification_for_entity_trigger).with(
-                notification: "request_revisions_from_creator", entity: entity, to_roles: 'creating_user',
+                notification: "request_revisions_from_creator", entity: entity, acting_as: 'creating_user',
                 comments: options.fetch(:comments)
               )
             )
@@ -248,17 +248,17 @@ module Sipity
             expect(repository).to(
               have_received(:send_notification_for_entity_trigger).with(
                 notification: "confirmation_of_entity_approved_for_ingest", entity: entity,
-                to_roles: ['creating_user', 'advisor', 'etd_reviewer'], additional_emails: options.fetch(:additional_emails)
+                acting_as: ['creating_user', 'advisor', 'etd_reviewer'], additional_emails: options.fetch(:additional_emails)
               )
             )
           end
           it 'will add permission entries for the catalog reviewers of the given ETD' do
-            expect(repository).to have_received(:grant_groups_permission_to_entity_for_role!).
-              with(entity: entity, roles: 'cataloger')
+            expect(repository).to have_received(:grant_groups_permission_to_entity_for_acting_as!).
+              with(entity: entity, acting_as: 'cataloger')
           end
           it 'will send an email notification to the catalogers saying the ETD is ready for cataloging' do
             expect(repository).to have_received(:send_notification_for_entity_trigger).
-              with(notification: "entity_ready_for_cataloging", entity: entity, to_roles: 'cataloger')
+              with(notification: "entity_ready_for_cataloging", entity: entity, acting_as: 'cataloger')
           end
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).


### PR DESCRIPTION
The word "role" comes with so much baggage. In conversations, it can
easily be mixed with the idea of a group (i.e. Catalogers can be
easily perceived as a Group and a Role).

This is unlikely to be the final name, but it creates a new word that
allows for easier future changes.

In an effort to better reflect the intention of the parameter and
methods, I'm renaming a few of them as well.

NOTE: This is a major change, you will need to drop your development
and test database and load the new schema:

```console
rake db:drop db:create db:schema:load
```