### PR TITLE
Work event trigger policy

### DIFF
--- a/app/forms/sipity/forms/work_event_trigger_form.rb
+++ b/app/forms/sipity/forms/work_event_trigger_form.rb
@@ -5,7 +5,7 @@ module Sipity
       # TODO: I do not believe that this is the correct policy. We need a policy
       #   that will verify the state of the work and whether the event trigger
       #   can happen.
-      self.policy_enforcer = Policies::EnrichWorkByFormSubmissionPolicy
+      self.policy_enforcer = Policies::WorkEventTriggerPolicy
 
       def initialize(attributes = {})
         @work = attributes.fetch(:work)
@@ -22,6 +22,11 @@ module Sipity
         return false unless valid?
         save(repository: repository, requested_by: requested_by)
       end
+
+      def state_diagram
+        event_receiver.state_diagram_for(work_type: work.work_type)
+      end
+      deprecate :state_diagram
 
       private
 

--- a/app/policies/sipity/policies/work_event_trigger_policy.rb
+++ b/app/policies/sipity/policies/work_event_trigger_policy.rb
@@ -1,0 +1,16 @@
+module Sipity
+  module Policies
+    # Responsible for enforcing a user attempting to trigger an event on
+    # the given work.
+    #
+    # @see [Pundit gem](http://rubygems.org/gems/pundit) for more on object
+    #   oriented authorizaiton.
+    # @see WorkPolicy for more information on who can edit this object.
+    class WorkEventTriggerPolicy < BasePolicy
+      define_action_to_authorize :submit? do
+        return false unless user.present?
+        return false unless entity.persisted?
+      end
+    end
+  end
+end

--- a/app/policies/sipity/policies/work_event_trigger_policy.rb
+++ b/app/policies/sipity/policies/work_event_trigger_policy.rb
@@ -7,16 +7,37 @@ module Sipity
     #   oriented authorizaiton.
     # @see WorkPolicy for more information on who can edit this object.
     class WorkEventTriggerPolicy < BasePolicy
+      def initialize(user, entity, collaborators = {})
+        self.user = user
+        self.entity = entity
+        @repository = collaborators.fetch(:repository) { default_repository }
+      end
+
       define_action_to_authorize :submit? do
         return false unless user.present?
         return false unless work.persisted?
         return false unless valid_state_transition?
+        return false unless all_required_todo_items_are_done?
+        return false unless user_can_trigger_event_for_work?
+        true
       end
 
       alias_method :form, :entity
-      attr_reader :work
+      attr_reader :work, :repository
 
       private
+
+      def user_can_trigger_event_for_work?
+        # TODO: Need a better state diagram, see below.
+        allowed_if_acting_as = form.state_diagram.fetch(work.processing_state).fetch(event_name_for_lookup)
+        repository.can_the_user_act_on_the_entity?(user: user, acting_as: allowed_if_acting_as, entity: work)
+      rescue KeyError
+        false
+      end
+
+      def all_required_todo_items_are_done?
+        repository.are_all_of_the_required_todo_items_done_for_work?(work: work)
+      end
 
       def valid_state_transition?
         form.state_diagram.fetch(work.processing_state).fetch(event_name_for_lookup)
@@ -35,6 +56,10 @@ module Sipity
         else
           fail Exceptions::PolicyEntityExpectationError, "Expected #{object} to have a #work."
         end
+      end
+
+      def default_repository
+        Repository.new
       end
     end
   end

--- a/app/policies/sipity/policies/work_event_trigger_policy.rb
+++ b/app/policies/sipity/policies/work_event_trigger_policy.rb
@@ -27,22 +27,23 @@ module Sipity
 
       private
 
+      def valid_state_transition?
+        # This may be a duplication of logic, but it prevents a database hit.
+        processing_state_actors_for_event_name.present?
+      end
+
       def user_can_trigger_event_for_work?
-        # TODO: Need a better state diagram, see below.
-        allowed_if_acting_as = form.state_diagram.fetch(work.processing_state).fetch(event_name_for_lookup)
+        allowed_if_acting_as = processing_state_actors_for_event_name
         repository.can_the_user_act_on_the_entity?(user: user, acting_as: allowed_if_acting_as, entity: work)
