### PR TITLE
Associating an advisor with grad school members

### DIFF
--- a/app/models/sipity/models/permission.rb
+++ b/app/models/sipity/models/permission.rb
@@ -33,6 +33,7 @@ module Sipity
     #   DeclarativeAuthorization gem
     class Permission < ActiveRecord::Base
       CREATING_USER = 'creating_user'.freeze
+      ADVISOR = 'advisor'.freeze
       self.table_name = 'sipity_permissions'
       belongs_to :actor, polymorphic: true
       belongs_to :entity, polymorphic: true

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -45,8 +45,7 @@ module Sipity
         end
       end
       module_function :grant_permission_for!
-      private :grant_permission_for!
-      private_class_method :grant_permission_for!
+      public :grant_permission_for!
     end
   end
 end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -6,11 +6,33 @@ module Sipity
 
       context '#assign_collaborators_to' do
         let(:work) { Models::Work.new(id: 123) }
-        let(:collaborator) { Models::Collaborator.new(name: 'Jeremy', role: 'advisor') }
-        it 'will create an collaborator' do
-          expect(test_repository).to receive(:create_sipity_user_from).with(netid: collaborator.netid)
-          expect { test_repository.assign_collaborators_to(work: work, collaborators: collaborator) }.
-            to change { Models::Collaborator.where(work_id: work.id).count }.by(1)
+        let(:collaborator) do
+          Models::Collaborator.new(responsible_for_review: is_responsible_for_review?, name: 'Jeremy', role: 'advisor', netid: 'somebody')
+        end
+        context 'when a collaborator is responsible_for_review' do
+          let(:is_responsible_for_review?) { false }
+          it 'will create a collaborator but not a user nor permission' do
+            expect do
+              expect do
+                expect do
+                  test_repository.assign_collaborators_to(work: work, collaborators: collaborator)
+                end.to change(Models::Collaborator, :count).by(1)
+              end.to_not change(Models::Permission, :count)
+            end.to_not change(User, :count)
+          end
+        end
+
+        context 'when a collaborator is responsible_for_review' do
+          let(:is_responsible_for_review?) { true }
+          it 'will create a collaborator, user, and permission' do
+            expect do
+              expect do
+                expect do
+                  test_repository.assign_collaborators_to(work: work, collaborators: collaborator)
+                end.to change(Models::Collaborator, :count).by(1)
+              end.to change(Models::Permission, :count).by(1)
+            end.to change(User, :count).by(1)
+          end
         end
       end
 


### PR DESCRIPTION
As a grad student when I assign a NetID for an advisor that requires
signoff
Then I want to associate the work with my advisor's NetID
So that my advisor can review the document

Closes DLTP-368