### PR TITLE
Adding ability to update an enrichment

### DIFF
--- a/app/controllers/sipity/controllers/work_enrichments_controller.rb
+++ b/app/controllers/sipity/controllers/work_enrichments_controller.rb
@@ -13,6 +13,20 @@ module Sipity
         end
       end
 
+      def update
+        run(work_id: work_id, enrichment_type: enrichment_type, attributes: update_params) do |on|
+          on.success do |work|
+            redirect_to work_path(work), notice: message_for("#{work.enrichment_type}_enrichment", title: work.title)
+          end
+          on.failure do |model|
+            @model = model
+            respond_with(@model) do |wants|
+              wants.html { render action: @model.enrichment_type }
+            end
+          end
+        end
+      end
+
       attr_reader :model
       protected :model
       helper_method :model
@@ -25,6 +39,10 @@ module Sipity
 
       def enrichment_type
         params.require(:enrichment_type)
+      end
+
+      def update_params
+        params.require(:work)
       end
     end
   end

--- a/app/controllers/sipity/controllers/work_enrichments_controller.rb
+++ b/app/controllers/sipity/controllers/work_enrichments_controller.rb
@@ -15,14 +15,12 @@ module Sipity
 
       def update
         run(work_id: work_id, enrichment_type: enrichment_type, attributes: update_params) do |on|
-          on.success do |work|
-            redirect_to work_path(work), notice: message_for("#{work.enrichment_type}_enrichment", title: work.title)
-          end
+          on.success { |work| redirect_to work_path(work), notice: message_for("#{work.enrichment_type}_enrichment", title: work.title) }
           on.failure do |model|
             @model = model
-            respond_with(@model) do |wants|
-              wants.html { render action: @model.enrichment_type }
-            end
+            # HACK: Consider the JSON; But for now this will have to do as the
+            #   Rubocop is complaining about cyclomatic complexity.
+            render action: model.enrichment_type
           end
         end
       end

--- a/app/controllers/sipity/controllers/work_enrichments_controller.rb
+++ b/app/controllers/sipity/controllers/work_enrichments_controller.rb
@@ -9,18 +9,18 @@ module Sipity
       def edit
         _status, @model = run(work_id: work_id, enrichment_type: enrichment_type)
         respond_with(@model) do |wants|
-          wants.html { render action: @model.enrichment_type }
+          wants.html { render action: enrichment_type }
         end
       end
 
       def update
         run(work_id: work_id, enrichment_type: enrichment_type, attributes: update_params) do |on|
-          on.success { |work| redirect_to work_path(work), notice: message_for("#{work.enrichment_type}_enrichment", title: work.title) }
+          on.success { |work| redirect_to work_path(work), notice: message_for("#{enrichment_type}_enrichment", title: work.title) }
           on.failure do |model|
             @model = model
             # HACK: Consider the JSON; But for now this will have to do as the
             #   Rubocop is complaining about cyclomatic complexity.
-            render action: model.enrichment_type
+            render action: enrichment_type
           end
         end
       end

--- a/app/forms/sipity/forms/describe_work_form.rb
+++ b/app/forms/sipity/forms/describe_work_form.rb
@@ -14,6 +14,20 @@ module Sipity
 
       validates :abstract, presence: true
       validates :work, presence: true
+
+      def submit(repository:, requested_by:)
+        super() do |_f|
+          repository.update_work_attribute_values!(work: work, key: 'abstract', values: abstract)
+          repository.log_event!(entity: work, user: requested_by, event_name: event_name)
+          work
+        end
+      end
+
+      private
+
+      def event_name
+        File.join(self.class.to_s.demodulize.underscore, 'submit')
+      end
     end
   end
 end

--- a/app/models/sipity/models/additional_attribute.rb
+++ b/app/models/sipity/models/additional_attribute.rb
@@ -10,6 +10,7 @@ module Sipity
       CITATION_TYPE_PREDICATE_NAME = 'citationType'.freeze
       PUBLISHER_PREDICATE_NAME = 'publisher'.freeze
       PUBLICATION_DATE_PREDICATE_NAME = 'publicationDate'.freeze
+      ABSTRACT_PREDICATE_NAME = 'abstract'.freeze
 
       self.table_name = 'sipity_additional_attributes'
       belongs_to :work, foreign_key: 'work_id'