-      rescue KeyError
-        false
+      end
+
+      def processing_state_actors_for_event_name
+        # TODO: Need a better state diagram, see below.
+        @processing_state_actors_for_event_name ||= form.state_diagram.fetch(work.processing_state, {}).fetch(event_name_for_lookup, [])
       end
 
       def all_required_todo_items_are_done?
         repository.are_all_of_the_required_todo_items_done_for_work?(work: work)
-      end
-
-      def valid_state_transition?
-        form.state_diagram.fetch(work.processing_state).fetch(event_name_for_lookup)
-      rescue KeyError
-        false
       end
 
       def event_name_for_lookup
@@ -50,11 +51,20 @@ module Sipity
       end
 
       def entity=(object)
-        if object.respond_to?(:work) && object.work.present?
+        if object.respond_to?(:work) && object.work.present? && object.respond_to?(:event_name) && object.event_name.present?
           super(object)
-          @work = object.work
+          self.work = object.work
         else
-          fail Exceptions::PolicyEntityExpectationError, "Expected #{object} to have a #work."
+          fail Exceptions::PolicyEntityExpectationError, "Expected #{object} to have a #work and #event_name."
+        end
+      end
+
+      def work=(object)
+        # A Subtle violation of demeter; I already have asked the entity for the work
+        if object.respond_to?(:processing_state) && object.processing_state.present?
+          @work = object
+        else
+          fail Exceptions::PolicyEntityExpectationError, "Expected #{object} to have a #processing_state."
         end
       end
 

--- a/app/policies/sipity/policies/work_event_trigger_policy.rb
+++ b/app/policies/sipity/policies/work_event_trigger_policy.rb
@@ -9,7 +9,21 @@ module Sipity
     class WorkEventTriggerPolicy < BasePolicy
       define_action_to_authorize :submit? do
         return false unless user.present?
-        return false unless entity.persisted?
+        return false unless work.persisted?
+      end
+
+      alias_method :form, :entity
+      attr_reader :work
+
+      private
+
+      def entity=(object)
+        if object.respond_to?(:work) && object.work.present?
+          super(object)
+          @work = object.work
+        else
+          fail Exceptions::PolicyEntityExpectationError, "Expected #{object} to have a #work."
+        end
       end
     end
   end

--- a/app/policies/sipity/policies/work_event_trigger_policy.rb
+++ b/app/policies/sipity/policies/work_event_trigger_policy.rb
@@ -10,12 +10,23 @@ module Sipity
       define_action_to_authorize :submit? do
         return false unless user.present?
         return false unless work.persisted?
+        return false unless valid_state_transition?
       end
 
       alias_method :form, :entity
       attr_reader :work
 
       private
+
+      def valid_state_transition?
+        form.state_diagram.fetch(work.processing_state).fetch(event_name_for_lookup)
+      rescue KeyError
+        false
+      end
+
+      def event_name_for_lookup
+        "#{form.event_name}?".to_sym
+      end
 
       def entity=(object)
         if object.respond_to?(:work) && object.work.present?

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -19,6 +19,12 @@ module Sipity
       module_function :emails_for_associated_users
       public :emails_for_associated_users
 
+      def can_the_user_act_on_the_entity?(user:, acting_as:, entity:)
+        scope_users_by_entity_and_acting_as(acting_as: acting_as, entity: entity).
+          where(User.arel_table[:id].eq(user.id)).
+          count > 0
+      end
+
       # Responsible for returning a User scope:
       # That will include all users
       # That have one or more acting_as

--- a/app/state_machines/sipity/state_machines.rb
+++ b/app/state_machines/sipity/state_machines.rb
@@ -39,6 +39,10 @@ module Sipity
         trigger!(event_name, options.except(:entity, :user, :repository, :event_name))
     end
 
+    def state_diagram_for(work_type:)
+      find_state_machine_for(work_type: work_type).state_diagram
+    end
+
     def find_state_machine_for(work_type:)
       state_machine_name_by_convention = "#{work_type.classify}StateMachine"
       if const_defined?(state_machine_name_by_convention)

