### PR TITLE
Inverting the potentialAction and entryPoint relation

### DIFF
--- a/app/views/sipity/controllers/work_event_triggers/new.html.erb
+++ b/app/views/sipity/controllers/work_event_triggers/new.html.erb
@@ -1,7 +1,7 @@
-<form itemscope itemtype="http://schema.org/EntryPoint" method="post" action="<%= event_trigger_for_work_path(model.work, model.event_name) %>">
+<div itemprop="potentialAction" itemscope itemtype="http://schema.org/Action">
   <link itemprop="url" href="<%= event_trigger_for_work_path(model.work, model.event_name) %>">
   <meta itemprop="name" content="confirm>event_trigger>submit_for_review">
-  <div itemtype="http://schema.org/Action" itemscope itemprop='potentialAction'>
+  <form itemprop='target' itemscope itemtype="http://schema.org/EntryPoint" method="post" action="<%= event_trigger_for_work_path(model.work, model.event_name) %>">
     <%= submit_tag("Submit", itemprop: 'name') %>
-  </div>
-</form>
+  </form>
+</div>

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -1,13 +1,6 @@
 <div itemscope itemtype="http://schema.org/CreativeWork">
 <div class="card">
   <h2 itemprop="name"><%= model.title %></h2>
-  <div itemprop="hasPart" itemscope itemtype="http://schema.org/Enumeration">
-    <meta itemprop="name" content="work>processing_state" />
-    <%# Opting to not use a meta-tag instead; If this becomes a meta-tag, then
-    the underlying tests will need to change to find[:content] instead of
-    find.text %>
-    <h3 itemprop="description"><%= model.processing_state %></h3>
-  </div>
   <dl class="work">
     <dt class="predicate title"><%= model.human_attribute_name(:title) %></dt>
     <dd class="value title"><%= model.title %></dt>
@@ -52,11 +45,11 @@
       <h2><%= set %></h2>
       <ul>
         <%- actions.each do |action| -%>
-          <li itemscope itemtype="http://schema.org/EntryPoint">
+          <li itemprop="potentialAction" itemscope itemtype="http://schema.org/Action">
             <meta itemprop="name" content="todo><%= set %>><%= action.name %>">
             <span itemprop="description"><%= action.label %></span>
-            <div itemtype="http://schema.org/Action" itemscope itemprop='potentialAction'>
-              <span itemprop="actionStatus"><%= action.state %></span>
+            <span itemprop="actionStatus"><%= action.state %></span>
+            <div itemprop='target' itemscope itemtype="http://schema.org/EntryPoint">
               <a itemprop="url" href="<%= action.path %>"><span itemprop="name">Do it!</span></a>
             </div>
           </li>
@@ -68,17 +61,22 @@
 
 <!-- TODO: This is hard-coded for now; I want to get to auto-generation -->
 <div>
-  <ul>
-    <li>
-      <form itemscope itemtype="http://schema.org/EntryPoint" method="get" action="<%= event_trigger_for_work_path(model, 'submit_for_review') %>">
-        <link itemprop="url" href="<%= event_trigger_for_work_path(model, 'submit_for_review') %>">
+  <div itemprop="hasPart" itemscope itemtype="http://schema.org/Enumeration">
+    <meta itemprop="name" content="work>processing_state" />
+    <%# Opting to not use a meta-tag instead; If this becomes a meta-tag, then
+    the underlying tests will need to change to find[:content] instead of
+    find.text %>
+    <h3 itemprop="description"><%= model.processing_state %></h3>
+    <ul>
+      <li itemprop="potentialAction" itemscope itemtype="http://schema.org/Action">
         <meta itemprop="name" content="event_trigger>submit_for_review">
-        <div itemtype="http://schema.org/Action" itemscope itemprop='potentialAction'>
+        <link itemprop="url" href="<%= event_trigger_for_work_path(model, 'submit_for_review') %>">
+        <form itemprop='target' itemscope itemtype="http://schema.org/EntryPoint" method="get" action="<%= event_trigger_for_work_path(model, 'submit_for_review') %>">
           <%= submit_tag("Submit for Review", itemprop: 'name') %>
-        </div>
-      </form>
-    </li>
-  </ul>
+        </form>
+      </li>
+    </ul>
+  </div>
 </div>
 
 <div class="recommendations">

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -16,15 +16,15 @@ module SitePrism
         # click on.
         action =
         begin
-          entry_point.find("[itemprop='potentialAction'] [itemprop='url']")
+          entry_point.find("[itemprop='target'] [itemprop='url']")
         rescue Capybara::ElementNotFound
-          entry_point.find("[itemprop='potentialAction'] [itemprop='name']")
+          entry_point.find("[itemprop='target'] [itemprop='name']")
         end
         action.click
       end
 
-      def find_named_object(name, itemtype: 'EntryPoint')
-        object_name_node = find("[itemtype='http://schema.org/#{itemtype}'] [itemprop='name'][content='#{name.downcase}']")
+      def find_named_object(name, itemprop: 'potentialAction')
+        object_name_node = find("[itemprop='#{itemprop}'] [itemprop='name'][content='#{name.downcase}']")
         # Because Capybara does not support an ancestors find method, I need to
         # dive into the native object (i.e. a Nokogiri node). The end goal is to
         # find the named object element and thus be able to retrieve any of the
@@ -104,11 +104,11 @@ module SitePrism
       end
 
       def todo_item_named_status_for(name)
-        find_named_object(name).find("[itemprop='potentialAction'] [itemprop='actionStatus']").text
+        find_named_object(name).find("[itemprop='actionStatus']").text
       end
 
       def processing_state
-        find_named_object('work>processing_state', itemtype: 'Enumeration').find("[itemprop='description']").text
+        find_named_object('work>processing_state', itemprop: 'hasPart').find("[itemprop='description']").text
       end
     end
 


### PR DESCRIPTION
Given that an action can have entryPoints and an entryPoint can have
possibleActions, which one is the parent container is somewhat
arbitrary.

However, given that a Thing > CreativeWork can have a potentialAction
it makes sense that the Action would contain the entryPoint. In this
way I can have the nested concept, and push the actions into the
CreativeWork container (as they are actions to take on that work).