### PR TITLE
Adding work type to database

### DIFF
--- a/app/models/sipity/models/processing/strategy.rb
+++ b/app/models/sipity/models/processing/strategy.rb
@@ -13,6 +13,8 @@ module Sipity
         has_many :strategy_actions, dependent: :destroy
         has_many :strategy_roles, dependent: :destroy
         has_many :roles, through: :strategy_roles
+
+        belongs_to :proxy_for, polymorphic: true
       end
     end
   end

--- a/app/models/sipity/models/work_type.rb
+++ b/app/models/sipity/models/work_type.rb
@@ -5,35 +5,31 @@ module Sipity
     #
     # One reason for the class is that I want translations. This is something
     # that will be added later as it is not a primary concern.
-    class WorkType
-      NAMED_WORK_TYPES = [
-        'etd'
-      ].freeze
+    class WorkType < ActiveRecord::Base
+      self.table_name = 'sipity_work_types'
 
-      def self.[](key)
-        name = key.to_s.downcase
-        if NAMED_WORK_TYPES.include?(name)
-          new(name)
-        else
-          fail Exceptions::WorkTypeNotFoundError, name: name, container: 'WorkType::NAMED_WORK_TYPES'
-        end
+      NAMED_WORK_TYPES_FOR_ENUM = {
+        'etd' => 'etd'
+      }.freeze
+
+      # As I don't have a means for assigning roles for a given processing type
+      # I need a controlled vocabulary for roles.
+      enum(name: NAMED_WORK_TYPES_FOR_ENUM)
+
+      def self.[](name)
+        where(name: name.to_s).first!
+      end
+
+      def self.valid_names
+        names.keys
       end
 
       # Because the Work#work_type is being enforced via an enum; So I want the
       # Work object to not have to worry about translating the structure as it
       # has no knowledge of the underlying structure of the NAMED_WORK_TYPES
       def self.all_for_enum_configuration
-        NAMED_WORK_TYPES.each_with_object({}) do |name, mem|
-          mem[name] = name
-          mem
-        end
+        NAMED_WORK_TYPES_FOR_ENUM
       end
-
-      def initialize(name)
-        @name = name
-      end
-
-      attr_reader :name
     end
   end
 end

--- a/app/models/sipity/models/work_type.rb
+++ b/app/models/sipity/models/work_type.rb
@@ -30,6 +30,8 @@ module Sipity
       def self.all_for_enum_configuration
         NAMED_WORK_TYPES_FOR_ENUM
       end
+
+      has_one :default_processing_strategy, as: :proxy_for, class_name: 'Sipity::Models::Processing::Strategy', dependent: :destroy
     end
   end
 end

--- a/db/migrate/20150205171226_create_sipity_models_work_types.rb
+++ b/db/migrate/20150205171226_create_sipity_models_work_types.rb
@@ -1,0 +1,12 @@
+class CreateSipityModelsWorkTypes < ActiveRecord::Migration
+  def change
+    create_table :sipity_work_types do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps null: false
+    end
+
+    add_index :sipity_work_types, :name, unique: true
+  end
+end

--- a/db/migrate/20150205172137_adding_work_type_to_processing_strategy.rb
+++ b/db/migrate/20150205172137_adding_work_type_to_processing_strategy.rb
@@ -1,0 +1,10 @@
+class AddingWorkTypeToProcessingStrategy < ActiveRecord::Migration
+  def change
+    add_column :sipity_processing_strategies, :proxy_for_id, :integer
+    add_column :sipity_processing_strategies, :proxy_for_type, :string
+
+    add_index :sipity_processing_strategies, [:proxy_for_id, :proxy_for_type], unique: true, name: :sipity_processing_strategies_proxy_for
+    change_column_null :sipity_processing_strategies, :proxy_for_id, false
+    change_column_null :sipity_processing_strategies, :proxy_for_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150205171226) do
+ActiveRecord::Schema.define(version: 20150205172137) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -211,13 +211,16 @@ ActiveRecord::Schema.define(version: 20150205171226) do
   add_index "sipity_processing_entity_specific_responsibilities", ["strategy_role_id"], name: "sipity_processing_entity_specific_responsibilities_role"
 
   create_table "sipity_processing_strategies", force: :cascade do |t|
-    t.string   "name",        null: false
+    t.string   "name",           null: false
     t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.integer  "proxy_for_id",   null: false
+    t.string   "proxy_for_type", null: false
   end
 
   add_index "sipity_processing_strategies", ["name"], name: "index_sipity_processing_strategies_on_name", unique: true
+  add_index "sipity_processing_strategies", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_strategies_proxy_for", unique: true
 
   create_table "sipity_processing_strategy_action_prerequisites", force: :cascade do |t|
     t.integer  "guarded_strategy_action_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150204172806) do
+ActiveRecord::Schema.define(version: 20150205171226) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -331,6 +331,15 @@ ActiveRecord::Schema.define(version: 20150204172806) do
 
   add_index "sipity_work_type_todo_list_configs", ["work_type", "work_processing_state", "enrichment_group"], name: "sipity_work_type_todo_list_config_completion_index"
   add_index "sipity_work_type_todo_list_configs", ["work_type", "work_processing_state", "enrichment_type"], name: "sipity_work_type_todo_list_config_composite_index", unique: true
