### PR TITLE
Reworking module_function declaration

### DIFF
--- a/app/jobs/sipity/jobs.rb
+++ b/app/jobs/sipity/jobs.rb
@@ -12,13 +12,14 @@ module Sipity
   module Jobs
     # Herein lies the inflection point. If you want to run things
     # asynchronously, this is your place to make changes.
-    module_function def submit(job_name, *args)
+    def submit(job_name, *args)
       job = find_job_by_name(job_name)
       verify_primativeness_of!(*args)
       job.submit(*args)
     end
+    module_function :submit
 
-    module_function def find_job_by_name(job_name)
+    def find_job_by_name(job_name)
       job_name_as_constant = job_name.to_s.classify
       if const_defined?(job_name_as_constant)
         const_get(job_name_as_constant)
@@ -26,14 +27,16 @@ module Sipity
         fail Exceptions::JobNotFoundError, name: job_name, container: self
       end
     end
+    module_function :find_job_by_name
     private_class_method :find_job_by_name
 
-    module_function def verify_primativeness_of!(*)
+    def verify_primativeness_of!(*)
       # REVIEW: Would it make sense to verify that each of the args is a
       #   primative? Given that we could be passing this information through
       #   REDIS
       true
     end
+    module_function :verify_primativeness_of!
     private_class_method :verify_primativeness_of!
   end
 end

--- a/app/policies/sipity/policies.rb
+++ b/app/policies/sipity/policies.rb
@@ -23,12 +23,13 @@ module Sipity
   # @see [Elabs' Pundit gem](http://github.com/elabs/pundit) for
   #   further explanation of Policy and Scope objects.
   module Policies
-    module_function def authorized_for?(user:, action_to_authorize:, entity:)
+    def authorized_for?(user:, action_to_authorize:, entity:)
       policy_enforcer = find_policy_enforcer_for(entity: entity)
       policy_enforcer.call(user: user, entity: entity, action_to_authorize: action_to_authorize)
     end
+    module_function :authorized_for?
 
-    module_function def find_policy_enforcer_for(entity:)
+    def find_policy_enforcer_for(entity:)
       return entity.policy_enforcer if entity.respond_to?(:policy_enforcer) && entity.policy_enforcer.present?
       policy_name_as_constant = "#{entity.class.to_s.demodulize}Policy"
       if const_defined?(policy_name_as_constant)
@@ -37,5 +38,6 @@ module Sipity
         fail Exceptions::PolicyNotFoundError, name: policy_name_as_constant, container: self
       end
     end
+    module_function :find_policy_enforcer_for
   end
 end

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -15,7 +15,7 @@ module Sipity
       # the given entity's work type.
       #
       # @raise Exception if for any of the given acting_as, no group could be found
-      module_function def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
+      def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
         # TODO: Extract this map of acting_as to groups; Will we need acting_as by
         #   work type?
         Array.wrap(acting_as).each do |an_acting_as|
@@ -26,22 +26,25 @@ module Sipity
           end
         end
       end
+      module_function :grant_groups_permission_to_entity_for_acting_as!
       public :grant_groups_permission_to_entity_for_acting_as!
 
-      module_function def grant_creating_user_permission_for!(entity:, user: nil, group: nil, actor: nil)
+      def grant_creating_user_permission_for!(entity:, user: nil, group: nil, actor: nil)
         # REVIEW: Does the constant even make sense on the data structure? Or
         #   is it more relevant here?
         acting_as = Models::Permission::CREATING_USER
         actors = [user, group, actor]
         grant_permission_for!(entity: entity, actors: actors, acting_as: acting_as)
       end
+      module_function :grant_creating_user_permission_for!
       public :grant_creating_user_permission_for!
 
-      module_function def grant_permission_for!(entity:, actors:, acting_as:)
+      def grant_permission_for!(entity:, actors:, acting_as:)
         Array.wrap(actors).flatten.compact.each do |an_actor|
           Models::Permission.create!(entity: entity, actor: an_actor, acting_as: acting_as)
         end
       end
