### PR TITLE
Adding Sipity::Models::Attachment

### DIFF
--- a/app/models/sipity/models/attachment.rb
+++ b/app/models/sipity/models/attachment.rb
@@ -1,0 +1,9 @@
+module Sipity
+  module Models
+    # Represents a single file attached to a given sip.
+    class Attachment < ActiveRecord::Base
+      self.table_name = 'sipity_attachments'
+      belongs_to :sip
+    end
+  end
+end

--- a/app/models/sipity/models/sip.rb
+++ b/app/models/sipity/models/sip.rb
@@ -11,6 +11,7 @@ module Sipity
 
       has_many :collaborators, foreign_key: :sip_id, dependent: :destroy
       has_many :additional_attributes, foreign_key: :sip_id, dependent: :destroy
+      has_many :attachments, foreign_key: :sip_id, dependent: :destroy
       has_one :doi_creation_request, foreign_key: :sip_id, dependent: :destroy
 
       # REVIEW: Do I really want to deal with nested attributes such as these?

--- a/db/migrate/20150112142919_create_sipity_models_attachments.rb
+++ b/db/migrate/20150112142919_create_sipity_models_attachments.rb
@@ -1,0 +1,20 @@
+class CreateSipityModelsAttachments < ActiveRecord::Migration
+  def change
+    create_table :sipity_attachments, id: false do |t|
+      t.integer :sip_id
+      t.string :pid
+      t.string :predicate_name
+      t.string :file_uid
+      t.string :file_name
+
+      t.timestamps null: false
+    end
+
+    add_index :sipity_attachments, :sip_id
+    add_index :sipity_attachments, :pid, unique: true
+    change_column_null :sipity_attachments, :sip_id, false
+    change_column_null :sipity_attachments, :predicate_name, false
+    change_column_null :sipity_attachments, :file_uid, false
+    change_column_null :sipity_attachments, :file_name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150108164454) do
+ActiveRecord::Schema.define(version: 20150112142919) do
 
   create_table "sipity_account_placeholders", force: :cascade do |t|
     t.string   "identifier",                                     null: false
@@ -52,6 +52,19 @@ ActiveRecord::Schema.define(version: 20150108164454) do
 
   add_index "sipity_additional_attributes", ["sip_id", "key"], name: "index_sipity_additional_attributes_on_sip_id_and_key"
   add_index "sipity_additional_attributes", ["sip_id"], name: "index_sipity_additional_attributes_on_sip_id"
+
+  create_table "sipity_attachments", id: false, force: :cascade do |t|
+    t.integer  "sip_id",         null: false
+    t.string   "pid"
+    t.string   "predicate_name", null: false
+    t.string   "file_uid",       null: false
+    t.string   "file_name",      null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "sipity_attachments", ["pid"], name: "index_sipity_attachments_on_pid", unique: true
+  add_index "sipity_attachments", ["sip_id"], name: "index_sipity_attachments_on_sip_id"
 
   create_table "sipity_collaborators", force: :cascade do |t|
     t.integer  "sip_id",     null: false

--- a/spec/models/sipity/models/attachment_spec.rb
+++ b/spec/models/sipity/models/attachment_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+module Sipity
+  module Models
+    RSpec.describe Attachment, type: :model do
+      subject { described_class }
+
+      its(:column_names) { should include('sip_id') }
+      its(:column_names) { should include('pid') }
+      its(:column_names) { should include('predicate_name') }
+      its(:column_names) { should include('file_uid') }
+      its(:column_names) { should include('file_name') }
+      its(:primary_key) { should be_nil }
+    end
+  end
+end

--- a/spec/models/sipity/models/sip_spec.rb
+++ b/spec/models/sipity/models/sip_spec.rb
@@ -48,6 +48,11 @@ module Sipity
           to be_a(ActiveRecord::Reflection::AssociationReflection)
       end
 
+      it 'has many :attachments' do
+        expect(Sip.reflect_on_association(:attachments)).
+          to be_a(ActiveRecord::Reflection::AssociationReflection)
+      end
+
       it 'has one :doi_creation_request' do
         expect(Sip.reflect_on_association(:doi_creation_request)).
           to be_a(ActiveRecord::Reflection::AssociationReflection)


### PR DESCRIPTION
This migration is ported over from Hydramata::Works. We will need to
associate attachments with a given sip. These attachments are their
own entity (hence the PID).