### PR TITLE
Splicing in permission granting

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -32,6 +32,7 @@ MethodLength:
   CountComments: false
   Enabled: true
   Exclude:
+    - app/conversions/**/*.rb
     - 'app/controllers/sipity/controllers/dois_controller.rb'
     - 'app/repositories/sipity/queries/permission_queries.rb'
     - 'app/repositories/sipity/queries/enrichment_queries.rb'

--- a/app/conversions/sipity/conversions/convert_to_processing_actor.rb
+++ b/app/conversions/sipity/conversions/convert_to_processing_actor.rb
@@ -1,0 +1,26 @@
+module Sipity
+  module Conversions
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToProcessingActor
+      def self.call(input)
+        convert_to_processing_actor(input)
+      end
+
+      def convert_to_processing_actor(input)
+        return input if input.is_a?(Models::Processing::Actor)
+        case input
+        when User, Models::Group then
+          # I'm opting to use input.id.present? instead of persisted? as I'm
+          # thinking that I would prefer the option of tests not quite building
+          # up the whole world.
+          return Models::Processing::Actor.find_or_create_by!(proxy_for: input) if input.id.present?
+        end
+        fail Exceptions::ProcessingActorConversionError, input
+      end
+
+      module_function :convert_to_processing_actor
+      private_class_method :convert_to_processing_actor
+      private :convert_to_processing_actor
+    end
+  end
+end

--- a/app/conversions/sipity/conversions/convert_to_role.rb
+++ b/app/conversions/sipity/conversions/convert_to_role.rb
@@ -1,0 +1,25 @@
+module Sipity
+  module Conversions
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToRole
+      def self.call(input)
+        convert_to_role(input)
+      end
+
+      def convert_to_role(input)
+        return input if input.is_a?(Models::Role)
+        case input
+        when String, Symbol then
+          return Models::Role.find_or_create_by!(name: input)
+        end
+        fail Exceptions::RoleConversionError, input
+      rescue ActiveRecord::RecordInvalid, ArgumentError
+        raise Exceptions::RoleConversionError, input
+      end
+
+      module_function :convert_to_role
+      private_class_method :convert_to_role
+      private :convert_to_role
+    end
+  end
+end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -59,14 +59,19 @@ module Sipity
       self.conversion_target = 'PermanentURI'
     end
 
-    # Unable to convert the given object into a permanent URI
+    # Unable to convert the given object into an entity type
     class EntityTypeConversionError < ConversionError
       self.conversion_target = 'EntityType'
     end
 
-    # Unable to convert the given object into a permanent URI
+    # Unable to convert the given object into a processing entity
     class ProcessingEntityConversionError < ConversionError
       self.conversion_target = 'Processing::Entity'
+    end
+
+    # Unable to convert the given object into a processing actor
+    class ProcessingActorConversionError < ConversionError
+      self.conversion_target = 'Processing::Actor'
     end
 
     # As you are looking up something by name, within a given container.

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -64,14 +64,19 @@ module Sipity
       self.conversion_target = 'EntityType'
     end
 
+    # Unable to convert the given object into a Role
+    class RoleConversionError < ConversionError
+      self.conversion_target = 'Models::Role'
+    end
+
     # Unable to convert the given object into a processing entity
     class ProcessingEntityConversionError < ConversionError
-      self.conversion_target = 'Processing::Entity'
+      self.conversion_target = 'Models::Processing::Entity'
     end
 
     # Unable to convert the given object into a processing actor
     class ProcessingActorConversionError < ConversionError
-      self.conversion_target = 'Processing::Actor'
+      self.conversion_target = 'Models::Processing::Actor'
     end
 
     # As you are looking up something by name, within a given container.

--- a/app/models/sipity/models/role.rb
+++ b/app/models/sipity/models/role.rb
@@ -27,6 +27,10 @@ module Sipity
       def self.valid_names
         names.keys
       end
+
+      def to_s
+        name
+      end
     end
   end
 end

--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -26,6 +26,12 @@ module Sipity
 
       has_one :processing_entity, as: :proxy_for, dependent: :destroy, class_name: 'Sipity::Models::Processing::Entity'
 
