### PR TITLE
Renaming email notification name

### DIFF
--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -26,7 +26,7 @@ module Sipity
         mail(to: to, cc: cc, bcc: bcc)
       end
 
-      def confirmation_of_entity_approved_for_ingest(entity:, to:, cc: [], bcc: [])
+      def confirmation_of_entity_ingested(entity:, to:, cc: [], bcc: [])
         @entity = entity
         mail(to: to, cc: cc, bcc: bcc)
       end

--- a/app/state_machines/sipity/state_machines/etd_student_submission.rb
+++ b/app/state_machines/sipity/state_machines/etd_student_submission.rb
@@ -91,7 +91,7 @@ module Sipity
           notification: "entity_ready_for_cataloging", entity: entity, acting_as: 'cataloger'
         )
         repository.send_notification_for_entity_trigger(
-          notification: "confirmation_of_entity_approved_for_ingest", entity: entity,
+          notification: "confirmation_of_entity_ingested", entity: entity,
           acting_as: ['creating_user', 'advisor', 'etd_reviewer'], additional_emails: additional_emails
         )
       end

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -46,15 +46,6 @@ module Sipity
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
-      context '#confirmation_of_entity_approved_for_ingest' do
-        let(:entity) { Models::Work.new }
-        let(:to) { 'test@example.com' }
-        it 'should send an email' do
-          described_class.confirmation_of_entity_approved_for_ingest(entity: entity, to: to).deliver_now
-
-          expect(ActionMailer::Base.deliveries.count).to eq(1)
-        end
-      end
       context '#request_revisions_from_creator' do
         let(:entity) { Models::Work.new }
         let(:to) { 'test@example.com' }
@@ -82,11 +73,11 @@ module Sipity
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
-      context '#confirmation_of_entity_approved_for_ingest' do
+      context '#confirmation_of_entity_ingested' do
         let(:entity) { Models::Work.new }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
-          described_class.confirmation_of_entity_approved_for_ingest(entity: entity, to: to).deliver_now
+          described_class.confirmation_of_entity_ingested(entity: entity, to: to).deliver_now
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end

--- a/spec/state_machines/sipity/state_machines/etd_student_submission_spec.rb
+++ b/spec/state_machines/sipity/state_machines/etd_student_submission_spec.rb
@@ -247,7 +247,7 @@ module Sipity
           it 'will send an email notification to the student and grad school and any additional emails provided (i.e. ISSA)' do
             expect(repository).to(
               have_received(:send_notification_for_entity_trigger).with(
-                notification: "confirmation_of_entity_approved_for_ingest", entity: entity,
+                notification: "confirmation_of_entity_ingested", entity: entity,
                 acting_as: ['creating_user', 'advisor', 'etd_reviewer'], additional_emails: options.fetch(:additional_emails)
               )
             )


### PR DESCRIPTION
The notification name, while correct, is made more correct by
renaming it to something that better reflects the state of the entity.