### PR TITLE
Rendering EntityEnrichmentAction in show view

### DIFF
--- a/app/decorators/sipity/decorators/entity_enrichment_action.rb
+++ b/app/decorators/sipity/decorators/entity_enrichment_action.rb
@@ -6,14 +6,21 @@ module Sipity
     # REVIEW: Should this object respond to render? Instead of requiring the
     #   template to render different elements.
     class EntityEnrichmentAction
-      extend ActiveModel::Translation
       def initialize(entity:, name:)
         @entity, @name = entity, name
       end
       attr_reader :entity, :name
 
       def path
+        # REVIEW: Should I make use of a proper route method? Or is this even
+        #   the correct routing method?
         File.join("#{view_context.polymorphic_path(entity)}", name)
+      end
+
+      def label
+        i18n_options = { scope: "sipity/decorators/entitiy_enrichment_actions.#{name}" }
+        i18n_options[:entity_type] = entity.respond_to?(:work_type) ? entity.work_type : 'item'
+        I18n.t(:label, i18n_options).html_safe
       end
 
       private

--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -31,6 +31,15 @@ module Sipity
           work_collaborators_for(work: object, role: 'author').map { |obj| decorator.decorate(obj) }
       end
 
+      def required_enrichment_actions
+        # REVIEW: Should I have an EnrichmentActionSet that could be rendered?
+        # REVIEW: This is dependent on work type,  state and perhaps current user.
+        [
+          EntityEnrichmentAction.new(entity: self, name: 'attach'),
+          EntityEnrichmentAction.new(entity: self, name: 'describe')
+        ]
+      end
+
       def available_linked_actions
         # TODO: This is dependent on object state
         # TODO: What to do when I have a non-persisted state? Can this decorator

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -37,12 +37,12 @@
   </div>
 </div>
 
-<%# REVIEW: This is ETD centric; and will need to be based on associated tasks; But for now its what we need %>
 <div>
   <h2>Required</h2>
   <ul>
-    <li><span><strong>Attach</strong> files</strong> to this <%= model.work_type %></span> <a class="btn btn-primary">Do It!</a></li>
-    <li><span>Further <strong>describe</strong> your <%= model.work_type %></span> <a class="btn btn-primary">Do It!</a></li>
+    <%- model.required_enrichment_actions.each do |action| -%>
+    <li class="require-<%= action.name %>"><span><%= action.label %></span> <a href="<%= action.path %>" class="btn btn-primary">Do It!</a></li>
+    <%- end -%>
   </ul>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,11 @@ en:
       doi_already_assigned: 'A DOI has already been assigned to %{title}.'
       doi_request_is_pending: 'A request for a DOI is pending for %{title}.'
       doi_not_assigned: 'It appears that you do not have a DOI for %{title}. Would you like to fix that?'
+  sipity/decorators/entitiy_enrichment_actions:
+    attach:
+      label: "<strong>Attach</strong> files to this %{entity_type}"
+    describe:
+      label: "Further <strong>describe</strong> your %{entity_type}"
   sipity/decorators/recommendations/doi_recommendation:
     state:
       doi_already_assigned: 'DOI Already Assigned'

--- a/spec/decorators/sipity/decorators/entity_enrichment_action_spec.rb
+++ b/spec/decorators/sipity/decorators/entity_enrichment_action_spec.rb
@@ -9,6 +9,10 @@ module Sipity
       its(:entity) { should eq(entity) }
       its(:name) { should eq(name) }
       its(:path) { should eq("/works/#{entity.to_param}/#{name}") }
+
+      it 'will have a translated label based on the given name and entity' do
+        expect(subject.label).to eq("translation missing: en.sipity/decorators/entitiy_enrichment_actions.#{name}.label")
+      end
     end
   end
 end

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -15,6 +15,12 @@ module Sipity
         end
       end
 
+      context '#required_enrichment_actions' do
+        it 'will return an enumerable in which all elements responds to path' do
+          expect(subject.required_enrichment_actions.all? { |action| action.respond_to?(:path) }).to be_truthy
+        end
+      end
+
       context '#with_form_panel' do
         it 'wrap the results of the block inside a panel' do
           rendered = subject.with_form_panel('attributes') { 'hello' }


### PR DESCRIPTION
EntityEnrichmentActions are going to vary by:

* User - some users may not need to or be able to see a certain option
  a grad may not be given the opportunity to add all kinds of
  metadata to their deposit, that may be reserved for an approving
  librarian or metadata specialist)
* State - based on an object's state, additional enrichments may not
  be available; Once an ETD has been approved for review we may choose
  to disallow one or more forms, opting instead to make the "kitchen
  sink" enrichment option available.
* Entity Type - the enrichment options for an ETD vs. an Image vs.
  some other work type will vary

An important thing as we continue developing this application is to
make sure that we have named concepts. In naming things we can grow
our understanding as a team. It also draws attention to the fact that
most everything should have a proper name.