### PR TITLE
Creating a sipity:rebuild_interfaces task

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -23,6 +23,8 @@ AllCops:
     - config/**/*
     - 'spec/fixtures/**/*'
     - 'vendor/**/*'
+    - 'scripts/**/*'
+    - 'spec/support/sipity/command_repository_interface.rb'
 
 MethodLength:
   Max: 10

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ end
 
 namespace :spec do
   desc "Run all specs"
-  RSpec::Core::RakeTask.new(:all) do
+  RSpec::Core::RakeTask.new(all: 'sipity:rebuild_interfaces') do
     ENV['COVERAGE'] = 'true'
   end
 
@@ -51,16 +51,4 @@ end
 
 Rake::Task["default"].clear
 task default: ['db:schema:load', 'rubocop', 'spec:all']
-
-namespace :sipity do
-  task :stats_setup do
-    require 'rails/code_statistics'
-    types.each do |type, dir|
-      name = type.pluralize.capitalize
-      ::STATS_DIRECTORIES << [name, dir] unless ::STATS_DIRECTORIES.find { |array| array[0] == name }
-    end
-    ::STATS_DIRECTORIES.sort!
-  end
-end
-
 task stats: ['sipity:stats_setup']

--- a/app/repositories/sipity/commands.rb
+++ b/app/repositories/sipity/commands.rb
@@ -8,6 +8,8 @@ module Sipity
   #
   # @see http://martinfowler.com/bliki/CommandQuerySeparation.html Martin
   #   Folwer's article on Command/Query separation
+  # @see 'sipity:rebuild_interfaces' rake task for information about rebuilding
+  #   the Sipity command interface from the existing method signatures.
   module Commands
     extend ActiveSupport::Concern
 

--- a/lib/tasks/sipity.rake
+++ b/lib/tasks/sipity.rake
@@ -1,0 +1,58 @@
+namespace :sipity do
+  desc 'Build the various repository interfaces for testing purposes; These are descriptive interfaces'
+  task :rebuild_interfaces do
+    Rake::Task['sipity:build_command_repository_interface'].invoke unless ENV['TRAVIS']
+  end
+
+  desc 'Builds the interface for the command repository; Useful for testing purposes'
+  task :build_command_repository_interface do
+    MethodDefinition = Struct.new(:name, :definition, :source_filename)
+    method_definitions = []
+
+    dirname = File.expand_path('../../../app/repositories/sipity/commands/**/*.rb', __FILE__)
+
+    # Gather all of the command methods
+    Dir.glob(dirname).each do |filename|
+      File.read(filename).each_line do |line|
+        if line =~ /^ *def ([\w]*)[^\w].*$/
+          method_name = $1
+          # This is a potentially big problem that I want to address.
+          if method_definitions.detect { |m| m.name == method_name }
+            $stderr.puts "Duplicate method_name encountered. \"#{method_name}\" has been defined in multiple files."
+            exit(1)
+          else
+            filename.sub!(/^.*\/app\//, './app/')
+            method_definitions << MethodDefinition.new(method_name, line.strip, filename)
+          end
+        end
+      end
+    end
+
+    # Be kind, lets put the methods in the file in alphabetical order.
+    method_definitions.sort! { |a,b| a.name <=> b.name }
+
+    # Write a Sipity::CommandRepositoryInterface object for use in testing.
+    mock_repository_filename = File.expand_path('../../../spec/support/sipity/command_repository_interface.rb', __FILE__)
+    File.open(mock_repository_filename, 'w+') do |file|
+      file.puts "module Sipity"
+      file.puts "  class CommandRepositoryInterface"
+      method_definitions.each do |method|
+        file.puts "    # @see #{method.source_filename}"
+        file.puts "    #{method.definition}"
+        file.puts "    end"
+        file.puts ""
+      end
+      file.puts "  end"
+      file.puts "end"
+    end
+  end
+
+  task :stats_setup do
+    require 'rails/code_statistics'
+    types.each do |type, dir|
+      name = type.pluralize.capitalize
+      ::STATS_DIRECTORIES << [name, dir] unless ::STATS_DIRECTORIES.find { |array| array[0] == name }
+    end
+    ::STATS_DIRECTORIES.sort!
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -1,0 +1,72 @@
+module Sipity
+  class CommandRepositoryInterface
+    # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
+    def create_work_attribute_values!(work:, key:, values:)
+    end
+
+    # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
+    def destroy_work_attribute_values!(work:, key:, values:)
+    end
+
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def grant_creating_user_permission_for!(entity:, user: nil, group: nil, actor: nil)
+    end
+
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def grant_permission_for!(entity:, actors:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/commands/transient_answer_commands.rb
+    def handle_transient_access_rights_answer(entity:, answer:)
+    end
+
+    # @see ./app/repositories/sipity/commands/event_log_commands.rb
+    def log_event!(entity:, user:, event_name:)
+    end
+
+    # @see ./app/repositories/sipity/commands/notification_commands.rb
+    def send_notification_for_entity_trigger(notification:, entity:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/commands/doi_commands.rb
+    def submit_assign_a_doi_form(form, requested_by:)
+    end
+
+    # @see ./app/repositories/sipity/commands/account_placeholder_commands.rb
+    def submit_create_orcid_account_placeholder_form(form, requested_by:)
+    end
+
+    # @see ./app/repositories/sipity/commands/doi_commands.rb
+    def submit_doi_creation_request_job!(work:)
+    end
+
+    # @see ./app/repositories/sipity/commands/doi_commands.rb
+    def submit_request_a_doi_form(form, requested_by:)
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
+    def update_processing_state!(work:, new_processing_state:)
+    end
+
+    # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
+    def update_work_attribute_values!(work:, key:, values:)
+    end
+
+    # @see ./app/repositories/sipity/commands/doi_commands.rb
+    def update_work_doi_creation_request_state!(work:, state:, response_message: nil)
+    end
+
+    # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
+    def update_work_publication_date!(work:, publication_date:)
+    end
+
+    # @see ./app/repositories/sipity/commands/doi_commands.rb
+    def update_work_with_doi_predicate!(work:, values:)
+    end
+
+  end
+end


### PR DESCRIPTION
This is an experimental proposal, but one that I want to start kicking
around.

The intent is to create an object that has the same method signature
of existing repository methods; This way we can leverage a mock
repository that conveys the corresponding method signatures.

The implementation is a bit naive as it will grab any and all public
and private methods. Something like Github: seattlerb/sexp_processor.