### PR TITLE
Replacing object query with repository query

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
@@ -48,7 +48,7 @@ module Sipity
 
         def build_collaborator_from_input(collection, attributes)
           return if !attributes[:name].present? && !attributes[:id].present?
-          collaborator = work.collaborators.find_or_initialize_by(id: attributes[:id])
+          collaborator = Queries::CollaboratorQueries.find_or_initialize_collaborators_by(work: work, id: attributes[:id])
           collaborator.attributes = extract_collaborator_attributes(attributes)
           collection << collaborator
         end

--- a/app/repositories/sipity/queries/collaborator_queries.rb
+++ b/app/repositories/sipity/queries/collaborator_queries.rb
@@ -1,8 +1,16 @@
 module Sipity
   module Queries
     # Queries
-    # Queries
+    #
+    # TODO: Remove module methods for these functions. I want them to be mixins
+    #   instead of the existing singletons.
     module CollaboratorQueries
+      def find_or_initialize_collaborators_by(work:, id:, &block)
+        Models::Collaborator.find_or_initialize_by(work_id: work.id, id: id, &block)
+      end
+      module_function :find_or_initialize_collaborators_by
+      public :find_or_initialize_collaborators_by
+
       def work_collaborators_for(options = {})
         Models::Collaborator.includes(:work).where(options.slice(:work, :role))
       end

--- a/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
@@ -48,6 +48,7 @@ module Sipity
             end
 
             it 'will create a collaborator' do
+              expect(Queries::CollaboratorQueries).to receive(:find_or_initialize_collaborators_by).and_call_original
               expect(repository).to receive(:assign_collaborators_to).and_call_original
               subject.submit(repository: repository, requested_by: user)
             end

--- a/spec/repositories/sipity/queries/collaborator_queries_spec.rb
+++ b/spec/repositories/sipity/queries/collaborator_queries_spec.rb
@@ -7,6 +7,13 @@ module Sipity
       let(:work_two) { Models::Work.new(id: '456') }
       subject { test_repository }
 
+      context '#find_or_initialize_collaborators' do
+        subject { test_repository.find_or_initialize_collaborators_by(work: work, id: '12') }
+        it 'will initialize a collaborator based on the work id' do
+          expect(subject.work_id).to eq(work.id)
+        end
+      end
+
       context '.work_collaborators_for' do
         it 'returns the collaborators for the given work and role' do
           Models::Collaborator.create!(work: work, role: 'author', name: 'jeremy')


### PR DESCRIPTION
I encountered an odd interaction that is a result of @3d612b50.

Building the form went from:

```ruby
work = repository.find_work(work_id)
form = repository.build_enrichment_form(work: work, enrichment_type: enrichment_type)
```

to

```ruby
work = repository.find_work(work_id)
decorated_work = Decorators::WorkDecorator.decorate(work)
form = repository.build_enrichment_form(work: decorated_work, enrichment_type: enrichment_type)
```

It appears the intent of adding the decoration is to get the following:

```ruby
def with_action_pane(name, css_class = '', &block)
  h.render(layout: 'sipity/form_action_pane', locals: { name: name, css_class: css_class, object: self }, &block)
end
```
https://github.com/ndlib/sipity/blob/3d612b50/app/decorators/sipity/decorators/work_decorator.rb#L17-L20

This meant that the WorkEnrichments::CollaboratorForm was breaking in
a subtle way. The following line of code was throwing `NoMethodError`,
`undefined method 'find_or_initialize_by' for #<Draper::CollectionDecorator:0x007fe8fb538360>`

ruby
```
51: collaborator = work.collaborators.find_or_initialize_by(id: attributes[:id])
```

I believe the method that @danhorst was interested in has a more
general purpose than being scoped to the work. This raises the
question should forms behave like draper objects?

See @3d612b50