+      def to_processing_entity
+        # This is a bit of a short cut, perhaps I should check if its persisted?
+        # But I'll settle for this right now.
+        processing_entity || fail(Exceptions::ProcessingEntityConversionError, self)
+      end
+
       # TODO: Extract to TransientAnswer
       ALREADY_PUBLISHED = 'already_published'.freeze
       WILL_NOT_PUBLISH = 'will_not_publish'.freeze

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -37,11 +37,30 @@ module Sipity
 
       def grant_permission_for!(entity:, actors:, acting_as:)
         Array.wrap(actors).flatten.compact.each do |an_actor|
-          Models::Permission.create!(entity: entity, actor: an_actor, acting_as: acting_as)
+          grant_deprecated_permission_for!(entity: entity, actor: an_actor, acting_as: acting_as)
+          grant_processing_permission_for!(entity: entity, actor: an_actor, role: acting_as)
         end
       end
       module_function :grant_permission_for!
       public :grant_permission_for!
+
+      def grant_processing_permission_for!(_options = {})
+        # processing_actor = Conversions::ConvertToProcessingActor.call(actor)
+        # entity = Conversions::ConvertToProcessingEntity.call(entity)
+        # role = Conversions::ConvertToRole.call(role)
+      end
+      module_function :grant_processing_permission_for!
+      public :grant_processing_permission_for!
+
+      def grant_deprecated_permission_for!(entity:, actor:, acting_as:)
+        Models::Permission.create!(entity: entity, actor: actor, acting_as: acting_as)
+      end
+      module_function :grant_deprecated_permission_for!
+      class << self
+        deprecate :grant_deprecated_permission_for!
+      end
+      private :grant_deprecated_permission_for!
+      deprecate :grant_deprecated_permission_for!
     end
   end
 end

--- a/spec/conversions/sipity/conversions/convert_to_processing_actor_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_actor_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToProcessingActor do
+      include ::Sipity::Conversions::ConvertToProcessingActor
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          object = Models::Processing::Actor.new
+          expect(described_class.call(object)).to eq(object)
+        end
+      end
+
+      context '.convert_to_processing_actor' do
+        it 'will be private' do
+          object = Models::Processing::Actor.new
+          expect { described_class.convert_to_processing_actor(object) }.
+            to raise_error(NoMethodError, /private method `convert_to_processing_actor'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_processing_actor' do
+
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_processing_actor)
+        end
+
+        context 'for a Models::Group' do
+          context 'that is persisted' do
+            let(:object) { Models::Group.create!(name: 'Hello') }
+            it 'will find or create the associated Processing::Actor' do
+              expect(convert_to_processing_actor(object)).to be_a(Models::Processing::Actor)
+            end
+          end
+          context 'that is NOT persisted' do
+            let(:object) { Models::Group.new }
+            it 'will raise an exception' do
+              expect { convert_to_processing_actor(object) }.to raise_error(Exceptions::ProcessingActorConversionError)
+            end
+          end
+        end
+
+        context 'for a Models::User' do
+          context 'that is persisted' do
+            let(:object) { User.create!(username: 'hello') }
+            it 'will find or create the associated Processing::Actor' do
+              expect(convert_to_processing_actor(object)).to be_a(Models::Processing::Actor)
+            end
+          end
+          context 'that is NOT persisted' do
+            let(:object) { User.new }
+            it 'will raise an exception' do
+              expect { convert_to_processing_actor(object) }.to raise_error(Exceptions::ProcessingActorConversionError)
+            end
+          end
+        end
+
+        it 'will return the object if it is a Processing::Actor' do
+          object = Models::Processing::Actor.new
+          expect(convert_to_processing_actor(object)).to eq(object)
+        end
+
+        it 'will raise an exception if it is unhandled' do
+          object = double
+          expect { convert_to_processing_actor(object) }.to raise_error(Exceptions::ProcessingActorConversionError)
+        end
+      end
+    end
+  end
+end

--- a/spec/conversions/sipity/conversions/convert_to_processing_entity_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_entity_spec.rb
@@ -37,6 +37,21 @@ module Sipity
           expect(convert_to_processing_entity(object)).to eq(object)
         end
 
+        context 'a Models::Work (because it will be processed)' do
+          # This is poking knowledge over into the inner workings of Models::Work
+          # but is a reasonable place to understand this.
+          it 'will raise an exception if one has not been assigned' do
+            object = Models::Work.new
+            expect(object.processing_entity).to be_nil
+            expect { convert_to_processing_entity(object) }.to raise_error(Exceptions::ProcessingEntityConversionError)
+          end
+          it 'will return the corresponding processing_entity' do
+            object = Models::Work.new
+            expected_processing_entity = object.build_processing_entity
+            expect(convert_to_processing_entity(object)).to eq(expected_processing_entity)
+          end
+        end
+
         it 'will return the to_processing_entity if the object responds to the processing entity' do
           object = double(to_processing_entity: :processing_entity)
           expect(convert_to_processing_entity(object)).to eq(:processing_entity)

--- a/spec/conversions/sipity/conversions/convert_to_role_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_role_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToRole do
+      include ::Sipity::Conversions::ConvertToRole
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          object = double(to_role: 'Hello')
+          expect { described_class.call(object) }.to raise_error(Exceptions::RoleConversionError)
+        end
+      end
+
+      context '.convert_to_role' do
+        it 'will be private' do
+          object = double
+          expect { described_class.convert_to_role(object) }.
+            to raise_error(NoMethodError, /private method `convert_to_role'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_role' do
+
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_role)
+        end
+
+        it "will raise exception even if object implements to_role" do
+          object = double(to_role: 'Hello')
+          expect { convert_to_role(object) }.to raise_error(Exceptions::RoleConversionError)
+        end
+
+        it "will find_or_create a valid role name" do
+          object = Models::Role.valid_names.first
+          expect(convert_to_role(object)).to be_a(Models::Role)
+        end
+
+        it "will raise exception if the name is invalid" do
+          object = '__not_valid__'
+          expect { convert_to_role(object) }.to raise_error(Exceptions::RoleConversionError)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/sipity/models/role_spec.rb
+++ b/spec/models/sipity/models/role_spec.rb
@@ -24,6 +24,10 @@ module Sipity
         expect { subject.name = '__incorrect_name__' }.to raise_error(ArgumentError)
       end
 
