### PR TITLE
Reworking low hanging module_function defs

### DIFF
--- a/app/policies/sipity/policies.rb
+++ b/app/policies/sipity/policies.rb
@@ -23,14 +23,12 @@ module Sipity
   # @see [Elabs' Pundit gem](http://github.com/elabs/pundit) for
   #   further explanation of Policy and Scope objects.
   module Policies
-    module_function
-
-    def authorized_for?(user:, action_to_authorize:, entity:)
+    module_function def authorized_for?(user:, action_to_authorize:, entity:)
       policy_enforcer = find_policy_enforcer_for(entity: entity)
       policy_enforcer.call(user: user, entity: entity, action_to_authorize: action_to_authorize)
     end
 
-    def find_policy_enforcer_for(entity:)
+    module_function def find_policy_enforcer_for(entity:)
       return entity.policy_enforcer if entity.respond_to?(:policy_enforcer) && entity.policy_enforcer.present?
       policy_name_as_constant = "#{entity.class.to_s.demodulize}Policy"
       if const_defined?(policy_name_as_constant)

--- a/app/repositories/sipity/commands/collaborator_commands.rb
+++ b/app/repositories/sipity/commands/collaborator_commands.rb
@@ -3,10 +3,8 @@ module Sipity
   module Commands
     # Commands
     module CollaboratorCommands
-      module_function
-
       # REVIEW: Consider moving these into the SipCommands
-      def create_collaborators_for_sip!(sip:, collaborators:)
+      module_function def create_collaborators_for_sip!(sip:, collaborators:)
         collaborators.each do |collaborator|
           collaborator.sip = sip
           collaborator.save!

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -11,13 +11,11 @@ module Sipity
     # How is that different from module functions and instance methods via
     # mixin? Something to think about.
     module PermissionCommands
-      module_function
-
       # Responsible for finding the groups that are assigned the given acting_as for
       # the given entity's sip type.
       #
       # @raise Exception if for any of the given acting_as, no group could be found
-      def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
+      module_function def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
         # TODO: Extract this map of acting_as to groups; Will we need acting_as by
         #   sip type?
         Array.wrap(acting_as).each do |an_acting_as|
@@ -30,7 +28,7 @@ module Sipity
       end
       public :grant_groups_permission_to_entity_for_acting_as!
 
-      def grant_creating_user_permission_for!(entity:, user: nil, group: nil, actor: nil)
+      module_function def grant_creating_user_permission_for!(entity:, user: nil, group: nil, actor: nil)
         # REVIEW: Does the constant even make sense on the data structure? Or
         #   is it more relevant here?
         acting_as = Models::Permission::CREATING_USER
@@ -39,7 +37,7 @@ module Sipity
       end
       public :grant_creating_user_permission_for!
 
-      def grant_permission_for!(entity:, actors:, acting_as:)
+      module_function def grant_permission_for!(entity:, actors:, acting_as:)
         Array.wrap(actors).flatten.compact.each do |an_actor|
           Models::Permission.create!(entity: entity, actor: an_actor, acting_as: acting_as)
         end

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -2,19 +2,17 @@ module Sipity
   module Queries
     # Queries
     module PermissionQueries
-      module_function
-
       ACTING_AS_TO_GROUP_NAME = {
         'etd_reviewer' => 'graduate_school', 'cataloger' => 'library_cataloging'
       }.freeze
 
-      def group_names_for_entity_and_acting_as(options = {})
+      module_function def group_names_for_entity_and_acting_as(options = {})
         acting_as = options.fetch(:acting_as)
         Array.wrap(ACTING_AS_TO_GROUP_NAME.fetch(acting_as))
       end
       public :group_names_for_entity_and_acting_as
 
-      def emails_for_associated_users(acting_as:, entity:)
+      module_function def emails_for_associated_users(acting_as:, entity:)
         scope_users_by_entity_and_acting_as(acting_as: acting_as, entity: entity).pluck(:email)
       end
       public :emails_for_associated_users
@@ -34,7 +32,7 @@ module Sipity
       #
       # @note Welcome to the land of AREL.
       # @see https://github.com/rails/arel AREL - A Relational Algebra
-      def scope_users_by_entity_and_acting_as(acting_as:, entity:)
+      module_function def scope_users_by_entity_and_acting_as(acting_as:, entity:)
         user_table = User.arel_table
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
@@ -82,7 +80,7 @@ module Sipity
       #
       # @note Welcome to the land of AREL.
       # @see https://github.com/rails/arel AREL - A Relational Algebra
-      def scope_entities_for_entity_type_and_user_acting_as(entity_type:, user:, acting_as:)
+      module_function def scope_entities_for_entity_type_and_user_acting_as(entity_type:, user:, acting_as:)
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
         actor_id = user.to_param

--- a/spec/support/sipity/factories.rb
+++ b/spec/support/sipity/factories.rb
@@ -1,8 +1,6 @@
 module Sipity
   module Factories
-    module_function
-
-    def create_user(overrides = {})
+    module_function def create_user(overrides = {})
       default_attributes = { name: 'Test User', email: 'test@example.com', password: 'please123' }
       User.create!(default_attributes.merge(overrides))
     end


### PR DESCRIPTION
Instead of the important module_function declaration at the top of the
module, I want close association with the defined method. This will
help with pull requests legibility.

See sipity@dacfcb4108b6afd98562249fed2a4abe1e5aaa1a