+      module_function :grant_permission_for!
       private :grant_permission_for!
       private_class_method :grant_permission_for!
     end

--- a/app/repositories/sipity/commands/transient_answer_commands.rb
+++ b/app/repositories/sipity/commands/transient_answer_commands.rb
@@ -6,7 +6,7 @@ module Sipity
     #
     # @see Sipity::Models::TransientAnswer
     module TransientAnswerCommands
-      module_function def handle_transient_access_rights_answer(entity:, answer:)
+      def handle_transient_access_rights_answer(entity:, answer:)
         # REVIEW: Is a transient answer necessary for the the "trivial" answers?
         # That is to say the ones that write the more permanent "AccessRights"
         transient_answer = Models::TransientAnswer.create!(
@@ -22,6 +22,7 @@ module Sipity
         end
         transient_answer
       end
+      module_function :handle_transient_access_rights_answer
       public :handle_transient_access_rights_answer
     end
     private_constant :TransientAnswerCommands

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -6,15 +6,17 @@ module Sipity
         'etd_reviewer' => 'graduate_school', 'cataloger' => 'library_cataloging'
       }.freeze
 
-      module_function def group_names_for_entity_and_acting_as(options = {})
+      def group_names_for_entity_and_acting_as(options = {})
         acting_as = options.fetch(:acting_as)
         Array.wrap(ACTING_AS_TO_GROUP_NAME.fetch(acting_as))
       end
+      module_function :group_names_for_entity_and_acting_as
       public :group_names_for_entity_and_acting_as
 
-      module_function def emails_for_associated_users(acting_as:, entity:)
+      def emails_for_associated_users(acting_as:, entity:)
         scope_users_by_entity_and_acting_as(acting_as: acting_as, entity: entity).pluck(:email)
       end
+      module_function :emails_for_associated_users
       public :emails_for_associated_users
 
       # Responsible for returning a User scope:
@@ -32,7 +34,7 @@ module Sipity
       #
       # @note Welcome to the land of AREL.
       # @see https://github.com/rails/arel AREL - A Relational Algebra
-      module_function def scope_users_by_entity_and_acting_as(acting_as:, entity:)
+      def scope_users_by_entity_and_acting_as(acting_as:, entity:)
         user_table = User.arel_table
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
@@ -64,6 +66,7 @@ module Sipity
           or(user_table[:id].in(subqyery_user_relation_entity))
         )
       end
+      module_function :scope_users_by_entity_and_acting_as
       public :scope_users_by_entity_and_acting_as
 
       # Responsible for returning a scope for the entity type:
@@ -80,7 +83,7 @@ module Sipity
       #
       # @note Welcome to the land of AREL.
       # @see https://github.com/rails/arel AREL - A Relational Algebra
-      module_function def scope_entities_for_entity_type_and_user_acting_as(entity_type:, user:, acting_as:)
+      def scope_entities_for_entity_type_and_user_acting_as(entity_type:, user:, acting_as:)
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
         actor_id = user.to_param
@@ -107,6 +110,7 @@ module Sipity
           or(entity_type.arel_table[:id].in(subquery_entity_relation_to_user_by_group_membership))
         )
       end
+      module_function :scope_entities_for_entity_type_and_user_acting_as
       public :scope_entities_for_entity_type_and_user_acting_as
     end
   end

--- a/spec/support/sipity/factories.rb
+++ b/spec/support/sipity/factories.rb
@@ -1,8 +1,9 @@
 module Sipity
   module Factories
-    module_function def create_user(overrides = {})
+    def create_user(overrides = {})
       default_attributes = { name: 'Test User', email: 'test@example.com', password: 'please123' }
       User.create!(default_attributes.merge(overrides))
     end
+    module_function :create_user
   end
 end


### PR DESCRIPTION
I am running into a case where the Ruby beautifier (and to some extent
style guide) are not liking the module_function with method def. What
happens is the auto-beautify is getting very confused. I use the auto-
beautify to make sure spacing is "correct" and there is no trailing
white-space.