### PR TITLE
Adding todo list

### DIFF
--- a/app/decorators/sipity/decorators/entity_enrichment_action.rb
+++ b/app/decorators/sipity/decorators/entity_enrichment_action.rb
@@ -11,7 +11,6 @@ module Sipity
       end
       attr_reader :entity, :name
 
-
       def status
         # REVIEW: This should not be static but is based on the state of the
         #   entity and the particular enrichment in question. It will be set

--- a/app/decorators/sipity/decorators/entity_enrichment_action.rb
+++ b/app/decorators/sipity/decorators/entity_enrichment_action.rb
@@ -11,6 +11,14 @@ module Sipity
       end
       attr_reader :entity, :name
 
+
+      def status
+        # REVIEW: This should not be static but is based on the state of the
+        #   entity and the particular enrichment in question. It will be set
+        #   elsewhere.
+        'incomplete'
+      end
+
       def path
         # REVIEW: Should I make use of a proper route method? Or is this even
         #   the correct routing method?

--- a/app/decorators/sipity/decorators/todo_list.rb
+++ b/app/decorators/sipity/decorators/todo_list.rb
@@ -1,0 +1,28 @@
+module Sipity
+  module Decorators
+    class TodoList
+      def initialize(options = {})
+        @entity = options.fetch(:entity)
+        @item_builder = options.fetch(:item_builder) { default_item_builder }
+        @item_sets = {}
+      end
+
+      attr_reader :entity, :item_sets
+      attr_reader :item_builder
+      private :item_builder
+
+      def add_to(item_set:, item_name:)
+        item_sets[item_set.to_s] ||= Set.new
+        item_sets[item_set.to_s] << item_builder.call(item_name)
+      end
+
+      private
+
+      def default_item_builder
+        lambda do |name|
+          EntityEnrichmentAction.new(entity: entity, name: name)
+        end
+      end
+    end
+  end
+end

--- a/app/decorators/sipity/decorators/todo_list.rb
+++ b/app/decorators/sipity/decorators/todo_list.rb
@@ -1,19 +1,26 @@
 module Sipity
   module Decorators
+    # Responsible for exposing an interface to register a set and item as well
+    # as iterate on those concerns.
+    #
+    # TODO: Should the set container be a named object
     class TodoList
       def initialize(options = {})
         @entity = options.fetch(:entity)
+        # REVIEW: Should I be including this? Or is it up to the initializer of
+        #   this object?
         @item_builder = options.fetch(:item_builder) { default_item_builder }
-        @item_sets = {}
+        @sets = {}
+        yield(self) if block_given?
       end
 
-      attr_reader :entity, :item_sets
+      attr_reader :entity, :sets
       attr_reader :item_builder
       private :item_builder
 
-      def add_to(item_set:, item_name:)
-        item_sets[item_set.to_s] ||= Set.new
-        item_sets[item_set.to_s] << item_builder.call(item_name)
+      def add_to(set:, name:)
+        sets[set.to_s] ||= Set.new
+        sets[set.to_s] << item_builder.call(name)
       end
 
       private

--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -52,7 +52,18 @@ module Sipity
         ]
       end
 
+      def each_todo_item_set
+        todo_list.sets.each { |name, items| yield(name, items) if items.present? }
+      end
+
       private
+
+      def todo_list
+        @todo_list = TodoList.new(entity: self) do |list|
+          list.add_to(set: 'required', name: 'attach')
+          list.add_to(set: 'required', name: 'describe')
+        end
+      end
 
       def recommendation_for(name)
         Recommendations.const_get("#{name.classify}Recommendation").new(work: self)

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -37,13 +37,22 @@
   </div>
 </div>
 
-<div>
-  <h2>Required</h2>
-  <ul>
-    <%- model.required_enrichment_actions.each do |action| -%>
-      <li class="require-<%= action.name %>"><span><%= action.label %></span><%= link_to action.label, action.path %></li>
-    <%- end -%>
-  </ul>
+<div class="todo">
+  <%- model.each_todo_item_set do |set, actions| -%>
+    <%# TODO: the set should be an object not a string; That object should have I18n %>
+    <div class="todo todo-<%= set %>">
+      <h2><%= set %></h2>
+      <ul>
+        <%- actions.each do |action| -%>
+          <li class="<%= set %>-<%= action.name %>">
+            <span><%= action.status %></span>
+            <span><%= action.label %></span>
+            <%= link_to 'Do it!', action.path %>
+          </li>
+        <%- end -%>
+      <ul>
+    </div>
+  <%- end -%>
 </div>
 
 <div class="recommendations">

