### PR TITLE
Adding work type todo

### DIFF
--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -49,6 +49,7 @@ module Sipity
           repository.handle_transient_access_rights_answer(entity: work, answer: f.access_rights_answer)
           repository.update_work_publication_date!(work: work, publication_date: f.publication_date)
           repository.grant_creating_user_permission_for!(entity: work, user: requested_by)
+          repository.create_work_todo_list_for_current_state(work: work, processing_state: work.processing_state)
           repository.log_event!(entity: work, user: requested_by, event_name: __method__)
           work
         end

--- a/app/models/sipity/models/todo_item_state.rb
+++ b/app/models/sipity/models/todo_item_state.rb
@@ -1,0 +1,32 @@
+module Sipity
+  module Models
+    # Responsible for persisting the state of a todo list item for a given
+    # entity and its processing state.
+    class TodoItemState < ActiveRecord::Base
+      self.table_name = 'sipity_todo_item_states'
+      belongs_to :entity, polymorphic: true
+
+      ENRICHMENT_STATE_INCOMPLETE = 'incomplete'.freeze
+      ENRICHMENT_STATE_DONE = 'done'.freeze
+
+      # While this make look ridiculous, if I use an Array, the enum declaration
+      # insists on persisting the value as the index instead of the key. While
+      # this might make more sense from a storage standpoint, it is not as clear
+      # and leverages a more opaque assumption.
+      enum(
+        enrichment_state: {
+          ENRICHMENT_STATE_INCOMPLETE => ENRICHMENT_STATE_INCOMPLETE,
+          ENRICHMENT_STATE_DONE => ENRICHMENT_STATE_DONE
+        }
+      )
+
+      private
+
+      after_initialize :set_initial_enrichment_state, if: :new_record?
+
+      def set_initial_enrichment_state
+        self.enrichment_state ||= ENRICHMENT_STATE_INCOMPLETE
+      end
+    end
+  end
+end

--- a/app/repositories/sipity/commands.rb
+++ b/app/repositories/sipity/commands.rb
@@ -22,6 +22,7 @@ module Sipity
       base.send(:include, AdditionalAttributeCommands)
       base.send(:include, PermissionCommands)
       base.send(:include, TransientAnswerCommands)
+      base.send(:include, TodoListCommands)
     end
   end
 end

--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -1,0 +1,26 @@
+module Sipity
+  # :nodoc:
+  module Commands
+    # REVIEW: Is this the best place to put this information? Do I want to
+    #   persist this in a database? Does that make sense?
+    #
+    # REVIEW: Considere that some enrichments are not required. This associates
+    #   the enrichments with the entity, but does not assert policies related to
+    #   each enrichment; I believe that is the correct way to do things.
+    WORK_TYPE_PROCESSING_STATE_TODO_LIST_ITEMS = {
+      'etd' => {
+        'new' => ['attach', 'describe']
+      }
+    }.freeze
+
+    # Responsible for interaction with the todo list.
+    module TodoListCommands
+      def create_work_todo_list_for_current_state(work:, processing_state: work.processing_state, work_type: work.work_type)
+        WORK_TYPE_PROCESSING_STATE_TODO_LIST_ITEMS.fetch(work_type).fetch(processing_state).each do |item_name|
+          Models::TodoItemState.create!(entity: work, entity_processing_state: processing_state, enrichment_type: item_name)
+        end
+      end
+    end
+    private_constant :TodoListCommands
+  end
+end

