### PR TITLE
Allow passed parameters to populate new Sip form

### DIFF
--- a/app/controllers/sipity/controllers/sips_controller.rb
+++ b/app/controllers/sipity/controllers/sips_controller.rb
@@ -7,7 +7,7 @@ module Sipity
       self.runner_container = Sipity::Runners::SipRunners
 
       def new
-        _status, model = run
+        _status, model = run(attributes: new_params)
         @model = Decorators::SipDecorator.decorate(model)
         respond_with(@model)
       end
@@ -44,6 +44,10 @@ module Sipity
 
       def sip_id
         params.require(:id)
+      end
+
+      def new_params
+        params[:sip] || {}
       end
 
       def create_params

--- a/app/runners/sipity/runners/sip_runners.rb
+++ b/app/runners/sipity/runners/sip_runners.rb
@@ -7,8 +7,8 @@ module Sipity
         self.authentication_layer = :default
         self.authorization_layer = :default
 
-        def run
-          sip = repository.build_create_sip_form
+        def run(attributes: {})
+          sip = repository.build_create_sip_form(attributes: attributes)
           authorization_layer.enforce!(create?: sip) do
             callback(:success, sip)
           end

--- a/spec/controllers/sipity/controllers/sips_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/sips_controller_spec.rb
@@ -10,14 +10,14 @@ module Sipity
         before { controller.runner = runner }
         let(:runner) do
           Hesburgh::Lib::MockRunner.new(
-            yields: yields, callback_name: callback_name, run_with: [], context: controller
+            yields: yields, callback_name: callback_name, run_with: { attributes: attributes }, context: controller
           )
         end
-
+        let(:attributes) { { 'title' => 'My Title' } }
         let(:yields) { sip }
         let(:callback_name) { :success }
         it 'will render the new page' do
-          get 'new'
+          get 'new', sip: attributes
           expect(assigns(:model)).to_not be_nil
           expect(response).to render_template('new')
         end

--- a/spec/runners/sipity/runners/sip_runners_spec.rb
+++ b/spec/runners/sipity/runners/sip_runners_spec.rb
@@ -29,6 +29,13 @@ module Sipity
           expect(handler).to have_received(:invoked).with("SUCCESS", sip)
           expect(response).to eq([:success, sip])
         end
+
+        it 'allows attributes to be set via attributes' do
+          attributes = { title: 'Hello World' }
+          expect(context.repository).to receive(:build_create_sip_form).with(attributes: attributes)
+          response = subject.run(attributes: attributes)
+          expect(response).to eq([:success, sip])
+        end
       end
 
       RSpec.describe Create do


### PR DESCRIPTION
This feature is intended to provide consumers of Sipity to provide
direct links that allow form elements to be pre-populated.

This is something that is necessary for the ETD system, as patrons
preparing their ETD for deposit need not concern themselves with
choosing which work type they are submitting.