### PR TITLE
Adding create processing entity when work is created

### DIFF
--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -43,9 +43,9 @@ module Sipity
 
       def submit(repository:, requested_by:)
         super() do |f|
-          # REVIEW: Should the create work behavior be extracted to a repository
-          #   command?
-          work = Models::Work.create!(title: f.title, work_publication_strategy: f.work_publication_strategy)
+          # This method shows an intimate knowledge of the data structure of
+          # what goes into a work. It works for now, but is something to consider.
+          work = repository.create_work!(title: title, work_publication_strategy: work_publication_strategy, work_type: work_type)
           repository.handle_transient_access_rights_answer(entity: work, answer: f.access_rights_answer)
           repository.update_work_publication_date!(work: work, publication_date: f.publication_date)
           repository.grant_creating_user_permission_for!(entity: work, user: requested_by)

--- a/app/models/sipity/models/processing/strategy.rb
+++ b/app/models/sipity/models/processing/strategy.rb
@@ -6,6 +6,7 @@ module Sipity
       # type felt to much of a noun, not conveying potentiality. Strategy
       # conveys "things will happen" because of this.
       class Strategy < ActiveRecord::Base
+        DEFAULT_INITIAL_STRATEGY_STATE = 'new'.freeze
         self.table_name = 'sipity_processing_strategies'
 
         has_many :entities, dependent: :destroy
@@ -15,6 +16,10 @@ module Sipity
         has_many :roles, through: :strategy_roles
 
         belongs_to :proxy_for, polymorphic: true
+
+        def initial_strategy_state
+          strategy_states.find_or_create_by!(name: DEFAULT_INITIAL_STRATEGY_STATE)
+        end
       end
     end
   end

--- a/app/models/sipity/models/work_type.rb
+++ b/app/models/sipity/models/work_type.rb
@@ -32,6 +32,15 @@ module Sipity
       end
 
       has_one :default_processing_strategy, as: :proxy_for, class_name: 'Sipity::Models::Processing::Strategy', dependent: :destroy
+
+      def find_or_initialize_default_processing_strategy(&block)
+        if default_processing_strategy
+          block_given? yield(default_processing_strategy)
+          default_processing_strategy
+        else
+          build_default_processing_strategy(name: "#{name} processing", &block)
+        end
+      end
     end
   end
 end

--- a/app/models/sipity/models/work_type.rb
+++ b/app/models/sipity/models/work_type.rb
@@ -35,10 +35,12 @@ module Sipity
 
       def find_or_initialize_default_processing_strategy(&block)
         if default_processing_strategy
-          block_given? yield(default_processing_strategy)
+          yield(default_processing_strategy) if block_given?
           default_processing_strategy
-        else
+        elsif block_given?
           build_default_processing_strategy(name: "#{name} processing", &block)
+        else
+          build_default_processing_strategy(name: "#{name} processing")
         end
       end
     end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -17,12 +17,12 @@ module Sipity
 
       def create_work!(attributes = {})
         Models::Work.create!(attributes.slice(:title, :work_publication_strategy, :work_type)) do |work|
+          named_work_type = attributes.fetch(:work_type)
+          work_type = Models::WorkType.find_or_create_by!(name: named_work_type)
           # A bit of a weirdness as I splice in the new behavior
-          strategy = attributes.fetch(:processing_strategy) do
-            Models::WorkType[attributes.fetch(:work_type)].default_processing_strategy
-          end
+          strategy = attributes.fetch(:processing_strategy) { work_type.find_or_initialize_default_processing_strategy.tap(&:save!) }
           strategy_state = attributes.fetch(:processing_strategy_state) { strategy.initial_strategy_state }
-          Models::Processing::Entity.build(proxy_for: work, strategy_state: strategy_state, strategy: strategy)
+          work.build_processing_entity(strategy_state: strategy_state, strategy: strategy)
         end
       end
 

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -15,6 +15,12 @@ module Sipity
         end
       end
 
+      def create_work!(attributes = {})
+        Models::Work.create!(attributes.slice(:title, :work_publication_strategy, :work_type)) do |work|
+
+        end
+      end
+
       def update_processing_state!(entity:, to:)
         # REVIEW: Should this be re-finding the work? Is it cheating to re-use
         #   the given work? Is it unsafe as far as state is concerned?

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -17,7 +17,12 @@ module Sipity
 
       def create_work!(attributes = {})
         Models::Work.create!(attributes.slice(:title, :work_publication_strategy, :work_type)) do |work|
