### PR TITLE
DLTP 370 dashboard page

### DIFF
--- a/app/controllers/sipity/controllers/dashboards_controller.rb
+++ b/app/controllers/sipity/controllers/dashboards_controller.rb
@@ -6,7 +6,7 @@ module Sipity
       respond_to :html, :json
 
       def index
-        @view = Models::Work.all
+        @view = repository.find_works_for(user: current_user)
         respond_with(@view)
       end
       attr_reader :view

--- a/app/controllers/sipity/controllers/dashboards_controller.rb
+++ b/app/controllers/sipity/controllers/dashboards_controller.rb
@@ -6,11 +6,18 @@ module Sipity
       respond_to :html, :json
 
       def index
-        @view = repository.find_works_for(user: current_user)
+        # TODO: Extract the runner
+        @view = repository.find_works_for(user: current_user, processing_state: processing_state)
         respond_with(@view)
       end
       attr_reader :view
       helper_method :view
+
+      private
+
+      def processing_state
+        params[:processing_state]
+      end
     end
   end
 end

--- a/app/controllers/sipity/controllers/dashboards_controller.rb
+++ b/app/controllers/sipity/controllers/dashboards_controller.rb
@@ -1,0 +1,16 @@
+module Sipity
+  module Controllers
+    # Controller responsible for rendering a user's dashboard. That is to say
+    # How can I see everything?
+    class DashboardsController < ApplicationController
+      respond_to :html, :json
+
+      def index
+        @view = Models::Work.all
+        respond_with(@view)
+      end
+      attr_reader :view
+      helper_method :view
+    end
+  end
+end

--- a/app/controllers/sipity/controllers/dashboards_controller.rb
+++ b/app/controllers/sipity/controllers/dashboards_controller.rb
@@ -5,9 +5,10 @@ module Sipity
     class DashboardsController < ApplicationController
       respond_to :html, :json
 
+      self.runner_container = Sipity::Runners::DashboardRunners
+
       def index
-        # TODO: Extract the runner
-        @view = repository.find_works_for(user: current_user, processing_state: processing_state)
+        _status, @view = run(processing_state: processing_state)
         respond_with(@view)
       end
       attr_reader :view

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -142,6 +142,7 @@ module Sipity
       # @note Welcome to the land of AREL.
       # @see https://github.com/rails/arel AREL - A Relational Algebra
       def scope_entities_for_entity_type_and_user_acting_as(entity_type:, user:, acting_as:)
+        return entity_type.where("0 = 1") unless user.present?
         perm_table = Models::Permission.arel_table
         memb_table = Models::GroupMembership.arel_table
         actor_id = user.id

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -14,9 +14,14 @@ module Sipity
         URI.parse("http://change.me/show/#{work_id}")
       end
 
-      def find_works_for(user:)
+      def find_works_for(user:, processing_state: nil)
         # REVIEW: Is this bleeding into the authorization layer?
-        Policies::WorkPolicy::Scope.resolve(user: user, scope: Models::Work)
+        scope = Policies::WorkPolicy::Scope.resolve(user: user, scope: Models::Work)
+        if processing_state.present?
+          scope.where(processing_state: processing_state)
+        else
+          scope
+        end
       end
 
       def build_create_work_form(attributes: {})

--- a/app/runners/sipity/runners/dashboard_runners.rb
+++ b/app/runners/sipity/runners/dashboard_runners.rb
@@ -1,0 +1,17 @@
+module Sipity
+  module Runners
+    # Container for Dashboard related actions.
+    module DashboardRunners
+      # Responsible for building a general view object for the dashboard.
+      class Index < BaseRunner
+        self.authentication_layer = :default
+        self.authorization_layer = :none
+
+        def run(processing_state: nil)
+          works = repository.find_works_for(user: current_user, processing_state: processing_state)
+          callback(:success, works)
+        end
+      end
+    end
+  end
+end

--- a/app/state_machines/sipity/state_machines/state_diagram.rb
+++ b/app/state_machines/sipity/state_machines/state_diagram.rb
@@ -13,6 +13,10 @@ module Sipity
       attr_reader :data_structure
       private :data_structure
 
+      def states
+        @states ||= data_structure.keys.map(&:to_s)
+      end
+
       # REVIEW: This is really complicated
       def available_events_for_when_acting_as(current_state:, acting_as:)
         events_and_acting_as_for(current_state).each_with_object(Set.new) do |(event_name, possible_acting_as), mem|

