### PR TITLE
Marking up our action via Schema.org

### DIFF
--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -40,14 +40,20 @@
 <div class="todo">
   <%- model.each_todo_item_set do |set, actions| -%>
     <%# TODO: the set should be an object not a string; That object should have I18n %>
-    <div class="todo todo-<%= set %>">
+    <div>
       <h2><%= set %></h2>
       <ul>
         <%- actions.each do |action| -%>
-          <li class="<%= set %>-<%= action.name %>">
-            <span><%= action.status %></span>
-            <span><%= action.label %></span>
-            <%= link_to 'Do it!', action.path %>
+          <%# REVIEW: This is an experimental idea; We are using the Schema.org
+              structure to drive our automated testing. This should be viewed as
+              experimental and will be part of an ongoing conversation amongst
+              the developers.
+          %>
+          <li itemscope itemtype="http://schema.org/Action">
+            <span itemprop="actionStatus"><%= action.status %></span>
+            <span itemprop="description"><%= action.label %></span>
+            <meta itemprop="name" content="<%= set %>><%= action.name %>">
+            <a itemprop="url" href="<%= action.path %>">Do it!</a>
           </li>
         <%- end -%>
       <ul>

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -65,7 +65,7 @@ module SitePrism
       end
 
       def click_required(name)
-        find(".required-#{name.downcase} a").click
+        find("[itemprop='name'][content='required>#{name.downcase}']+[itemprop='url']").click
       end
 
       def click_edit


### PR DESCRIPTION
As part of an experiment we are attempting to reduce the collision of
concerns related to CSS, Javascript, and automated testing.

Dan will be working to articulate the markup guidelines; At present
we are looking to reserve dom classes for CSS and JS interaction.
Testing is a somewhat different concern. The hope is that by spending
time marking up via Schema.org, when someone sees that markup they
will consider "What does this mean?" and be less prone to
modification.

REVIEW: This is an experimental idea; We are using the Schema.org
structure to drive our automated testing. This should be viewed as
experimental and will be part of an ongoing conversation amongst the
developers.