### PR TITLE
Extracting #submit method to form

### DIFF
--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -7,41 +7,10 @@ module Sipity
       included do |base|
         base.send(:include, Queries::WorkQueries)
       end
-      # TODO: This is duplicationed
-      BASE_HEADER_ATTRIBUTES = [:title, :work_publication_strategy].freeze
       def update_processing_state!(work:, new_processing_state:)
         # REVIEW: Should this be re-finding the work? Is it cheating to re-use
         #   the given work? Is it unsafe as far as state is concerned?
         work.update(processing_state: new_processing_state)
-      end
-
-      def submit_update_work_form(form, requested_by:)
-        form.submit do |f|
-          work = find_work(f.work.id)
-          with_work_attributes_for_form(f) { |attributes| work.update(attributes) }
-          with_each_additional_attribute_for_work_form(f) do |key, values|
-            AdditionalAttributeCommands.update_work_attribute_values!(work: work, key: key, values: values)
-          end
-          EventLogCommands.log_event!(entity: work, user: requested_by, event_name: __method__) if requested_by
-          work
-        end
-      end
-
-      private
-
-      def with_each_additional_attribute_for_work_form(form)
-        Queries::AdditionalAttributeQueries.work_attribute_keys_for(work: form.work).each do |key|
-          next unless  form.exposes?(key)
-          yield(key, form.public_send(key))
-        end
-      end
-
-      def with_work_attributes_for_form(form)
-        attributes = {}
-        BASE_HEADER_ATTRIBUTES.each do |attribute_name|
-          attributes[attribute_name] = form.public_send(attribute_name) if form.exposes?(attribute_name)
-        end
-        yield(attributes) if attributes.any?
       end
     end
     private_constant :WorkCommands

--- a/app/runners/sipity/runners/work_runners.rb
+++ b/app/runners/sipity/runners/work_runners.rb
@@ -79,7 +79,7 @@ module Sipity
           work = repository.find_work(work_id)
           form = repository.build_update_work_form(work: work, attributes: attributes)
           authorization_layer.enforce!(submit?: form) do
-            work = repository.submit_update_work_form(form, requested_by: current_user)
+            work = form.submit(repository: repository, requested_by: current_user)
             if work
               callback(:success, work)
             else

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -14,40 +14,6 @@ module Sipity
             to change { work.processing_state }.to('hello')
         end
       end
-
-      context '#submit_update_work_form' do
-        let(:user) { User.new(id: '123') }
-        let(:work) { Models::Work.create(title: 'My Title', work_publication_strategy: 'do_not_know') }
-        let(:form) { test_repository.build_update_work_form(work: work, attributes: { title: 'My New Title', publisher: 'dance' }) }
-        context 'with invalid data' do
-          before do
-            allow(work).to receive(:persisted?).and_return(true)
-            allow(form).to receive(:valid?).and_return(false)
-          end
-          it 'will return false' do
-            expect(test_repository.submit_update_work_form(form, requested_by: user)).to eq(false)
-          end
-          it 'will NOT update the work' do
-            expect { test_repository.submit_update_work_form(form, requested_by: user) }.
-              to_not change { work.reload.title }
-          end
-        end
-        context 'with valid data' do
-          before do
-            Models::AdditionalAttribute.create!(work: work, key: 'publisher', value: 'parmasean')
-            allow(work).to receive(:persisted?).and_return(true)
-            allow(form).to receive(:valid?).and_return(true)
-          end
-          it 'will return the work after updating the work, additional attributes, and creating an event log entry' do
-            response = test_repository.submit_update_work_form(form, requested_by: user)
-
-            expect(response).to eq(work)
-            expect(work.reload.title).to eq('My New Title')
-            expect(Models::AdditionalAttribute.where(work: work).pluck(:key, :value)).to eq([['publisher', 'dance']])
-            expect(Models::EventLog.where(user: user, event_name: 'submit_update_work_form').count).to eq(1)
-          end
-        end
-      end
     end
   end
 end

--- a/spec/runners/sipity/runners/work_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_runners_spec.rb
@@ -166,13 +166,9 @@ module Sipity
 
       RSpec.describe Update do
         let(:work) { double('Work') }
-        let(:form) { double('Form') }
+        let(:form) { double('Form', submit: update_response) }
         let(:user) { double('User') }
-        let(:context) do
-          TestRunnerContext.new(
-            find_work: work, build_update_work_form: form, submit_update_work_form: update_response, current_user: user
-          )
-        end
+        let(:context) { TestRunnerContext.new(find_work: work, build_update_work_form: form, current_user: user) }
         let(:update_response) { nil }
         let(:handler) { double(invoked: true) }
         let(:attributes) { {} }


### PR DESCRIPTION
* Polymorphism related to forms - That is to say each form has a
  reasonable idea of what it needs to do; so do that. This aligns
  better with the Reform and ActiveForm behaviors
* Begin removing repository command module_functions - Given that many
  of the command behaviors were both a module_function and an instance
  method, it implies a certain complexity and leakyness in the
  abstraction.
* Removes several methods from the command modules
* Pushes the relevant form code closer to the object in question.

See Sipity@e4dfa9a and Sipity@c1ebbe2 for additional commentary