### PR TITLE
Adding state diagram object

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -35,6 +35,7 @@ MethodLength:
     - 'app/controllers/sipity/controllers/dois_controller.rb'
     - 'app/repositories/sipity/queries/permission_queries.rb'
     - 'app/repositories/sipity/queries/enrichment_queries.rb'
+    - 'app/state_machines/sipity/state_machines/state_diagram.rb'
 
 LineLength:
   Description: 'Limit lines to 140 characters.'
@@ -187,11 +188,13 @@ CyclomaticComplexity:
   Enabled: true
   Exclude:
      - app/conversions/**/*.rb
+     - app/state_machines/sipity/state_machines/state_diagram.rb
 
 Metrics/PerceivedComplexity:
   Enabled: true
   Exclude:
      - app/conversions/**/*.rb
+     - app/state_machines/sipity/state_machines/state_diagram.rb
 
 Metrics/AbcSize:
   Enabled: true
@@ -201,6 +204,7 @@ Metrics/AbcSize:
      - app/repositories/sipity/queries/permission_queries.rb
      - app/repositories/sipity/queries/notification_queries.rb
      - app/repositories/sipity/queries/enrichment_queries.rb
+     - 'app/state_machines/sipity/state_machines/state_diagram.rb'
 
 DefWithParentheses:
   Description: 'Use def with parentheses when there are arguments.'

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -112,6 +112,15 @@ module Sipity
       end
     end
 
+    # The proposed state diagram was malformed.
+    class InvalidStateDiagramRawStructure < RuntimeError
+      attr_reader :structure
+      def initialize(structure:)
+        @structure = structure
+        super("#{structure} is not well formed for StateDiagram")
+      end
+    end
+
     # For some reason, you have an entity in an incorrect state. Push up what
     # information we can to be helpful to the end user.
     class InvalidStateError < RuntimeError

--- a/app/policies/sipity/policies/work_event_trigger_policy.rb
+++ b/app/policies/sipity/policies/work_event_trigger_policy.rb
@@ -28,7 +28,6 @@ module Sipity
       private
 
       def valid_state_transition?
-        # This may be a duplication of logic, but it prevents a database hit.
         processing_state_actors_for_event_name.present?
       end
 
@@ -39,7 +38,9 @@ module Sipity
 
       def processing_state_actors_for_event_name
         # TODO: Need a better state diagram, see below.
-        @processing_state_actors_for_event_name ||= form.state_diagram.fetch(work.processing_state, {}).fetch(event_name_for_lookup, [])
+        @processing_state_actors_for_event_name ||= form.state_diagram.event_trigger_availability(
+          current_state: work.processing_state, event_name: event_name_for_lookup
+        ).acting_as
       end
 
       def all_required_todo_items_are_done?

--- a/app/state_machines/sipity/state_machines/etd_state_machine.rb
+++ b/app/state_machines/sipity/state_machines/etd_state_machine.rb
@@ -9,9 +9,7 @@ module Sipity
     #   to runners? Is symmetry worth pursuing?
     class EtdStateMachine
       class_attribute :state_diagram, instance_writer: false
