### PR TITLE
Removing validation as input is not user available

### DIFF
--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -27,7 +27,6 @@ module Sipity
       validates :work_publication_strategy, inclusion: { in: :possible_work_publication_strategies }, presence: true
       validates :work_type, inclusion: { in: :possible_work_types }, presence: true
       validates :access_rights_answer, inclusion: { in: :possible_access_right_answers }, presence: true
-      validates(:publication_date, presence: { if: :publication_date_required? })
 
       def access_rights_answer_for_select
         possible_access_right_answers.map(&:to_sym)
@@ -67,10 +66,6 @@ module Sipity
       def possible_access_right_answers
         # TODO: This is a rather invasive question
         Models::TransientAnswer::ANSWERS.fetch(Models::TransientAnswer::ACCESS_RIGHTS_QUESTION)
-      end
-
-      def publication_date_required?
-        work_publication_strategy == Models::Work::ALREADY_PUBLISHED
       end
 
       def default_access_rights_answer

--- a/spec/forms/sipity/forms/create_work_form_spec.rb
+++ b/spec/forms/sipity/forms/create_work_form_spec.rb
@@ -65,17 +65,6 @@ module Sipity
             expect(subject.errors[:work_publication_strategy]).to be_present
           end
         end
-        context '#publication_date' do
-          it 'must be present when it was :already_published' do
-            subject.work_publication_strategy = 'already_published'
-            subject.valid?
-            expect(subject.errors[:publication_date]).to be_present
-          end
-          it 'need not be present otherwise' do
-            subject.valid?
-            expect(subject.errors[:publication_date]).to_not be_present
-          end
-        end
       end
 
       context '#submit' do


### PR DESCRIPTION
The HTML form that was capturing this information no longer has a
publication date associated with it. So I'm removing the validation.
If you give us one, we'll capture it.