### PR TITLE
Renaming pid_minter to default_pid_minter

### DIFF
--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -37,9 +37,10 @@ module Sipity
       deprecate :update_deprecated_processing_state!
       private :update_deprecated_processing_state!
 
-      # TODO: Create a PidMinter service
-      # REVIEW: Is this the correct location to put this behavior?
-      def attach_file_to(work:, file:, user: user, pid_minter: pid_minter)
+      def attach_file_to(work:, file:, user:, pid_minter: default_pid_minter)
+        # I know I want the user, but I'm not certain what we are doing with it
+        # just yet.
+        _user = user
         pid = pid_minter.call
         Models::Attachment.create!(work: work, file: file, pid: pid, predicate_name: 'attachment')
       end
@@ -56,7 +57,7 @@ module Sipity
       #
       # @note This is not a PID as per Fedora 3, but is something random,
       #   unique, and stringy. Which for these purposes is adequate.
-      def pid_minter
+      def default_pid_minter
         -> { Digest::UUID.uuid_v4 }
       end
     end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -51,8 +51,8 @@ module Sipity
         end
       end
 
-      context '#pid_minter' do
-        subject { test_repository.pid_minter }
+      context '#default_pid_minter' do
+        subject { test_repository.default_pid_minter }
         it { should respond_to(:call) }
         its(:call) { should be_a(String) }
       end
@@ -91,7 +91,7 @@ module Sipity
         let(:pid_minter) { -> { 'abc123' } }
         it 'will increment the number of attachments in the system' do
           expect { test_repository.attach_file_to(work: work, file: file, user: user, pid_minter: pid_minter) }.
-            to change { Models::Attachment.count }.by(1)
+            to change { Models::Attachment.where(pid: 'abc123').count }.by(1)
         end
       end
     end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -10,7 +10,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def attach_file_to(work:, file:, user: user, pid_minter: pid_minter)
+    def attach_file_to(work:, file:, user:, pid_minter: default_pid_minter)
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb
@@ -27,6 +27,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def create_work_attribute_values!(work:, key:, values:)
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
+    def default_pid_minter
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb
@@ -67,10 +71,6 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb
     def mark_work_todo_item_as_done(work:, enrichment_type:, processing_state: work.processing_state)
-    end
-
-    # @see ./app/repositories/sipity/commands/work_commands.rb
-    def pid_minter
     end
 
     # @see ./app/repositories/sipity/commands/notification_commands.rb


### PR DESCRIPTION
@banurekha noticed this behavior. In the previous implementation
I was hoping the named :pid_minter parameter, if nil would set the
named parameter to the module's `pid_minter` method. However it was
setting the named parameter's value to itself, thus
`attach_file_to(work: work, file: file, user: user)` would result in
the pid_minter parameter being nil.

This clarifies the behavior, and while I would prefer a pid_minter
method, I will settle for default_pid_minter.

Good catch @banurekha

Also, appeasing Rubocop's identification that the user parameter was
not needed. I know we need it, but for now, I'll settle one what we
have.