### PR TITLE
Adding Transient Answer model

### DIFF
--- a/app/models/sipity/models/sip.rb
+++ b/app/models/sipity/models/sip.rb
@@ -14,6 +14,7 @@ module Sipity
       has_many :attachments, foreign_key: :sip_id, dependent: :destroy
       has_one :doi_creation_request, foreign_key: :sip_id, dependent: :destroy
 
+      # TODO: Extract to TransientAnswer
       ALREADY_PUBLISHED = 'already_published'.freeze
       WILL_NOT_PUBLISH = 'will_not_publish'.freeze
       GOING_TO_PUBLISH = 'going_to_publish'.freeze

--- a/app/models/sipity/models/transient_answer.rb
+++ b/app/models/sipity/models/transient_answer.rb
@@ -1,0 +1,44 @@
+module Sipity
+  module Models
+    # There are some answers that we ask our patrons to complete that are
+    # prompts for additional thought or consideration. This model is the
+    # persistence of those answers, and is to be used to continue prompting for
+    # more permanent information.
+    #
+    # @example
+    #   Question: What is the applicable Access Right?
+    #   Possible Answers:
+    #     * Open Access
+    #     * Restricted
+    #     * Private
+    #     * It will change over time
+    #
+    #   In the case of Open Access, Restricted, and Private the answer is very
+    #   simple; We make an entry in AccessRight that starts as of today for
+    #   the given answer.
+    #
+    #   However, if the answer is "It will change over time", we don't want
+    #   to present additional decision points immediately, but instead want
+    #   to persist an answer that will require additional follow-up as we
+    #   assist our patron in completing their SIP.
+    #
+    #   The follow-up to the answer would allow for us to introduce a complex
+    #   decision in a more user focused and "gentle" manner. The idea being
+    #   that the process of depositing something should be a conversation.
+    class TransientAnswer < ActiveRecord::Base
+      self.table_name = 'sipity_transient_answers'
+
+      ACCESS_RIGHTS_QUESTION = 'access_rights'.freeze
+
+      QUESTIONS = [ACCESS_RIGHTS_QUESTION].freeze
+
+      ANSWERS = {
+        ACCESS_RIGHTS_QUESTION => [
+          'open_access', 'restricted_access', 'private_access', 'access_changes_over_time'
+        ].freeze
+      }.freeze
+
+      belongs_to :entity, polymorphic: true
+    end
+  end
+end

--- a/artifacts/sipity-erd.dot
+++ b/artifacts/sipity-erd.dot
@@ -3,7 +3,7 @@ digraph "G" {
     node[color="grey15" shape=record penwidth=2 margin="0.15, 0.125"];
 
     subgraph cluster_0 {
-        label="Sipity ERD (Draft v5)"
+        label="Sipity ERD (Draft v6)"
         color="seashell3"
         style="filled"
         node[style=filled fillcolor=white color="seashell4"]
@@ -21,12 +21,14 @@ digraph "G" {
         additional_attributes[label="{ AdditionalAttribute | sip | key | value }"]
         ActorForPermissionAssignment[label="{ ActorForPermissionAssignment | actor | acting_as | work_type }"]
         AccessRight[label="{ AccessRight | entity | access_right | enforcement_start_date | enforcement_end_date }"]
+        TransientAnswer[label="{ TransientAnswer | entity | question | answer }"]
 
         user -> group_membership
         group_entity -> ActorForPermissionAssignment[label="as actor"]
         user -> ActorForPermissionAssignment[label="as actor"]
 
         sip -> AccessRight[label="as entity"]
+        sip -> TransientAnswer[label="as entity"]
         user -> permission[label="as actor"]
         group_entity -> permission[label="as actor"]
         sip -> permission[label="as entity"]

--- a/db/migrate/20150113155503_create_sipity_models_transient_answers.rb
+++ b/db/migrate/20150113155503_create_sipity_models_transient_answers.rb
@@ -1,0 +1,19 @@
+class CreateSipityModelsTransientAnswers < ActiveRecord::Migration
+  def change
+    create_table :sipity_transient_answers do |t|
+      t.integer :entity_id
+      t.string :entity_type
+      t.string :question_code
+      t.string :answer_code
+
+      t.timestamps null: false
+    end
+
+    add_index :sipity_transient_answers, [:entity_id, :entity_type]
+    add_index :sipity_transient_answers, [:entity_id, :entity_type, :question_code], unique: true, name: :sipity_transient_entity_answers
+    change_column_null :sipity_transient_answers, :entity_id, false
+    change_column_null :sipity_transient_answers, :entity_type, false
+    change_column_null :sipity_transient_answers, :question_code, false
+    change_column_null :sipity_transient_answers, :answer_code, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150113145636) do
+ActiveRecord::Schema.define(version: 20150113155503) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -171,6 +171,18 @@ ActiveRecord::Schema.define(version: 20150113145636) do
 
   add_index "sipity_sips", ["processing_state"], name: "index_sipity_sips_on_processing_state"
   add_index "sipity_sips", ["work_type"], name: "index_sipity_sips_on_work_type"
+
+  create_table "sipity_transient_answers", force: :cascade do |t|
+    t.integer  "entity_id",     null: false
+    t.string   "entity_type",   null: false
+    t.string   "question_code", null: false
+    t.string   "answer_code",   null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "sipity_transient_answers", ["entity_id", "entity_type", "question_code"], name: "sipity_transient_entity_answers", unique: true
+  add_index "sipity_transient_answers", ["entity_id", "entity_type"], name: "index_sipity_transient_answers_on_entity_id_and_entity_type"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/spec/models/sipity/models/transient_answer_spec.rb
+++ b/spec/models/sipity/models/transient_answer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+module Sipity
+  module Models
+    RSpec.describe TransientAnswer, type: :model do
+      context 'schema' do
+        subject { described_class }
+        its(:column_names) { should include('entity_id') }
+        its(:column_names) { should include('entity_type') }
+        its(:column_names) { should include('question_code') }
+        its(:column_names) { should include('answer_code') }
+      end
+
+      context 'transient question answers for' do
+        context 'access rights' do
+          subject { described_class::ANSWERS['access_rights'] }
+          it { should include('open_access') }
+          it { should include('restricted_access') }
+          it { should include('private_access') }
+          it { should include('access_changes_over_time') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are some answers that we ask our patrons to complete that are
prompts for additional thought or consideration. This model is the
persistence of those answers, and is to be used to continue prompting
for more permanent information.

Consider the question about Access Rights. There are three somewhat
simple answers: Open, Restricted, and Private. However with the
concept of Embargos and Leases, the actual answer can require a whole
lot more prompting; namely when does one access right start and the
other end?