### PR TITLE
Handling access rights transient answer

### DIFF
--- a/app/models/sipity/models/transient_answer.rb
+++ b/app/models/sipity/models/transient_answer.rb
@@ -39,6 +39,8 @@ module Sipity
         ].freeze
       }.freeze
 
+      # TODO: Should there be validation concerning the question and answer?
+
       belongs_to :entity, polymorphic: true
     end
   end

--- a/app/repositories/sipity/commands/transient_answer_commands.rb
+++ b/app/repositories/sipity/commands/transient_answer_commands.rb
@@ -1,0 +1,29 @@
+module Sipity
+  # :nodoc:
+  module Commands
+    # Responsible for applying various transient answers to an entity. In some
+    # cases additional commands may fire.
+    #
+    # @see Sipity::Models::TransientAnswer
+    module TransientAnswerCommands
+      module_function def handle_transient_access_rights_answer(entity:, answer:)
+        # REVIEW: Is a transient answer necessary for the the "trivial" answers?
+        # That is to say the ones that write the more permanent "AccessRights"
+        transient_answer = Models::TransientAnswer.create!(
+          entity: entity, question_code: Models::TransientAnswer::ACCESS_RIGHTS_QUESTION, answer_code: answer
+        )
+        # REVIEW: There is some serious knowledge related to what is happening
+        #   here. Would it make sense to have a container for TransientAnswers
+        #   then within that container (i.e. question based) and send a
+        #   message to that container regarding application of the answer.
+        case answer
+        when 'open_access', 'restricted_access', 'private_access'
+          Models::AccessRight.create!(entity: entity, access_right_code: answer, enforcement_start_date: Date.today)
+        end
+        transient_answer
+      end
+      public :handle_transient_access_rights_answer
+    end
+    private_constant :TransientAnswerCommands
+  end
+end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -20,9 +20,7 @@ module Sipity
           work = Models::Work.create!(title: f.title, work_publication_strategy: f.work_publication_strategy)
           # TODO: Extract the method call below to a Repository command, because
           #   what happens based on answer could be very complicated.
-          Models::TransientAnswer.create!(
-            entity: work, question_code: Models::TransientAnswer::ACCESS_RIGHTS_QUESTION, answer_code: f.access_rights_answer
-          )
+          TransientAnswerCommands.handle_transient_access_rights_answer(entity: work, answer: f.access_rights_answer)
           AdditionalAttributeCommands.update_work_publication_date!(work: work, publication_date: f.publication_date)
           PermissionCommands.grant_creating_user_permission_for!(entity: work, user: requested_by)
           EventLogCommands.log_event!(entity: work, user: requested_by, event_name: __method__)

--- a/spec/repositories/sipity/commands/transient_answer_commands_spec.rb
+++ b/spec/repositories/sipity/commands/transient_answer_commands_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+module Sipity
+  module Commands
+    RSpec.describe TransientAnswerCommands, type: :repository_methods do
+      context '#handle_transient_access_rights_answer' do
+        Given(:entity) { Models::Work.new(id: 123) }
+
+        context 'with "open_access" answer' do
+          Given(:answer) { 'open_access' }
+          When(:response) { test_repository.handle_transient_access_rights_answer(entity: entity, answer: answer) }
+          Then { response.persisted? }
+          And { Models::AccessRight.count == 1 }
+        end
+
+        context 'with "restricted_access" answer' do
+          Given(:answer) { 'restricted_access' }
+          When(:response) { test_repository.handle_transient_access_rights_answer(entity: entity, answer: answer) }
+          Then { response.persisted? }
+          And { Models::AccessRight.count == 1 }
+        end
+
+        context 'with "private_access" answer' do
+          Given(:answer) { 'private_access' }
+          When(:response) { test_repository.handle_transient_access_rights_answer(entity: entity, answer: answer) }
+          Then { response.persisted? }
+          And { Models::AccessRight.count == 1 }
+        end
+
+        context 'with "access_changes_over_time" answer' do
+          Given(:answer) { 'access_changes_over_time' }
+          Invariant { Models::AccessRight.count }
+          When(:response) { test_repository.handle_transient_access_rights_answer(entity: entity, answer: answer) }
+          Then { response.persisted? }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In three of the four base cases, Sipity can write more "permanent"
information as it relates to the entity. This is also a question that
I want no more than one transient answer.