### PR TITLE
Spec Query#group_names_for_entity_and_acting_as

### DIFF
--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -18,11 +18,8 @@ module Sipity
       #
       # @raise Exception if for any of the given acting_as, no group could be found
       def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
-        # TODO: Extract this map of acting_as to groups; Will we need acting_as by
-        #   sip type?
-        map = { 'etd_reviewer' => 'graduate_school', 'cataloger' => 'library_cataloging' }
         Array.wrap(acting_as).each do |an_acting_as|
-          group_names = map.fetch(an_acting_as.to_s)
+          group_names = Queries::PermissionQueries.group_names_for_entity_and_acting_as(acting_as: an_acting_as, entity: entity)
           Array.wrap(group_names).each do |group_name|
             group = Models::Group.find_or_create_by!(name: group_name)
             grant_permission_for!(entity: entity, acting_as: an_acting_as, actors: group)

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -4,6 +4,16 @@ module Sipity
     module PermissionQueries
       module_function
 
+      ACTING_AS_TO_GROUP_NAME = {
+        'etd_reviewer' => 'graduate_school', 'cataloger' => 'library_cataloging'
+      }.freeze
+
+      def group_names_for_entity_and_acting_as(options = {})
+        acting_as = options.fetch(:acting_as)
+        Array.wrap(ACTING_AS_TO_GROUP_NAME.fetch(acting_as))
+      end
+      public :group_names_for_entity_and_acting_as
+
       def emails_for_associated_users(acting_as:, entity:)
         scope_users_by_entity_and_acting_as(acting_as: acting_as, entity: entity).pluck(:email)
       end

--- a/spec/repositories/sipity/queries/permission_queries_spec.rb
+++ b/spec/repositories/sipity/queries/permission_queries_spec.rb
@@ -4,6 +4,13 @@ module Sipity
   module Queries
     # Queries
     RSpec.describe PermissionQueries, type: :repository_methods do
+      context '#group_names_for_entity_and_acting_as' do
+        Given(:acting_as) { 'etd_reviewer' }
+        Given(:entity) { double('Entity') }
+        When(:group_names) { test_repository.group_names_for_entity_and_acting_as(entity: entity, acting_as: acting_as) }
+        Then { group_names == ['graduate_school'] }
+      end
+
       context '#emails_for_associated_users' do
         let(:entity) { Models::Sip.create! }
         let(:associated_user) { Sipity::Factories.create_user(email: 'associated@hotmail.com') }


### PR DESCRIPTION
There is a naive hash that translates a role name to a group name.
I want to expose a query method to retrieve that information; This
information will most certainly make it into a database for greater
configuration options.

Also, consider the fact that the Sipity::Commands::PermissionCommands
module will need to be changed and the underlying spec would benefit
from a tweak as well, saying that the Sipity::Queries::GroupQueries
is allowed to receive #group_names_for_entity_and_roles and return a
specified value.

See Sipity::Commands::PermissionCommands#grant_groups_permission_to_entity_for_role

[skip ci]

Refines to #52