### PR TITLE
Switching to module inclusion for conversion

### DIFF
--- a/app/services/sipity/services/doi_creation_request_metadata_gatherer.rb
+++ b/app/services/sipity/services/doi_creation_request_metadata_gatherer.rb
@@ -60,9 +60,10 @@ module Sipity
         @publication_year ||= begin
           repository.sip_attribute_values_for(
             sip: sip, key: Models::AdditionalAttribute::PUBLICATION_DATE_PREDICATE_NAME
-          ).map { |publication_date| Conversions::ConvertToYear.call(publication_date).to_s }.join(", ")
+          ).map { |publication_date| convert_to_year(publication_date).to_s }.join(", ")
         end
       end
+      include Conversions::ConvertToYear
 
       def default_repository
         Repository.new


### PR DESCRIPTION
Is the before commit more expressive or less? Consider the visual
chatter of the method.

Another option to consider is treating the method analogous to the
Array() method (see below).

```ruby
ConvertToYear(publication_date).to_s
```