### PR TITLE
Bumping version of terminal-notifier-guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,8 @@ group :development do
   gem 'rb-fsevent', :require=>false
   gem 'rb-inotify', :require=>false
   gem 'spring-commands-rspec'
-  gem 'terminal-notifier-guard', '~> 1.5.3'
+  gem 'terminal-notifier'
+  gem 'terminal-notifier-guard', '~> 1.6.4'
   gem 'pry-rails'
   gem 'pry-rescue'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,8 @@ GEM
       net-ssh (>= 2.8.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
-    terminal-notifier-guard (1.5.3)
+    terminal-notifier (1.6.2)
+    terminal-notifier-guard (1.6.4)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -474,7 +475,8 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sqlite3
-  terminal-notifier-guard (~> 1.5.3)
+  terminal-notifier
+  terminal-notifier-guard (~> 1.6.4)
   turbolinks
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
It had started throwing an error for me:
`uninitialized constant Guard::UI::ERROR_TERMINAL_NOTIFIER_ONLY_OSX10`