-
-      STATE_POLICY_QUESTION_ROLE_MAP =
-      {
+      self.state_diagram = StateDiagram.new(
         'new' => {
           update?: ['creating_user', 'advisor'], show?: ['creating_user', 'advisor'],
           delete?: ['creating_user'], submit_for_review?: ['creating_user']
@@ -25,8 +23,7 @@ module Sipity
         'ready_for_cataloging' => { show?: ['creating_user', 'advisor', 'etd_reviewer', 'cataloger'], finish_cataloging?: ['cataloger'] },
         'cataloged' => { show?: ['creating_user', 'advisor', 'etd_reviewer', 'cataloger'] },
         'done' => { show?: ['creating_user', 'advisor', 'etd_reviewer', 'cataloger'] }
-      }
-      self.state_diagram = StateDiagram.new(STATE_POLICY_QUESTION_ROLE_MAP)
+      )
 
       def initialize(entity:, user:, repository: nil)
         @entity, @user = entity, user

--- a/app/state_machines/sipity/state_machines/etd_state_machine.rb
+++ b/app/state_machines/sipity/state_machines/etd_state_machine.rb
@@ -8,13 +8,8 @@ module Sipity
     #   These should be codified as runners? Is there a symmetry of moving these
     #   to runners? Is symmetry worth pursuing?
     class EtdStateMachine
-      def self.state_diagram
-        STATE_POLICY_QUESTION_ROLE_MAP
-      end
-      # TODO: Extract policy questions into separate class; There is a
-      # relationship, but is this necessary. How to derive the StateDiagram
-      #
-      # { state => { action_to_authorize => acting_as } }
+      class_attribute :state_diagram, instance_writer: false
+
       STATE_POLICY_QUESTION_ROLE_MAP =
       {
         'new' => {
@@ -30,7 +25,8 @@ module Sipity
         'ready_for_cataloging' => { show?: ['creating_user', 'advisor', 'etd_reviewer', 'cataloger'], finish_cataloging?: ['cataloger'] },
         'cataloged' => { show?: ['creating_user', 'advisor', 'etd_reviewer', 'cataloger'] },
         'done' => { show?: ['creating_user', 'advisor', 'etd_reviewer', 'cataloger'] }
-      }.freeze
+      }
+      self.state_diagram = StateDiagram.new(STATE_POLICY_QUESTION_ROLE_MAP)
 
       def initialize(entity:, user:, repository: nil)
         @entity, @user = entity, user
@@ -42,10 +38,7 @@ module Sipity
       private :entity, :state_machine, :user, :repository
 
       def authorized_acting_as_for_action(action_to_authorize)
-        # @TODO - Catch invalid state look up
-        STATE_POLICY_QUESTION_ROLE_MAP.fetch(entity.processing_state.to_s).fetch(action_to_authorize, [])
-      rescue KeyError
-        raise Exceptions::StatePolicyQuestionRoleMapError, state: entity.processing_state, context: self
+        state_diagram.event_trigger_availability(current_state: entity.processing_state, event_name: action_to_authorize).acting_as
       end
 
       def trigger!(event, options = {})

--- a/app/state_machines/sipity/state_machines/state_diagram.rb
+++ b/app/state_machines/sipity/state_machines/state_diagram.rb
@@ -1,0 +1,79 @@
+module Sipity
+  module StateMachines
+    # Responsible for answering questions related to a StateDiagram. This is
+    # something that a DSL might be helpful for generating.
+    #
+    # @see the corresponding tests on what is a well-formed datastructure.
+    class StateDiagram
+      def initialize(data_structure)
+        @data_structure = data_structure
+        validate!
+        @data_structure.freeze
+      end
+      attr_reader :data_structure
+      private :data_structure
+
+      def event_trigger_availability(current_state:, event_name:)
+        normalized_event_name = event_name.to_s.sub(/([^\?])\Z/, '\1?').to_sym
+        acting_as = data_structure.fetch(current_state.to_s, {}).fetch(normalized_event_name, [])
+        ActionAvailability.new(event_name, acting_as, current_state)
+      end
+
+      def available_event_triggers(current_state:)
+        data_structure.fetch(current_state.to_s, {}).each_with_object(Set.new) do |(event_name, acting_as), mem|
+          mem << ActionAvailability.new(event_name, acting_as, current_state)
+          mem
+        end.to_a
+      end
+
+      private
+
+      # Crafting a welformed object
+      ActionAvailability = Struct.new(:event_name, :acting_as, :current_state) do
+        def initialize(event_name, acting_as, current_state)
+          modified_event_name = event_name.to_s.sub(/\?\Z/, '')
+          modified_acting_as = Array.wrap(acting_as)
+          super(modified_event_name, modified_acting_as, current_state.to_s)
+        end
+      end
+      private_constant :ActionAvailability
+
+      def validate!
+        # TODO: This could be tidied up by building a Hash with indifferent access.
+        no_errors = true
+        data_structure.each_pair do |state, hash|
+          if state.is_a?(String)
+            if state =~ /\?\Z/
+              no_errors = false
+              break
+            end
+          else
+            no_errors = false
+            break
+          end
+          hash.each_pair do |event_name, acting_as|
+            if event_name.is_a?(Symbol)
+              if event_name.to_s !~ /\?\Z/
+                no_errors = false
+                break
+              end
+            else
+              no_errors = false
+              break
+            end
+            Array.wrap(acting_as).each do |item|
+              unless item.is_a?(String)
+                no_errors = false
+                break
+              end
+            end
+          end
+        end
+        return true if no_errors
+        fail Exceptions::InvalidStateDiagramRawStructure, structure: data_structure
+      rescue NoMethodError
+        raise Exceptions::InvalidStateDiagramRawStructure, structure: data_structure
+      end
+    end
+  end
+end

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -19,6 +19,12 @@ module Sipity
       its(:conversion_target) { should be_a(String) }
     end
 
+    RSpec.describe InvalidStateDiagramRawStructure do
+      subject { described_class.new(structure: 'hello') }
+      its(:message) { should be_a(String) }
+      its(:structure) { should eq('hello') }
+    end
+
     RSpec.describe AuthenticationFailureError do
       subject { described_class.new('hello') }
       its(:message) { should be_a(String) }

--- a/spec/forms/sipity/forms/work_event_trigger_form_spec.rb
+++ b/spec/forms/sipity/forms/work_event_trigger_form_spec.rb
@@ -12,7 +12,8 @@ module Sipity
       context 'with defaults' do
         subject { described_class.new(work: work, event_name: 'submit_for_review') }
         its(:event_receiver) { should respond_to :trigger! }
-        its(:state_diagram) { should respond_to :fetch }
+        its(:state_diagram) { should respond_to :event_trigger_availability }
+        its(:state_diagram) { should respond_to :available_event_triggers }
       end
 
       context 'validations' do

--- a/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
@@ -9,7 +9,10 @@ module Sipity
       let(:repository) do
         double('Repository', are_all_of_the_required_todo_items_done_for_work?: true, can_the_user_act_on_the_entity?: true)
       end
-      let(:state_diagram) { StateMachines::EtdStateMachine::STATE_POLICY_QUESTION_ROLE_MAP }
+      # TODO: Disentangle the ETD State Machine
+      let(:state_diagram) do
+        StateMachines::StateDiagram.new('new' => { submit_for_review?: 'creating_user' })
+      end
       let(:form) { double('Form', work: work, event_name: event_name, state_diagram: state_diagram) }
       subject { described_class.new(user, form, repository: repository) }
 

--- a/spec/state_machines/sipity/state_machines/etd_state_machine_spec.rb
+++ b/spec/state_machines/sipity/state_machines/etd_state_machine_spec.rb
@@ -17,7 +17,8 @@ module Sipity
 
       context 'class methods' do
         subject { described_class }
-        its(:state_diagram) { should respond_to :fetch }
+        its(:state_diagram) { should respond_to :event_trigger_availability }
+        its(:state_diagram) { should respond_to :available_event_triggers }
       end
 
       context 'with the default repository' do
@@ -33,7 +34,7 @@ module Sipity
       context '#authorized_acting_as_for_action' do
         let(:initial_processing_state) { 'unknown' }
         it 'will raise an exception if the processing_state is unknown' do
-          expect { subject.authorized_acting_as_for_action(:update?) }.to raise_error(Exceptions::StatePolicyQuestionRoleMapError)
+          expect(subject.authorized_acting_as_for_action(:update?)).to eq([])
         end
         context 'for :new' do
           let(:initial_processing_state) { 'new' }

--- a/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
+++ b/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+module Sipity
+  module StateMachines
+    RSpec.describe StateDiagram do
+      let(:data_structure) do
+        {
+          'new' => {
+            delete?: ['creating_user'], submit_for_review?: ['creating_user']
+          }
+        }
+      end
+
+      [
+        nil,
+        { 'valid' => 'invalid' },
+        { 'valid' => { 'invalid?' => [] } },
+        { 'valid' => { 'invalid' => [] } },
+        { 'valid' => { :valid? => :invalid } },
+        { 'valid' => { :valid? => [:invalid, 'valid'] } },
+        'invalid?',
+        { 'invalid?' => {} },
+        { invalid: {} }
+      ].each_with_index do |malformed, index|
+        it "will not initialize scenario ##{index}" do
+          expect { described_class.new(malformed) }.to raise_error(Exceptions::InvalidStateDiagramRawStructure)
+        end
+      end
+
+      context '#available_event_triggers' do
+        subject { described_class.new(data_structure) }
+        it 'will return an array of ActionAvailability items' do
+          expect(subject.available_event_triggers(current_state: 'new')).to eq(
+            [
+              subject.event_trigger_availability(current_state: 'new', event_name: 'delete'),
+              subject.event_trigger_availability(current_state: 'new', event_name: 'submit_for_review')
+            ]
+          )
+        end
+      end
+
+      context '#event_trigger_availability' do
+        let(:state_diagram) { described_class.new(data_structure) }
+
+        context 'given a valid current_state' do
+          subject { state_diagram.event_trigger_availability(current_state: 'new', event_name: 'submit_for_review') }
+          its(:acting_as) { should eq(['creating_user']) }
+          its(:current_state) { should eq('new') }
+          its(:event_name) { should eq('submit_for_review') }
+        end
+
+        context 'given an invalid current_state' do
+          subject { state_diagram.event_trigger_availability(current_state: '__invalid__', event_name: 'submit_for_review') }
+          its(:acting_as) { should eq([]) }
+          its(:current_state) { should eq('__invalid__') }
+          its(:event_name) { should eq('submit_for_review') }
+        end
+
+        context 'given an invalid event_name' do
+          subject { state_diagram.event_trigger_availability(current_state: 'new', event_name: 'mangle_the_data') }
+          its(:acting_as) { should eq([]) }
+          its(:current_state) { should eq('new') }
+          its(:event_name) { should eq('mangle_the_data') }
+        end
+      end
+    end
+  end
+end

--- a/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
+++ b/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
@@ -17,6 +17,7 @@ module Sipity
         { 'valid' => { 'invalid?' => [] } },
         { 'valid' => { 'invalid' => [] } },
         { 'valid' => { :valid? => :invalid } },
+        { 'valid' => { :invalid => 'valid' } },
         { 'valid' => { :valid? => [:invalid, 'valid'] } },
         'invalid?',
         { 'invalid?' => {} },

--- a/spec/state_machines/sipity/state_machines_spec.rb
+++ b/spec/state_machines/sipity/state_machines_spec.rb
@@ -29,7 +29,7 @@ module Sipity
       let(:valid_work_type) { 'etd' }
       context 'with valid enrichment type' do
         subject { described_class.state_diagram_for(work_type: valid_work_type) }
-        it { should respond_to(:fetch) }
+        it { should be_a(StateMachines::StateDiagram) }
         it { should eq(StateMachines::EtdStateMachine.state_diagram) }
       end
     end


### PR DESCRIPTION
## Adding StateDiagram object

@436d18ce95a6ee57175ad4ae287ff535f4c51986

Encapsulate the state diagram and potential "acting_as" values.

## Incorporating state diagrams

@3b70051b574ebb2b64eff36fc84ae7510b340b43

Removing over usage of nested fetch imperatives; Prefer an object to
answer what was requested.

## Removing unused constant

@06e736f601601f4d698d90d93132446483d02fe5