@@ -20,7 +21,8 @@ module Sipity
           CITATION_PREDICATE_NAME => CITATION_PREDICATE_NAME,
           CITATION_TYPE_PREDICATE_NAME => CITATION_TYPE_PREDICATE_NAME,
           PUBLISHER_PREDICATE_NAME => PUBLISHER_PREDICATE_NAME,
-          PUBLICATION_DATE_PREDICATE_NAME => PUBLICATION_DATE_PREDICATE_NAME
+          PUBLICATION_DATE_PREDICATE_NAME => PUBLICATION_DATE_PREDICATE_NAME,
+          ABSTRACT_PREDICATE_NAME => ABSTRACT_PREDICATE_NAME
         }
       )
     end

--- a/app/runners/sipity/runners/work_enrichment_runners.rb
+++ b/app/runners/sipity/runners/work_enrichment_runners.rb
@@ -14,6 +14,24 @@ module Sipity
           end
         end
       end
+
+      # Responsible for updating an enrichment
+      class Update < BaseRunner
+        self.authentication_layer = :default
+        self.authorization_layer = :default
+
+        def run(work_id:, enrichment_type:, attributes:)
+          work = repository.find_work(work_id)
+          form = repository.build_enrichment_form(attributes.merge(work: work, enrichment_type: enrichment_type))
+          authorization_layer.enforce!(submit?: form) do
+            if form.submit(repository: repository, requested_by: current_user)
+              callback(:success, work)
+            else
+              callback(:failure, form)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/app/views/sipity/controllers/work_enrichments/describe.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/describe.html.erb
@@ -3,6 +3,6 @@
   <%= f.error_notification %>
   <%= field_set_tag do %>
     <%= f.input :abstract, as: :text %>
-    <%= f.submit %>
+    <%= f.submit nil, name: "form>#{model.enrichment_type}>submit" %>
   <% end %>
 <% end %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -111,7 +111,7 @@ SimpleForm.setup do |config|
   # in this configuration, which is recommended due to some quirks from different browsers.
   # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
   # change this configuration to true.
-  config.browser_validations = false
+  config.browser_validations = true
 
   # Collection of methods to detect if a file type was given.
   # config.file_methods = [ :mounted_as, :file?, :public_filename ]

--- a/spec/controllers/sipity/controllers/work_enrichments_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_enrichments_controller_spec.rb
@@ -4,21 +4,50 @@ require 'hesburgh/lib/mock_runner'
 module Sipity
   module Controllers
     RSpec.describe WorkEnrichmentsController, type: :controller do
-      let(:work) { double('Work', enrichment_type: 'describe') }
+      let(:work) { double('Work', enrichment_type: 'describe', persisted?: true, title: 'Hello World') }
       context 'GET #edit' do
-        let(:enrichment_type) { 'attach' }
         before { controller.runner = runner }
         let(:runner) do
           Hesburgh::Lib::MockRunner.new(
-            yields: yields, callback_name: callback_name,
-            run_with: { enrichment_type: enrichment_type, work_id: work.to_param }, context: controller
+            yields: yielded_object, callback_name: callback_name, context: controller,
+            run_with: { enrichment_type: work.enrichment_type, work_id: work.to_param }
           )
         end
-        let(:yields) { work }
+        let(:yielded_object) { work }
         let(:callback_name) { :success }
         it 'will render the edit page' do
-          get 'edit', work_id: work.to_param, enrichment_type: enrichment_type
+          get 'edit', work_id: work.to_param, enrichment_type: work.enrichment_type
           expect(assigns(:model)).to_not be_nil
+        end
+      end
+      context 'POST #update' do
+        let(:attributes) { { 'hello' => 'world' } }
+        let(:callback_name) { :success }
+        let(:runner) do
+          Hesburgh::Lib::MockRunner.new(
+            yields: yielded_object, callback_name: callback_name, context: controller,
+            run_with: { enrichment_type: work.enrichment_type, work_id: work.to_param, attributes: attributes }
+          )
+        end
+        before { controller.runner = runner }
+        context 'on success' do
+          let(:callback_name) { :success }
+          let(:yielded_object) { work }
+          it 'will redirect to the work' do
+            post 'update', work_id: work.to_param, enrichment_type: work.enrichment_type, work: attributes
+            expect(flash[:notice]).to_not be_empty
+            expect(assigns(:model)).to be_nil
+            expect(response).to redirect_to work_path(work.to_param)
+          end
+        end
+        context 'on failure' do
+          let(:callback_name) { :failure }
+          let(:yielded_object) { work }
+          it 'will redirect to the work' do
+            post 'update', work_id: work.to_param, enrichment_type: work.enrichment_type, work: attributes
+            expect(assigns(:model)).to be_present
+            expect(response).to render_template(work.enrichment_type)
+          end
         end
       end
     end

