### PR TITLE
Adding script and note concerning multi-commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,9 @@ If you need to skip the `pre-push` hook, use the `--no-verify` option when you p
 
 Either submit a pull request modifying the `.hound.yml` file or submit an issue
 and I can take a look at it.
+
+# Submitting a Pull Request
+
+When submitting a pull request, make sure to submit a useful description of what you are doing.
+If your pull request contains multiple commits, consider using `./script/build-multi-commit-message`.
+It will generate rudimentary markdown from all of the commit messages.

--- a/scripts/build-multi-commit-message
+++ b/scripts/build-multi-commit-message
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+git log --reverse --pretty="format:## %s%n%n@%H%n%n%b" master..


### PR DESCRIPTION
The attached script will generate a somewhat markdown compatable
string that can be used as the message of the pull request. This is
useful if your pull request has multiple commits.

[skip ci]