--- a/spec/decorators/sipity/decorators/entity_enrichment_action_spec.rb
+++ b/spec/decorators/sipity/decorators/entity_enrichment_action_spec.rb
@@ -8,6 +8,7 @@ module Sipity
       before { allow(entity).to receive(:persisted?).and_return(true) }
       its(:entity) { should eq(entity) }
       its(:name) { should eq(name) }
+      its(:status) { should be_a(String) }
       its(:path) { should eq("/works/#{entity.to_param}/#{name}") }
 
       it 'will have a translated label based on the given name and entity' do

--- a/spec/decorators/sipity/decorators/todo_list_spec.rb
+++ b/spec/decorators/sipity/decorators/todo_list_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Sipity
+  module Decorators
+    RSpec.describe TodoList do
+      let(:entity) { double('Entity') }
+      let(:item_builder) { ->(value) { value } }
+      subject { described_class.new(entity: entity, item_builder: item_builder) }
+
+      context '#add_to_item_set' do
+        it 'will create a new named item_set' do
+          expect { subject.add_to(item_set: 'required', item_name: 'describe') }.
+            to change { subject.item_sets.count }.by(1)
+        end
+
+        it 'will append an item to an existing item_set' do
+          subject.add_to(item_set: 'required', item_name: 'describe')
+          expect { subject.add_to(item_set: 'required', item_name: 'attach' ) }.
+            to_not change { subject.item_sets.count }
+        end
+      end
+    end
+  end
+end

--- a/spec/decorators/sipity/decorators/todo_list_spec.rb
+++ b/spec/decorators/sipity/decorators/todo_list_spec.rb
@@ -7,16 +7,19 @@ module Sipity
       let(:item_builder) { ->(value) { value } }
       subject { described_class.new(entity: entity, item_builder: item_builder) }
 
-      context '#add_to_item_set' do
-        it 'will create a new named item_set' do
-          expect { subject.add_to(item_set: 'required', item_name: 'describe') }.
-            to change { subject.item_sets.count }.by(1)
+      it 'will accept a block on initialize' do
+        expect { |b| described_class.new(entity: entity, &b) }.to yield_with_args(described_class)
+      end
+      context '#add_to' do
+        it 'will create a new named set' do
+          expect { subject.add_to(set: 'required', name: 'describe') }.
+            to change { subject.sets.count }.by(1)
         end
 
-        it 'will append an item to an existing item_set' do
-          subject.add_to(item_set: 'required', item_name: 'describe')
-          expect { subject.add_to(item_set: 'required', item_name: 'attach' ) }.
-            to_not change { subject.item_sets.count }
+        it 'will append an item to an existing set' do
+          subject.add_to(set: 'required', name: 'describe')
+          expect { subject.add_to(set: 'required', name: 'attach') }.
+            to_not change { subject.sets.count }
         end
       end
     end

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -9,6 +9,12 @@ module Sipity
         expect(subject.to_s).to eq(work.title)
       end
 
+      context '#each_todo_item_set' do
+        it 'will be an enumerable' do
+          expect { |b| subject.each_todo_item_set(&b) }.to yield_with_args('required', Set)
+        end
+      end
+
       context '#available_linked_actions' do
         it 'will return an enumerable in which all elements responds to render' do
           expect(subject.available_linked_actions.all? { |link| link.respond_to?(:render) }).to be_truthy

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -65,7 +65,7 @@ module SitePrism
       end
 
       def click_required(name)
-        find(".require-#{name.downcase} a").click
+        find(".required-#{name.downcase} a").click
       end
 
       def click_edit


### PR DESCRIPTION
## Incorporating Todo List into show UI

I want to create a common interface for rendering a work's todo items.
This is not the final state of the rendering but it is enough to allow
work to continue on the todo item.

## Adding the todo list

I want a way to dynamically generate the TODO list for rendering on
the work page. Right now I may be mixing the enrichment and todo items
before they should be mixed. However, the goal is to push up a
rudimentary listing option for dynamic rendering.

## Adding status to enrichment action

As per a conversation with Dan, as we move towards a TODO based page
rendering, I want to expose the status for view rendering.