--- a/spec/controllers/sipity/controllers/work_enrichments_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_enrichments_controller_spec.rb
@@ -4,19 +4,20 @@ require 'hesburgh/lib/mock_runner'
 module Sipity
   module Controllers
     RSpec.describe WorkEnrichmentsController, type: :controller do
-      let(:work) { double('Work', enrichment_type: 'describe', persisted?: true, title: 'Hello World') }
+      let(:work) { double('Work', persisted?: true, title: 'Hello World') }
+      let(:enrichment_type) { 'describe' }
       context 'GET #edit' do
         before { controller.runner = runner }
         let(:runner) do
           Hesburgh::Lib::MockRunner.new(
             yields: yielded_object, callback_name: callback_name, context: controller,
-            run_with: { enrichment_type: work.enrichment_type, work_id: work.to_param }
+            run_with: { enrichment_type: enrichment_type, work_id: work.to_param }
           )
         end
         let(:yielded_object) { work }
         let(:callback_name) { :success }
         it 'will render the edit page' do
-          get 'edit', work_id: work.to_param, enrichment_type: work.enrichment_type
+          get 'edit', work_id: work.to_param, enrichment_type: enrichment_type
           expect(assigns(:model)).to_not be_nil
         end
       end
@@ -26,7 +27,7 @@ module Sipity
         let(:runner) do
           Hesburgh::Lib::MockRunner.new(
             yields: yielded_object, callback_name: callback_name, context: controller,
-            run_with: { enrichment_type: work.enrichment_type, work_id: work.to_param, attributes: attributes }
+            run_with: { enrichment_type: enrichment_type, work_id: work.to_param, attributes: attributes }
           )
         end
         before { controller.runner = runner }
@@ -34,19 +35,20 @@ module Sipity
           let(:callback_name) { :success }
           let(:yielded_object) { work }
           it 'will redirect to the work' do
-            post 'update', work_id: work.to_param, enrichment_type: work.enrichment_type, work: attributes
+            post 'update', work_id: work.to_param, enrichment_type: enrichment_type, work: attributes
             expect(flash[:notice]).to_not be_empty
             expect(assigns(:model)).to be_nil
             expect(response).to redirect_to work_path(work.to_param)
           end
         end
         context 'on failure' do
+          let(:form) { double('Form') }
           let(:callback_name) { :failure }
-          let(:yielded_object) { work }
-          it 'will redirect to the work' do
-            post 'update', work_id: work.to_param, enrichment_type: work.enrichment_type, work: attributes
+          let(:yielded_object) { form }
+          it 'will render the work again' do
+            post 'update', work_id: work.to_param, enrichment_type: enrichment_type, work: attributes
             expect(assigns(:model)).to be_present
-            expect(response).to render_template(work.enrichment_type)
+            expect(response).to render_template(enrichment_type)
           end
         end
       end

--- a/spec/features/sipity/create_minimum_viable_work_spec.rb
+++ b/spec/features/sipity/create_minimum_viable_work_spec.rb
@@ -66,6 +66,7 @@ feature 'Minimum viable SIP', :devise do
     on('describe_page') do |the_page|
       expect(the_page).to be_all_there
       the_page.fill_in(:abstract, with: 'Lorem ipsum')
+      the_page.submit_button.click
     end
   end
 

--- a/spec/forms/sipity/forms/describe_work_form_spec.rb
+++ b/spec/forms/sipity/forms/describe_work_form_spec.rb
@@ -22,6 +22,47 @@ module Sipity
         subject.valid?
         expect(subject.errors[:work]).to_not be_empty
       end