-
+          # A bit of a weirdness as I splice in the new behavior
+          strategy = attributes.fetch(:processing_strategy) do
+            Models::WorkType[attributes.fetch(:work_type)].default_processing_strategy
+          end
+          strategy_state = attributes.fetch(:processing_strategy_state) { strategy.initial_strategy_state }
+          Models::Processing::Entity.build(proxy_for: work, strategy_state: strategy_state, strategy: strategy)
         end
       end
 

--- a/db/migrate/20150205183848_amending_processing_entity_indices.rb
+++ b/db/migrate/20150205183848_amending_processing_entity_indices.rb
@@ -1,0 +1,10 @@
+class AmendingProcessingEntityIndices < ActiveRecord::Migration
+  def change
+    # These were once unique true
+    remove_index :sipity_processing_entities, :strategy_id
+    remove_index :sipity_processing_entities, :strategy_state_id
+
+    add_index :sipity_processing_entities, :strategy_id
+    add_index :sipity_processing_entities, :strategy_state_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150205172137) do
+ActiveRecord::Schema.define(version: 20150205183848) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -185,8 +185,8 @@ ActiveRecord::Schema.define(version: 20150205172137) do
   end
 
   add_index "sipity_processing_entities", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_entities_proxy_for", unique: true
-  add_index "sipity_processing_entities", ["strategy_id"], name: "index_sipity_processing_entities_on_strategy_id", unique: true
-  add_index "sipity_processing_entities", ["strategy_state_id"], name: "index_sipity_processing_entities_on_strategy_state_id", unique: true
+  add_index "sipity_processing_entities", ["strategy_id"], name: "index_sipity_processing_entities_on_strategy_id"
+  add_index "sipity_processing_entities", ["strategy_state_id"], name: "index_sipity_processing_entities_on_strategy_state_id"
 
   create_table "sipity_processing_entity_action_registers", force: :cascade do |t|
     t.integer  "strategy_action_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,7 @@ ActiveRecord::Base.transaction do
   end
 
   $stdout.puts 'Creating ETD State Diagram...'
