### PR TITLE
Adding specs to ensure code coverage w/o features

### DIFF
--- a/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
@@ -11,6 +11,7 @@ module Sipity
 
         it { should respond_to :work }
         its(:enrichment_type) { should eq('collaborator') }
+        its(:collaborators) { should_not be_empty }
 
         it 'will require a work' do
           subject = described_class.new(work: nil)

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -20,6 +20,12 @@ module Sipity
         end
       end
 
+      context '.valid_names' do
+        it 'will be an Array' do
+          expect(described_class.valid_names).to be_a(Array)
+        end
+      end
+
       it 'has one :default_processing_strategy' do
         expect(described_class.reflect_on_association(:default_processing_strategy)).
           to be_a(ActiveRecord::Reflection::AssociationReflection)

--- a/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_event_trigger_policy_spec.rb
@@ -16,6 +16,12 @@ module Sipity
       let(:form) { double('Form', work: work, event_name: event_name, state_diagram: state_diagram) }
       subject { described_class.new(user, form, repository: repository) }
 
+      context 'defaults' do
+        subject { described_class.new(user, form) }
+        its(:repository) { should respond_to :are_all_of_the_required_todo_items_done_for_work? }
+        its(:repository) { should respond_to :can_the_user_act_on_the_entity? }
+      end
+
       context 'initialization' do
         it 'fails if the form does not have a work' do
           form = double

--- a/spec/services/sipity/services/grant_processing_permission_spec.rb
+++ b/spec/services/sipity/services/grant_processing_permission_spec.rb
@@ -15,6 +15,13 @@ module Sipity
       subject { described_class.new(entity: entity, role: role, actor: actor) }
       its(:strategy) { should eq entity.strategy }
 
+      context '.call' do
+        it 'will instantiate then call the instance' do
+          expect(described_class).to receive(:new).and_return(double(call: true))
+          described_class.call(entity: entity, role: role, actor: actor)
+        end
+      end
+
       context '#call' do
         let(:fake_relation) { double(first!: strategy_role) }
         before do

--- a/spec/services/sipity/services/update_entity_processing_state_spec.rb
+++ b/spec/services/sipity/services/update_entity_processing_state_spec.rb
@@ -8,6 +8,13 @@ module Sipity
 
       subject { described_class.new(entity: entity, processing_state: processing_state) }
 
+      context '.call' do
+        it 'will instantiate then call the instance' do
+          expect(described_class).to receive(:new).and_return(double(call: true))
+          described_class.call(entity: entity, processing_state: 'submit_for_review')
+        end
+      end
+
       context 'with an invalid processing state' do
         let(:processing_state) { double }
         it 'will raise an error' do


### PR DESCRIPTION
In an ongoing effort to make sure that the feature tests are
"disposable", I want to ensure that code coverage is 100% without
features.

This is done by running:

`$ rake spec:coverage:without_features`

There were a few missing cases, but they have been shored up.