### PR TITLE
Preparing for next enrichment

### DIFF
--- a/app/decorators/sipity/decorators/entity_enrichment_action.rb
+++ b/app/decorators/sipity/decorators/entity_enrichment_action.rb
@@ -17,12 +17,6 @@ module Sipity
         File.join("#{view_context.polymorphic_path(entity)}", name)
       end
 
-      def path_to_new
-        # REVIEW: Should I make use of a proper route method? Or is this even
-        #   the correct routing method?
-        File.join(path, 'new')
-      end
-
       def label
         i18n_options = { scope: "sipity/decorators/entitiy_enrichment_actions.#{name}" }
         i18n_options[:entity_type] = entity.respond_to?(:work_type) ? entity.work_type : 'item'

--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -36,7 +36,7 @@ module Sipity
         # REVIEW: This is dependent on work type,  state and perhaps current user.
         [
           EntityEnrichmentAction.new(entity: self, name: 'attach'),
-          EntityEnrichmentAction.new(entity: self, name: 'work_description')
+          EntityEnrichmentAction.new(entity: self, name: 'describe')
         ]
       end
 

--- a/app/views/sipity/controllers/work_descriptions/new.html.erb
+++ b/app/views/sipity/controllers/work_descriptions/new.html.erb
@@ -1,8 +1,8 @@
 <h2>Describe your work</h2>
-<%= simple_form_for(model, url: work_work_description_path(model.work), method: :post, as: :describe) do |f| %>
-<%= f.error_notification %>
-<%= field_set_tag do %>
-  <%= f.input :abstract, as: :text %>
-  <%= f.submit %>
-<% end %>
+<%= simple_form_for(model, url: describe_work_path(model.work), method: :post, as: :work) do |f| %>
+  <%= f.error_notification %>
+  <%= field_set_tag do %>
+    <%= f.input :abstract, as: :text %>
+    <%= f.submit %>
+  <% end %>
 <% end %>

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -41,7 +41,7 @@
   <h2>Required</h2>
   <ul>
     <%- model.required_enrichment_actions.each do |action| -%>
-      <li class="require-<%= action.name %>"><span><%= action.label %></span><%= link_to action.label, action.path_to_new %></li>
+      <li class="require-<%= action.name %>"><span><%= action.label %></span><%= link_to action.label, action.path %></li>
     <%- end -%>
   </ul>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
     scope module: :controllers do
       resources :works do
         resource :citation
-        resource :work_description
         resource :doi do
           member do
             post :assign_a_doi
@@ -11,6 +10,8 @@ Rails.application.routes.draw do
           end
         end
       end
+      get 'works/:work_id/describe', to: 'work_descriptions#new', as: 'describe_work'
+      post 'works/:work_id/describe', to: 'work_descriptions#create'
     end
   end
 

--- a/spec/decorators/sipity/decorators/entity_enrichment_action_spec.rb
+++ b/spec/decorators/sipity/decorators/entity_enrichment_action_spec.rb
@@ -9,19 +9,11 @@ module Sipity
       its(:entity) { should eq(entity) }
       its(:name) { should eq(name) }
       its(:path) { should eq("/works/#{entity.to_param}/#{name}") }
-      its(:path_to_new) { should eq("/works/#{entity.to_param}/#{name}/new") }
 
       it 'will have a translated label based on the given name and entity' do
         expect(subject.label).to eq("translation missing: en.sipity/decorators/entitiy_enrichment_actions.#{name}.label")
       end
 
-      it 'will have a :path' do
-        expect(subject.path).to eq("/works/#{entity.to_param}/#{name}")
-      end
-
-      it 'will have a :path_to_new' do
-        expect(subject.path_to_new).to eq("/works/#{entity.to_param}/#{name}/new")
-      end
     end
   end
 end

--- a/spec/features/sipity/create_minimum_viable_work_spec.rb
+++ b/spec/features/sipity/create_minimum_viable_work_spec.rb
@@ -59,7 +59,7 @@ feature 'Minimum viable SIP', :devise do
       the_page.submit_button.click
     end
     on('work_page') do |the_page|
-      the_page.click_required('work_description')
+      the_page.click_required('describe')
     end
 
     on('describe_page') do |the_page|

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -74,13 +74,12 @@ module SitePrism
     end
 
     class DescribePage < SitePrism::Page
-      DOM_CLASS = "new_describe"
-      PARAM_NAME_CONTAINER = 'describe'.freeze
-      element :form, "form.#{DOM_CLASS}"
-      element :input_abstract, "form.#{DOM_CLASS} textarea[name='#{PARAM_NAME_CONTAINER}[abstract]']"
+      PARAM_NAME_CONTAINER = 'work'.freeze
+      element :form, "form[method='post']"
+      element :input_abstract, "form [name='#{PARAM_NAME_CONTAINER}[abstract]']"
 
       def fill_in(predicate, with: nil)
-        find("form.#{DOM_CLASS} [name='#{PARAM_NAME_CONTAINER}[#{predicate}]']").set(with)
+        find("form [name='#{PARAM_NAME_CONTAINER}[#{predicate}]']").set(with)
       end
     end
 


### PR DESCRIPTION
Building on DLTP-346 and preparing for DLTP-347, I'm looking to reduce
the need for multiple controllers based on enrichment.

This current step is moving the routing to a less resource-based route
and more of a task-based route.

From:

```ruby
resources :works do
  resource :work_description
end
```

To:

```ruby
get(
  'works/:work_id/describe',
  to: 'work_descriptions#new', as: 'describe_work'
)
post 'works/:work_id/describe', to: 'work_descriptions#create'
```

My eventual goal for describe and attach are to leverage a shared
route as follows:

```ruby
get(
  'works/:work_id/:enrichment_type',
  to: 'work_descriptions#new', as: 'enrich_work'
)
post 'works/:work_id/:enrichment_type', to: 'work_enrichments#update'
```

Note that the action names change from #new/#update to #edit/#create.
This is because an enrichment is always a modification to an
underlying work.

For example (and it is arbitrary):

One enrichment is for DOIs:

* Title
* Publisher
* Publication Year
* Authors

Another enrichment is for Publication Intent:

* Publication date
* Publisher
* Publication format

If you complete the Publication Intent enrichment, then go to the DOI
enrichment, the publisher and publication year would be pre-populated
because you have already provided some of the information.