+
+  create_table "sipity_work_types", force: :cascade do |t|
+    t.string   "name",        null: false
+    t.text     "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "sipity_work_types", ["name"], name: "index_sipity_work_types_on_name", unique: true
 
   create_table "sipity_works", force: :cascade do |t|
     t.string   "work_publication_strategy"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,10 +10,6 @@
 
 ActiveRecord::Base.transaction do
 
-  Sipity::Models::WorkType.valid_names.each do |work_type_name|
-    Sipity::Models::WorkType.find_or_create_by!(name: work_type_name)
-  end
-
   $stdout.puts 'Configuring Work Type Todo List...'
 
   [
@@ -29,6 +25,13 @@ ActiveRecord::Base.transaction do
     )
   end
 
+  $stdout.puts 'Creating Work Types...'
+  work_types = {}
+  Sipity::Models::WorkType.valid_names.each do |work_type_name|
+    work_types[work_type_name] = Sipity::Models::WorkType.find_or_create_by!(name: work_type_name)
+  end
+
+
   $stdout.puts 'Creating ETD Reviewer Role...'
   roles = {}
 
@@ -41,7 +44,7 @@ ActiveRecord::Base.transaction do
   end
 
   $stdout.puts 'Creating ETD State Diagram...'
-  Sipity::Models::Processing::Strategy.find_or_create_by!(name: 'etd') do |etd_strategy|
+  Sipity::Models::Processing::Strategy.find_or_create_by!(proxy_for: work_types.fetch('etd'), name: 'etd processing') do |etd_strategy|
     etd_strategy_roles = {}
 
     [

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,10 @@
 
 ActiveRecord::Base.transaction do
 
+  Sipity::Models::WorkType.valid_names.each do |work_type_name|
+    Sipity::Models::WorkType.find_or_create_by!(name: work_type_name)
+  end
+
   $stdout.puts 'Configuring Work Type Todo List...'
 
   [

--- a/spec/models/sipity/models/processing/strategy_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_spec.rb
@@ -4,7 +4,10 @@ module Sipity
   module Models
     module Processing
       RSpec.describe Strategy, type: :model do
-        pending "add some examples to (or delete) #{__FILE__}"
+        subject { described_class }
+        its(:column_names) { should include('proxy_for_id') }
+        its(:column_names) { should include('proxy_for_type') }
+        its(:column_names) { should include('name') }
       end
     end
   end

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -5,11 +5,12 @@ module Sipity
     RSpec.describe WorkType, type: :model do
       context '.[]' do
         it 'will have an ETD' do
+          described_class.create!(name: 'etd')
           expect(described_class['etd']).to be_a(WorkType)
         end
 
         it 'will raise an exception if the WorkType is invalid' do
-          expect { described_class['__MISSIN__'] }.to raise_error(Exceptions::WorkTypeNotFoundError)
+          expect { described_class['__MISSIN__'] }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -19,6 +19,11 @@ module Sipity
           expect(described_class.all_for_enum_configuration).to be_a(Hash)
         end
       end
+
+      it 'has one :default_processing_strategy' do
+        expect(described_class.reflect_on_association(:default_processing_strategy)).
+          to be_a(ActiveRecord::Reflection::AssociationReflection)
+      end
     end
   end
 end

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -22,7 +22,7 @@ module Sipity
       let(:user) { User.find_or_create_by!(username: 'user') }
       let(:group) { Models::Group.find_or_create_by!(name: 'group') }
       let(:role) { Models::Role.find_or_create_by!(name: Models::Role.valid_names.first) }
-      let(:strategy) { Models::Processing::Strategy.find_or_create_by!(name: 'strategy') }
+      let(:strategy) { Models::Processing::Strategy.find_or_create_by!(name: 'strategy', proxy_for_id: '1', proxy_for_type: 'AnWorkType') }
       let(:entity) do
         Models::Processing::Entity.find_or_create_by!(
           proxy_for_id: 1, proxy_for_type: 'AnEntity', strategy: strategy, strategy_state: originating_state


### PR DESCRIPTION
## Adding WorkTypes to the database

@63209daa755d395252d02e6bc2f9c59f1350aa6f

Given that I may need to drive additional information based on the
WorkType, I want a place that I can begin to describe that
information.

Yes, I could continue to use the magic name, and in some cases I will,
but if I want an association to a ProcessingStrategy, I believe I
should perform my due diligence and craft a proper relationship.

## Moving WorkType to the database

@9b6b2468937d018b335430b6644b089ee364f820

Switching from a DB-less model to one backed by ActiveRecord::Base.
This also results in changes to the seeds.

## Adding ProxyFor to Processing Strategy

@aec418aa67f4fe434b5a104d2adb9da2a66d9f04

Mirroring the behavior of the Processing::Actor and Processing::Entity
I want to do likewise for the WorkType.

## Adding processing strategy for work type

@2647c2d76263c4d463efdb4bd3a4ba2940d10160

By creating the relationship, I'm able to work towards creating a
dynamic ProcessingEntity when a new Work is created.

## Tidying up specs

@54374fd44d6531ec61ea9a7acbe8f9bbbcf5739c

These were failing because of the new database constraints
