### PR TITLE
Extracting #submit method to form

### DIFF
--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -41,6 +41,17 @@ module Sipity
         possible_work_types.map { |elem| elem.first.to_sym }
       end
 
+      def submit(repository:, requested_by:)
+        super() do |f|
+          work = Models::Work.create!(title: f.title, work_publication_strategy: f.work_publication_strategy)
+          repository.handle_transient_access_rights_answer(entity: work, answer: f.access_rights_answer)
+          repository.update_work_publication_date!(work: work, publication_date: f.publication_date)
+          repository.grant_creating_user_permission_for!(entity: work, user: requested_by)
+          repository.log_event!(entity: work, user: requested_by, event_name: __method__)
+          work
+        end
+      end
+
       private
 
       def possible_work_types

--- a/app/repositories/sipity/commands.rb
+++ b/app/repositories/sipity/commands.rb
@@ -19,6 +19,7 @@ module Sipity
       base.send(:include, NotificationCommands)
       base.send(:include, AdditionalAttributeCommands)
       base.send(:include, PermissionCommands)
+      base.send(:include, TransientAnswerCommands)
     end
   end
 end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -15,19 +15,6 @@ module Sipity
         work.update(processing_state: new_processing_state)
       end
 
-      def submit_create_work_form(form, requested_by:)
-        form.submit do |f|
-          work = Models::Work.create!(title: f.title, work_publication_strategy: f.work_publication_strategy)
-          # TODO: Extract the method call below to a Repository command, because
-          #   what happens based on answer could be very complicated.
-          TransientAnswerCommands.handle_transient_access_rights_answer(entity: work, answer: f.access_rights_answer)
-          AdditionalAttributeCommands.update_work_publication_date!(work: work, publication_date: f.publication_date)
-          PermissionCommands.grant_creating_user_permission_for!(entity: work, user: requested_by)
-          EventLogCommands.log_event!(entity: work, user: requested_by, event_name: __method__)
-          work
-        end
-      end
-
       def submit_update_work_form(form, requested_by:)
         form.submit do |f|
           work = find_work(f.work.id)

--- a/app/runners/sipity/runners/work_runners.rb
+++ b/app/runners/sipity/runners/work_runners.rb
@@ -23,7 +23,7 @@ module Sipity
         def run(attributes:)
           form = repository.build_create_work_form(attributes: attributes)
           authorization_layer.enforce!(create?: form) do
-            work = repository.submit_create_work_form(form, requested_by: current_user)
+            work = form.submit(repository: repository, requested_by: current_user)
             if work
               callback(:success, work)
             else

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module Sipity
   module Commands
-    RSpec.describe WorkCommands, type: :repository_methods do
+    RSpec.describe WorkCommands, type: :command_repository do
       context '#assign_a_pid' do
         it 'will assign a unique permanent persisted identifier for the work'
       end
@@ -12,46 +12,6 @@ module Sipity
         it 'will update the underlying state of the object' do
           expect { test_repository.update_processing_state!(work: work, new_processing_state: 'hello') }.
             to change { work.processing_state }.to('hello')
-        end
-      end
-
-      context '#submit_create_work_form' do
-        let(:user) { User.new(id: '123') }
-        let(:form) do
-          test_repository.build_create_work_form(
-            attributes: {
-              title: 'This is my title',
-              work_publication_strategy: 'do_not_know',
-              publication_date: '2014-11-12',
-              access_rights_answer: Models::TransientAnswer::ACCESS_RIGHTS_PRIVATE
-            }
-          )
-        end
-        context 'with invalid data' do
-          it 'will not create a a work' do
-            allow(form).to receive(:valid?).and_return(false)
-            expect { test_repository.submit_create_work_form(form, requested_by: user) }.
-              to_not change { Models::Work.count }
-          end
-          it 'will return false' do
-            allow(form).to receive(:valid?).and_return(false)
-            expect(test_repository.submit_create_work_form(form, requested_by: user)).to eq(false)
-          end
-        end
-        context 'with valid data' do
-          let(:user) { User.new(id: '123') }
-          it 'will return the work having created the work, added the attributes,
-              assigned collaborators, assigned permission, and loggged the event' do
-            allow(form).to receive(:valid?).and_return(true)
-            response = test_repository.submit_create_work_form(form, requested_by: user)
-
-            expect(response).to be_a(Models::Work)
-            expect(Models::Work.count).to eq(1)
-            expect(Models::TransientAnswer.count).to eq(1)
-            expect(response.additional_attributes.count).to eq(1)
-            expect(Models::Permission.where(actor: user, acting_as: Models::Permission::CREATING_USER).count).to eq(1)
-            expect(Models::EventLog.where(user: user, event_name: 'submit_create_work_form').count).to eq(1)
-          end
         end
       end
 

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -25,8 +25,8 @@ module Sipity
             attributes: { title: 'My Title', work_publication_strategy: 'do_not_know', work_type: 'ETD' }
           )
         end
-        let!(:work_one) { command_repository.submit_create_work_form(form, requested_by: user_one) }
-        let!(:work_two) { command_repository.submit_create_work_form(form, requested_by: user_two) }
+        let!(:work_one) { form.submit(repository: Sipity::Repository.new, requested_by: user_one) }
+        let!(:work_two) { form.submit(repository: Sipity::Repository.new, requested_by: user_two) }
         it 'will include works that were created by the user' do
           expect(test_repository.find_works_for(user: user_one)).to eq([work_one])
         end

--- a/spec/runners/sipity/runners/work_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_runners_spec.rb
@@ -40,13 +40,11 @@ module Sipity
 
       RSpec.describe Create do
         let(:work) { double('Work') }
-        let(:form) { double('Form') }
+        let(:form) { double('Form', submit: creation_response) }
         let(:user) { User.new(id: '1') }
         let(:context) do
           TestRunnerContext.new(
-            current_user: user,
-            build_create_work_form: form, submit_create_work_form: creation_response,
-            policy_authorized_for?: true
+            current_user: user, build_create_work_form: form, policy_authorized_for?: true
           )
         end
         let(:creation_response) { nil }


### PR DESCRIPTION
* Polymorphism related to forms - That is to say each form has a
  reasonable idea of what it needs to do; so do that. This aligns
  better with the Reform and ActiveForm behaviors
* Begin removing repository command module_functions - Given that many
  of the command behaviors were both a module_function and an instance
  method, it implies a certain complexity and leakyness in the
  abstraction.
* Removes several methods from the command modules
* Pushes the relevant form code closer to the object in question.

See Sipity@e4dfa9a7d7ed6dc0ad81858095f9145786aa7bb5 for additional
commentary regarding why this change