--- a/app/views/sipity/controllers/dashboards/index.html.erb
+++ b/app/views/sipity/controllers/dashboards/index.html.erb
@@ -1,0 +1,31 @@
+<div>
+  <h2>Search Pane</h2>
+  <form method="get">
+    <fieldset>
+      <select name="work_type"><option value="etd">ETD</option></select>
+      <select name="processing_state"><option value="under_review">Under Review</option></select>
+      <input type="search">
+      <input type="submit">
+    </fieldset>
+  </form>
+</div>
+
+<div>
+  <table>
+    <thead>
+      <tr>
+        <th>Work</th>
+        <th>Type</th>
+        <th>Processing State</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% view.each do |work| %>
+        <tr>
+          <td><%= link_to(work.title, work_path(work)) %></td>
+          <td><%= work.work_type %></td>
+          <td><%= work.processing_state %></td>
+        </tr>
+      <% end %>
+  </table>
+</div>

--- a/app/views/sipity/controllers/dashboards/index.html.erb
+++ b/app/views/sipity/controllers/dashboards/index.html.erb
@@ -1,13 +1,17 @@
 <div>
-  <h2>Search Pane</h2>
-  <form method="get">
+  <%= form_tag(dashboard_path, method: 'get') do %>
     <fieldset>
-      <select name="work_type"><option value="etd">ETD</option></select>
-      <select name="processing_state"><option value="under_review">Under Review</option></select>
-      <input type="search">
-      <input type="submit">
+      <%# This is the very specific case, to get things working. %>
+      <%= select_tag(
+            :processing_state,
+            options_from_collection_for_select(
+              ::Sipity::StateMachines::EtdStateMachine.state_diagram.states, :to_s, :to_s, params[:processing_state]
+            ),
+            include_blank: true
+      ) %>
+      <%= submit_tag("Filter") %>
     </fieldset>
-  </form>
+  <% end %>
 </div>
 
 <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,5 +33,6 @@ Rails.application.routes.draw do
   mount Upmin::Engine => '/admin'
   root to: 'visitors#index'
   devise_for :users
+  get 'dashboard', to: 'sipity/controllers/dashboards#index', as: "dashboard"
   get 'start', to: redirect('/works/new'), as: 'start'
 end

--- a/spec/controllers/sipity/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/dashboards_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'hesburgh/lib/mock_runner'
+
+module Sipity
+  module Controllers
+    RSpec.describe DashboardsController, type: :controller do
+      context 'GET #index' do
+        before { controller.runner = runner }
+        let(:runner) do
+          Hesburgh::Lib::MockRunner.new(
+            yields: view_object, callback_name: callback_name, run_with: { processing_state: 'hello' }, context: controller
+          )
+        end
+        let(:view_object) { double }
+        let(:callback_name) { :success }
+        it 'will render the new page' do
+          get 'index', processing_state: 'hello'
+          expect(assigns(:view)).to_not be_nil
+          expect(response).to render_template('index')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/sipity/enriching_a_work_spec.rb
+++ b/spec/features/sipity/enriching_a_work_spec.rb
@@ -19,6 +19,12 @@ feature 'Enriching a Work', :devise do
     end
   end
 
+  scenario 'User creates a work then sees it on their dashboard' do
+    login_as(user, scope: :user)
+    create_a_work(work_type: 'etd', title: 'Hello World', work_publication_strategy: 'do_not_know')
+    visit '/dashboard'
+  end
+
   scenario 'User can create a Work' do
     login_as(user, scope: :user)
     create_a_work(work_type: 'etd', title: 'Hello World', work_publication_strategy: 'do_not_know')

--- a/spec/repositories/sipity/queries/permission_queries_spec.rb
+++ b/spec/repositories/sipity/queries/permission_queries_spec.rb
@@ -143,6 +143,14 @@ module Sipity
         let(:acting_as) { Models::Permission::CREATING_USER }
         subject { test_repository }
 