--- a/app/state_machines/sipity/state_machines/etd_state_machine.rb
+++ b/app/state_machines/sipity/state_machines/etd_state_machine.rb
@@ -8,8 +8,11 @@ module Sipity
     #   These should be codified as runners? Is there a symmetry of moving these
     #   to runners? Is symmetry worth pursuing?
     class EtdStateMachine
+      def self.state_diagram
+        STATE_POLICY_QUESTION_ROLE_MAP
+      end
       # TODO: Extract policy questions into separate class; There is a
-      # relationship, but is this necessary.
+      # relationship, but is this necessary. How to derive the StateDiagram
       #
       # { state => { action_to_authorize => acting_as } }
       STATE_POLICY_QUESTION_ROLE_MAP =

--- a/spec/features/sipity/trigger_work_state_change_spec.rb
+++ b/spec/features/sipity/trigger_work_state_change_spec.rb
@@ -35,6 +35,11 @@ feature "Trigger Work State Change", :devise do
     on('work_page') do |the_page|
       # The state was advanced
       expect(the_page.processing_state).to eq('under_review')
+
+      # NOTE: The link will be gone. More important, however, is that we won't
+      #   be able to submit that task.
+      expect { the_page.take_named_action('event_trigger>submit_for_review') }.
+        to raise_error(Sipity::Exceptions::AuthorizationFailureError)
     end
   end
 end

--- a/spec/forms/sipity/forms/work_event_trigger_form_spec.rb
+++ b/spec/forms/sipity/forms/work_event_trigger_form_spec.rb
@@ -7,11 +7,12 @@ module Sipity
       let(:event_receiver) { StateMachines::Interface }
       subject { described_class.new(work: work, event_name: 'submit_for_review', event_receiver: event_receiver) }
 
-      its(:policy_enforcer) { should eq(Policies::EnrichWorkByFormSubmissionPolicy) }
+      its(:policy_enforcer) { should eq(Policies::WorkEventTriggerPolicy) }
 
       context 'with defaults' do
         subject { described_class.new(work: work, event_name: 'submit_for_review') }
         its(:event_receiver) { should respond_to :trigger! }
+        its(:state_diagram) { should respond_to :fetch }
       end
 
       context 'validations' do

--- a/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
@@ -5,7 +5,8 @@ module Sipity
     RSpec.describe WorkEventTriggerPolicy do
       let(:user) { User.new(id: 123) }
       let(:work) { Models::Work.new(id: 123, work_type: 'etd') }
-      subject { described_class.new(user, work) }
+      let(:form) { double(work: work) }
+      subject { described_class.new(user, form) }
 
       context 'for a non-authenticated user' do
         let(:user) { nil }

--- a/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+module Sipity
+  module Policies
+    RSpec.describe WorkEventTriggerPolicy do
+      let(:user) { User.new(id: 123) }
+      let(:work) { Models::Work.new(id: 123, work_type: 'etd') }
+      subject { described_class.new(user, work) }
+
+      context 'for a non-authenticated user' do
+        let(:user) { nil }
+        its(:submit?) { should eq(false) }
+      end
+
+      context 'for a non-persisted entity' do
+        its(:submit?) { should eq(false) }
+      end
+
+      context 'for a user and persisted entity' do
+        before { expect(work).to receive(:persisted?).and_return(true) }
+        xit 'will disallow attempting to submit a trigger for a work in an incorrect state'
+        xit 'will disallow attempting to submit a trigger that they do not have access to for the given work'
+        xit 'will disallow attempting to submit a trigger for a work in which all todo items are not complete'
+      end
+    end
+  end
+end

--- a/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
@@ -13,6 +13,19 @@ module Sipity
       let(:form) { double('Form', work: work, event_name: event_name, state_diagram: state_diagram) }
       subject { described_class.new(user, form, repository: repository) }
 