--- a/db/migrate/20150122181425_create_sipity_models_todo_item_states.rb
+++ b/db/migrate/20150122181425_create_sipity_models_todo_item_states.rb
@@ -1,0 +1,25 @@
+class CreateSipityModelsTodoItemStates < ActiveRecord::Migration
+  def change
+    create_table :sipity_todo_item_states, id: false do |t|
+      t.integer :entity_id
+      t.string :entity_type
+      t.string :entity_processing_state
+      t.string :enrichment_type # REVIEW: Should this be todo item or enrichment_type? How are they the same?
+      t.string :enrichment_state
+
+      t.timestamps null: false
+    end
+
+    add_index :sipity_todo_item_states, [:entity_id, :entity_type]
+    add_index(
+      :sipity_todo_item_states,
+      [:entity_id, :entity_type, :entity_processing_state, :enrichment_type],
+      unique: true, name: :sipity_todo_item_states_key
+    )
+    change_column_null :sipity_todo_item_states, :entity_id, false
+    change_column_null :sipity_todo_item_states, :entity_type, false
+    change_column_null :sipity_todo_item_states, :entity_processing_state, false
+    change_column_null :sipity_todo_item_states, :enrichment_type, false
+    change_column_null :sipity_todo_item_states, :enrichment_state, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150122142820) do
+ActiveRecord::Schema.define(version: 20150122181425) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -159,6 +159,19 @@ ActiveRecord::Schema.define(version: 20150122142820) do
   add_index "sipity_permissions", ["entity_id", "entity_type", "acting_as"], name: "sipity_permissions_entity_acting_as"
   add_index "sipity_permissions", ["entity_id"], name: "index_sipity_permissions_on_entity_id"
   add_index "sipity_permissions", ["entity_type"], name: "index_sipity_permissions_on_entity_type"
+
+  create_table "sipity_todo_item_states", id: false, force: :cascade do |t|
+    t.integer  "entity_id",               null: false
+    t.string   "entity_type",             null: false
+    t.string   "entity_processing_state", null: false
+    t.string   "enrichment_type",         null: false
+    t.string   "enrichment_state",        null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  add_index "sipity_todo_item_states", ["entity_id", "entity_type", "entity_processing_state", "enrichment_type"], name: "sipity_todo_item_states_key", unique: true
+  add_index "sipity_todo_item_states", ["entity_id", "entity_type"], name: "index_sipity_todo_item_states_on_entity_id_and_entity_type"
 
   create_table "sipity_transient_answers", force: :cascade do |t|
     t.integer  "entity_id",     null: false

--- a/spec/models/sipity/models/todo_item_state_spec.rb
+++ b/spec/models/sipity/models/todo_item_state_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+module Sipity
+  module Models
+    RSpec.describe TodoItemState, type: :model do
+      subject { described_class.new }
+
+      it 'belongs to a :entity' do
+        expect(described_class.reflect_on_association(:entity)).
+          to be_a(ActiveRecord::Reflection::AssociationReflection)
+      end
+
+      context '#enrichment_state' do
+        it 'will raise an ArgumentError if you provide an invalid value' do
+          expect { subject.enrichment_state = '__incorrect_state__' }.to raise_error(ArgumentError)
+        end
+
+        it 'will initialize with a default' do
+          expect(subject.enrichment_state).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -8,7 +8,7 @@ module Sipity
       context '#create_work_todo_list_for_current_state' do
         it 'will' do
           expect { test_repository.create_work_todo_list_for_current_state(work: work) }.
-          to change { Models::TodoItemState.count }.by(2)
+            to change { Models::TodoItemState.count }.by(2)
         end
       end
     end

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+module Sipity
+  module Commands
+    RSpec.describe TodoListCommands, type: :repository_methods do
+      let(:work) { Models::Work.new(id: 1, work_type: 'etd', processing_state: 'new') }
+
+      context '#create_work_todo_list_for_current_state' do
+        it 'will' do
+          expect { test_repository.create_work_todo_list_for_current_state(work: work) }.
+          to change { Models::TodoItemState.count }.by(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -8,6 +8,10 @@ module Sipity
     def create_work_attribute_values!(work:, key:, values:)
     end
 
+    # @see ./app/repositories/sipity/commands/todo_list_commands.rb
+    def create_work_todo_list_for_current_state(work:, processing_state: work.processing_state, work_type: work.work_type)
+    end
+
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def destroy_work_attribute_values!(work:, key:, values:)
     end


### PR DESCRIPTION
## Adding the Sipity::Models::TodoItemState

Responsible for persisting the state of a todo list item for a given
entity and its processing state.

## Adding means for creating todo list items

Given that there is a state related to todo items, I need to have a
means of querying that state to present the todo list to a user. The
most obvious method is to track what to do items are associated with
the work at the given state.

I'm working my way around the todo list/enrichment design, attempting
to resolve how this information will be tracked. Its a multi-
dimensional problem: WorkType, State, Items maps to Work, User, State,
Items.

## Wiring in creating initial todo list

I want to populate the todo list for a new work; This list is not yet
retrieved, but is somewhat easy to capture.