+        it 'will return an empty result if we do not have a user' do
+          expect(
+            subject.scope_entities_for_entity_type_and_user_acting_as(
+              user: nil, acting_as: ['creating_user'], entity_type: entity.class
+            )
+          ).to eq([])
+        end
+
         it 'will return an empty result if there are no acting_as' do
           Models::Permission.create!(entity: entity, actor_id: user.id, actor_type: 'User', acting_as: acting_as)
           expect(subject.scope_entities_for_entity_type_and_user_acting_as(user: user, acting_as: [], entity_type: entity.class)).

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -21,6 +21,10 @@ module Sipity
         it 'will include works that were created by the user' do
           expect(test_repository.find_works_for(user: user_one)).to eq([work_one])
         end
+
+        it 'will allow scoping by processing_state' do
+          expect(test_repository.find_works_for(user: user_one, processing_state: 'abc')).to eq([])
+        end
       end
 
       context '#assign_a_pid' do

--- a/spec/runners/sipity/runners/dashboard_runners_spec.rb
+++ b/spec/runners/sipity/runners/dashboard_runners_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'sipity/runners/dashboard_runners'
+
+module Sipity
+  module Runners
+    module DashboardRunners
+      include RunnersSupport
+      RSpec.describe Index do
+        let(:user) { User.new }
+        let(:context) { TestRunnerContext.new(current_user: user, find_works_for: true) }
+        subject do
+          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
+            on.success { |a| context.handler.invoked("SUCCESS", a) }
+          end
+        end
+
+        it 'will require authentication by default' do
+          expect(described_class.authentication_layer).to eq(:default)
+        end
+
+        it 'does not enforce authorization (as it uses authorization-related scoped finders)' do
+          expect(described_class.authorization_layer).to eq(:none)
+        end
+
+        it 'issues the :success callback' do
+          view_object = double
+          expect(context.repository).to receive(:find_works_for).with(user: user, processing_state: :hello_dolly).and_return(view_object)
+          response = subject.run(processing_state: :hello_dolly)
+          expect(context.handler).to have_received(:invoked).with("SUCCESS", view_object)
+          expect(response).to eq([:success, view_object])
+        end
+      end
+    end
+  end
+end

--- a/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
+++ b/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
@@ -14,9 +14,11 @@ module Sipity
         }
       end
 
+      subject { described_class.new(data_structure) }
+      its(:states) { should eq(data_structure.keys.map(&:to_s)) }
+
       context '#available_events_for_when_acting_as' do
-        subject { described_class.new(data_structure) }
-        [
+         [
           { current_state: 'new', acting_as: 'creating_user', expected: ['delete', 'submit_for_review'] },
           { current_state: 'new', acting_as: 'a_reviewer', expected: [] },
           { current_state: 'new', acting_as: nil, expected: [] },
@@ -32,7 +34,6 @@ module Sipity
       end
 
       context '#available_event_triggers' do
-        subject { described_class.new(data_structure) }
         it 'will return an array of ActionAvailability items' do
           expect(subject.available_event_triggers(current_state: 'new')).to eq(
             [

--- a/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
+++ b/spec/state_machines/sipity/state_machines/state_diagram_spec.rb
@@ -18,7 +18,7 @@ module Sipity
       its(:states) { should eq(data_structure.keys.map(&:to_s)) }
 
       context '#available_events_for_when_acting_as' do
-         [
+        [
           { current_state: 'new', acting_as: 'creating_user', expected: ['delete', 'submit_for_review'] },
           { current_state: 'new', acting_as: 'a_reviewer', expected: [] },
           { current_state: 'new', acting_as: nil, expected: [] },


### PR DESCRIPTION
## Working on a rudimentary dashboard

@493246c1e5c79c624392429faf2ddc1548323eb2


## Leveraging work finding by scope

@3e856bcf01225167b49b10f3dc4670dc1f101b49


## Adding StateDiagram#states

@e127a3d9b2b1ddaabddea111a4cc7cd0e87940bd

I need to know this information for filtering purposes.

## Adjusting #find_works_for

@28f7d8221a0340c4c68cf297d0b7f45d2bf545f6

I want to allow for the processing state to be used as a filter on the
dashboard.

## Wiring in processing state filter

@dea2a7fd10bc57a2f77a0dfd99893a68d6046e3b


## Adding DashboardRunner

@5c00f0757ec1710663732135f3c8e8e4aaba13ea


## Extracting runner usage for DashboardsController

@01595debca9adf99098001b6dcc7cfddef086a2a


## Appeasing Rubocop

@9e1a50bd886af771933a75c514dd3dbab1198c2a