+      context 'initialization' do
+        it 'fails if the form does not have a work' do
+          form = double
+          expect { described_class.new(user, form) }.to raise_error Exceptions::PolicyEntityExpectationError
+        end
+
+        it 'fails if the form does not have a work' do
+          work = double('Work')
+          form = double(work: work, event_name: event_name)
+          expect { described_class.new(user, form) }.to raise_error Exceptions::PolicyEntityExpectationError
+        end
+      end
+
       context 'for a non-authenticated user' do
         let(:user) { nil }
         its(:submit?) { should eq(false) }

--- a/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
@@ -4,8 +4,10 @@ module Sipity
   module Policies
     RSpec.describe WorkEventTriggerPolicy do
       let(:user) { User.new(id: 123) }
-      let(:work) { Models::Work.new(id: 123, work_type: 'etd') }
-      let(:form) { double(work: work) }
+      let(:work) { Models::Work.new(id: 123, work_type: 'etd', processing_state: 'new') }
+      let(:event_name) { 'approve_for_ingest' }
+      let(:state_diagram) { StateMachines::EtdStateMachine::STATE_POLICY_QUESTION_ROLE_MAP }
+      let(:form) { double('Form', work: work, event_name: event_name, state_diagram: state_diagram) }
       subject { described_class.new(user, form) }
 
       context 'for a non-authenticated user' do
@@ -19,9 +21,16 @@ module Sipity
 
       context 'for a user and persisted entity' do
         before { expect(work).to receive(:persisted?).and_return(true) }
-        xit 'will disallow attempting to submit a trigger for a work in an incorrect state'
-        xit 'will disallow attempting to submit a trigger that they do not have access to for the given work'
-        xit 'will disallow attempting to submit a trigger for a work in which all todo items are not complete'
+        context 'and event trigger is for an invalid' do
+          its(:submit?) { should eq(false) }
+        end
+
+        context 'and event triggered by user without access' do
+          let(:event_name) { 'submit_for_review' }
+          xit { its(:submit?) { should eq(false) } }
+        end
+
+        xit 'disallows submitting a trigger for a work in which all todo items are not complete'
       end
     end
   end

--- a/spec/state_machines/sipity/state_machines/etd_state_machine_spec.rb
+++ b/spec/state_machines/sipity/state_machines/etd_state_machine_spec.rb
@@ -15,6 +15,11 @@ module Sipity
       end
       subject { described_class.new(entity: entity, user: user, repository: repository) }
 
+      context 'class methods' do
+        subject { described_class }
+        its(:state_diagram) { should respond_to :fetch }
+      end
+
       context 'with the default repository' do
         subject { described_class.new(entity: entity, user: user) }
         its(:repository) { should respond_to :log_event! }

--- a/spec/state_machines/sipity/state_machines_spec.rb
+++ b/spec/state_machines/sipity/state_machines_spec.rb
@@ -25,7 +25,16 @@ module Sipity
       end
     end
 
-    context '#find_state_machine_for' do
+    context '.state_diagram_for' do
+      let(:valid_work_type) { 'etd' }
+      context 'with valid enrichment type' do
+        subject { described_class.state_diagram_for(work_type: valid_work_type) }
+        it { should respond_to(:fetch) }
+        it { should eq(StateMachines::EtdStateMachine.state_diagram) }
+      end
+    end
+
+    context '.find_state_machine_for' do
       let(:valid_work_type) { 'etd' }
       let(:invalid_work_type) { '__very_much_not_valid__' }
       context 'with valid enrichment type' do


### PR DESCRIPTION
## Initial work on WorkEventTriggerPolicy

## Teasing apart collaborators for WorkEventTrigger

## Working on EventTrigger policy behavior

There are quite a few actors/collaborators in this sequence; I'm going
to be visiting those and attempting to stitch together their
collaboration.

## Adding spec for state verification

## Adding method for state_diagram

I want to access this information.

## Adding means of retrieving state_diagram

Leveraging the finder, I'm getting the state diagram for a given work
type.

## Adding Query#can_the_user_act_on_the_entity?

I need to know specifically if the given :user can act as the given
:acting_as on the given :entity

## Finalizing WorkEventTriggerPolicy

Stepping through the various scenarios on policy enforcement.

## Switching policy for WorkEventTriggerForm

The previous policy is one that was more liberal in what could be
done. The WorkEventTriggerPolicy makes sure all critera for events
are met.