+      it 'will have a #to_s that is a name' do
+        subject.name = 'advisor'
+        expect(subject.to_s).to eq(subject.name)
+      end
     end
   end
 end

--- a/spec/models/sipity/models/work_spec.rb
+++ b/spec/models/sipity/models/work_spec.rb
@@ -13,6 +13,16 @@ module Sipity
         its(:column_names) { should include('title') }
       end
 
+      context '#to_processing_entity' do
+        it 'will raise an exception if one has not been created' do
+          expect { subject.to_processing_entity }.to raise_error(Exceptions::ProcessingEntityConversionError)
+        end
+        it 'will return the existing process entity' do
+          expect_processing_entity = subject.build_processing_entity
+          expect(subject.to_processing_entity).to eq(expect_processing_entity)
+        end
+      end
+
       context '.work_types' do
         it 'is a Hash of keys that equal their values' do
           expect(Work.work_types.keys).

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -38,11 +38,19 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def grant_deprecated_permission_for!(entity:, actor:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
     def grant_groups_permission_to_entity_for_acting_as!(entity:, acting_as:)
     end
 
     # @see ./app/repositories/sipity/commands/permission_commands.rb
     def grant_permission_for!(entity:, actors:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def grant_processing_permission_for!(_options = {})
     end
 
     # @see ./app/repositories/sipity/commands/transient_answer_commands.rb


### PR DESCRIPTION
## Splicing in and deprecating permission granting

@b65264358d1faee7885d31b0a27dbcef78b81113

I want to leverage both systems at the same time, so I'm introducing
the appropriate seem.

## Adding Work#to_processing_entity

@5f2d9e4e53c1776da6d207da63cc64c3c7221544

This is something that I most certainly am going to use. So I'm laying
that out now.

Next up, convert_to_processing_strategy!

## Adding scenario regarding Models::Work

@17b0dc7e7dd84ff91350e31bc2c352ca11c94c90

This is a matter of confidence, and draws attention to its behavior.

## Adding conversion method for processing actor

@96891a5d5d907554c29feba58134c2317ff9fe90

I want to be able to ensure that when I'm working with a given user
or group that I'm transforming that into the other sub-system object.

## Adding method to convert string to a Role object

@172fc2da1430f70c228f09ca7e7b22b2498218b5