-  Sipity::Models::Processing::Strategy.find_or_create_by!(proxy_for: work_types.fetch('etd'), name: 'etd processing') do |etd_strategy|
+  work_types.fetch('etd').default_processing_strategy do |etd_strategy|
     etd_strategy_roles = {}
 
     [

--- a/spec/forms/sipity/forms/create_work_form_spec.rb
+++ b/spec/forms/sipity/forms/create_work_form_spec.rb
@@ -104,11 +104,13 @@ module Sipity
         end
         context 'with valid data' do
           let(:user) { User.new(id: '123') }
+          let(:work) { double }
           it 'will return the work having created the work, added the attributes,
               assigned collaborators, assigned permission, and loggged the event' do
             allow(subject).to receive(:valid?).and_return(true)
+            expect(repository).to receive(:create_work!).and_return(work)
             response = subject.submit(repository: repository, requested_by: user)
-            expect(response).to be_a(Models::Work)
+            expect(response).to eq(work)
           end
         end
       end

--- a/spec/models/sipity/models/processing/entity_spec.rb
+++ b/spec/models/sipity/models/processing/entity_spec.rb
@@ -4,7 +4,11 @@ module Sipity
   module Models
     module Processing
       RSpec.describe Entity, type: :model do
-        pending "add some examples to (or delete) #{__FILE__}"
+        subject { described_class }
+        its(:column_names) { should include("proxy_for_id") }
+        its(:column_names) { should include("proxy_for_type") }
+        its(:column_names) { should include("strategy_id") }
+        its(:column_names) { should include("strategy_state_id") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_spec.rb
@@ -9,7 +9,6 @@ module Sipity
         its(:column_names) { should include('proxy_for_type') }
         its(:column_names) { should include('name') }
 
-
         context '#initial_strategy_state' do
           subject { described_class.new(proxy_for_id: 1, proxy_for_type: 'A Type', name: 'ETD Workflow') }
           it 'will create a state if one does not exist' do

--- a/spec/models/sipity/models/processing/strategy_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_spec.rb
@@ -8,6 +8,16 @@ module Sipity
         its(:column_names) { should include('proxy_for_id') }
         its(:column_names) { should include('proxy_for_type') }
         its(:column_names) { should include('name') }
+
+
+        context '#initial_strategy_state' do
+          subject { described_class.new(proxy_for_id: 1, proxy_for_type: 'A Type', name: 'ETD Workflow') }
+          it 'will create a state if one does not exist' do
+            subject.save!
+            expect { subject.initial_strategy_state }.
+              to change { subject.strategy_states.count }.by(1)
+          end
+        end
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_state_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_spec.rb
@@ -4,7 +4,9 @@ module Sipity
   module Models
     module Processing
       RSpec.describe StrategyState, type: :model do
-        pending "add some examples to (or delete) #{__FILE__}"
+        subject { described_class }
+        its(:column_names) { should include("strategy_id") }
+        its(:column_names) { should include("name") }
       end
     end
   end

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -28,9 +28,8 @@ module Sipity
       context '#find_or_initialize_default_processing_strategy' do
         subject { described_class.new(name: 'etd') }
         it 'will create a processing strategy if none already exist' do
-          expect {
-            subject.find_or_initialize_default_processing_strategy
-          }.to change { subject.default_processing_strategy }.from(nil)
+          expect { subject.find_or_initialize_default_processing_strategy }.
+            to change { subject.default_processing_strategy }.from(nil)
         end
 
         it 'will yield the processing' do

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -24,6 +24,19 @@ module Sipity
         expect(described_class.reflect_on_association(:default_processing_strategy)).
           to be_a(ActiveRecord::Reflection::AssociationReflection)
       end
+
+      context '#find_or_initialize_default_processing_strategy' do
+        subject { described_class.new(name: 'etd') }
+        it 'will create a processing strategy if none already exist' do
+          expect {
+            subject.find_or_initialize_default_processing_strategy
+          }.to change { subject.default_processing_strategy }.from(nil)
+        end
+
+        it 'will yield the processing' do
+          expect { |b| subject.find_or_initialize_default_processing_strategy(&b) }.to yield_control
+        end
+      end
     end
   end
 end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -40,8 +40,10 @@ module Sipity
         let(:attributes) { { title: 'Hello', work_publication_strategy: 'do_not_know', work_type: 'etd' } }
         it 'will create a work object' do
           expect do
-            test_repository.create_work!(attributes)
-          end.to change { Models::Work.count }.by(1)
+            expect do
+              test_repository.create_work!(attributes)
+            end.to change { Models::Work.count }.by(1)
+          end.to change { Models::Processing::Entity.count }.by(1)
         end
       end
 

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -36,6 +36,15 @@ module Sipity
         end
       end
 
+      context '#create_work!' do
+        let(:attributes) { { title: 'Hello', work_publication_strategy: 'do_not_know', work_type: 'etd' } }
+        it 'will create a work object' do
+          expect do
+            test_repository.create_work!(attributes)
+          end.to change { Models::Work.count }.by(1)
+        end
+      end
+
       context '#pid_minter' do
         subject { test_repository.pid_minter }
         it { should respond_to(:call) }

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -21,6 +21,10 @@ module Sipity
     def create_sipity_user_from(netid:)
     end
 
+    # @see ./app/repositories/sipity/commands/work_commands.rb
+    def create_work!(attributes = {})
+    end
+
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def create_work_attribute_values!(work:, key:, values:)
     end


### PR DESCRIPTION
## Adding #create_work!

@2b7901f428f817eda65b8d5f8b55ae58b14b51bb

I want a method to handle both the work creation and its corresponding
processing proxy object.

## Adding entity column spec

@bfa6577f81eaf79609d3210e9f210cccb8a09a1d

Because I was wanting to see what the database columns were, I figured
I may as well add tests to verify.

## Initial work on processing state

@e6c04d70769bdac72f198357153cf8ac42953a59


## Replacing direct database access with repository

@3018d4244007622ff36caa10826e3a33265385d6


## Adding entity column spec

@459ad8677349d9e40e8d3df7499329ef1a0fd790

Because I was wanting to see what the database columns were, I figured
I may as well add tests to verify.

## Assigning the default strategy state

@17dbe91c07ca7088b606805847fb9248f61166c3

This is hard-coding, but it helps bootstrap the behavior as expected.
I'd prefer to have a convention related to how a processing strategy
"gets started".

## Adding bootstrapping methods for work type

@84d82075b0c9168f2488d16434ce20468777f403

Again, this is hard-coding expectaions, but it helps bootstrap the
data as best I can.

By keeping these methods separate and not part of a callback, I'm not
likely to encounter a situation where I persist numerous objects
without very much knowing I'm doing such a thing.

## Removing uniqueness from indices

@aa7d0f299328f846ff01bbe94742c86cf6316312

This was done in haste and is being removed. It makes no sense to have
the strategy nor strategy state be unique across the database.

## Tidying up all failing tests

@93505e46b124d6aa74b47964d4a6e058b7bcc5dc

Needed a bit of different logic for some things, removing blank lines
for others.