+
+      context '#submit' do
+        let(:repository) { double('Repository', log_event!: true, update_work_attribute_values!: true) }
+        let(:user) { double('User') }
+        context 'with invalid data' do
+          before do
+            expect(subject).to receive(:valid?).and_return(false)
+          end
+          it 'will return false if not valid' do
+            expect(subject.submit(repository: repository, requested_by: user))
+          end
+          it 'will not create create any additional attributes entries' do
+            expect { subject.submit(repository: repository, requested_by: user) }.
+              to_not change { Models::AdditionalAttribute.count }
+          end
+        end
+
+        context 'with valid data' do
+          subject { described_class.new(work: work, abstract: 'Hello Dolly') }
+          before do
+            expect(subject).to receive(:valid?).and_return(true)
+          end
+
+          it 'will return the work' do
+            returned_value = subject.submit(repository: repository, requested_by: user)
+            expect(returned_value).to eq(work)
+          end
+
+          it 'will add additional attributes entries' do
+            subject.submit(repository: repository, requested_by: user)
+            expect(repository).to have_received(:update_work_attribute_values!).
+              with(work: work, key: 'abstract', values: subject.abstract)
+          end
+
+          it 'will record the event' do
+            subject.submit(repository: repository, requested_by: user)
+            expect(repository).to have_received(:log_event!).with(entity: work, user: user, event_name: 'describe_work_form/submit')
+          end
+        end
+
+      end
     end
   end
 end

--- a/spec/runners/sipity/runners/work_enrichment_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_enrichment_runners_spec.rb
@@ -35,6 +35,54 @@ module Sipity
           expect(response).to eq([:success, form])
         end
       end
+
+      RSpec.describe Update do
+        let(:work) { double('Work', id: 1234) }
+        let(:form) { double('Form') }
+        let(:user) { double('User') }
+        let(:enrichment_type) { 'fandango' }
+        let(:attributes) { { 'title' => 'match' } }
+        let(:handler) { double(invoked: true) }
+        let(:context) do
+          TestRunnerContext.new(find_work: work, build_enrichment_form: form)
+        end
+        subject do
+          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
+            on.success { |a| handler.invoked("SUCCESS", a) }
+            on.failure { |a| handler.invoked("FAILURE", a) }
+          end
+        end
+
+        it 'will require authentication by default' do
+          expect(described_class.authentication_layer).to eq(:default)
+        end
+
+        it 'enforces authorization' do
+          expect(described_class.authorization_layer).to eq(:default)
+        end
+
+        context 'when the form submission fails' do
+          it 'issues the :failure callback' do
+            expect(form).to receive(:submit).
+              with(repository: context.repository, requested_by: context.current_user).
+              and_return(false)
+            response = subject.run(work_id: work.id, enrichment_type: enrichment_type, attributes: attributes)
+            expect(handler).to have_received(:invoked).with("FAILURE", form)
+            expect(response).to eq([:failure, form])
+          end
+        end
+
+        context 'when the form submission succeeds' do
+          it 'issues the :success callback' do
+            expect(form).to receive(:submit).
+              with(repository: context.repository, requested_by: context.current_user).
+              and_return(true)
+            response = subject.run(work_id: work.id, enrichment_type: enrichment_type, attributes: attributes)
+            expect(handler).to have_received(:invoked).with("SUCCESS", work)
+            expect(response).to eq([:success, work])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -71,8 +71,8 @@ module SitePrism
 
     class DescribePage < SitePrism::Page
       PARAM_NAME_CONTAINER = 'work'.freeze
-      element :form, "form[method='post']"
       element :input_abstract, "form [name='#{PARAM_NAME_CONTAINER}[abstract]']"
+      element :submit_button, "form [name='form>describe>submit'][type='submit']"
 
       def fill_in(predicate, with: nil)
         find("form [name='#{PARAM_NAME_CONTAINER}[#{predicate}]']").set(with)


### PR DESCRIPTION
## Adding DescribeWorkForm#submit behavior

This is an initial conjecture. I'm not certain what attributes we will
attempt to capture but I'm laying the initial groundwork.

Also, a minor tweak related to the enrichment_type; a work does not
have an enrichment type, but I can instead use the parameter to derive
that information.

## Making concessions for Rubocop

## Adding WorkEnrichmentsRunner::Update class

I am exposing a singular end-point for updating an enrichment. Each of
the envisioned enrichments will behave in a similar manner (hence a
unified controller aciton).

## Adding ability to target and click submit

Moving towards naming things, this exposes a method consistent with
the behavior of the Schema.org/Action update.

See sipity@fc4a444b114e559fad39bd6d0df68bd8b5f989c5

## Adding Enrichment#update action

This is the generalized behavior. I hope to push most enrichment forms
through this controller. Ultimately it is a decision of the router to
handle this behavior.
