### PR TITLE
Working on processing queries

### DIFF
--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -81,6 +81,49 @@ module Sipity
       #
       # An ActiveRecord::Relation scope that meets the following criteria:
       #
+      # * Processing Entities with the same processing strategy
+      #
+      # @param user [User]
+      # @param strategy [Sipity::Models::Processing::Strategy]
+      # @param roles [Array<Sipity::Models::Role>]
+      #
+      # @return ActiveRecord::Relation<Models::Processing::Entity>
+      def scope_entities_for_user_strategy_and_roles(user:, strategy:, roles:)
+        role_ids = Array.wrap(roles).map { |role| convert_to_role(role).id }
+        # IT NEEDS TO DO THE FOLLOWING:
+        #
+        # ```SQL
+        # SELECT * FROM entities
+        # WHERE (
+        #   strategy_id IN (
+        #     SELECT strategy_id FROM strategy_roles
+        #     INNER JOIN strategy_responsibilities ON strategy_roles.id = strategy_responsibilities.strategy_role_id
+        #     INNER JOIN actors ON actors.id = strategy_responsibilities.actor_id
+        #     WHERE(
+        #       strategy_id = <GIVEN_STRATEGY_ID>
+        #       AND role_id IN (<GIVEN_ROLE_IDS>)
+        #       AND actors.id BLAH BLAH BLAH
+        #     )
+        #   )
+        # ) OR (
+        #   id IN (
+        #     SELECT entity_id FROM entity_specific_responsibilities
+        #     INNER JOIN strategy_roles ON strategy_roles.id = entity_specific_responsibilities.strategy_role_id
+        #     INNER JOIN actors ON actors.id = entity_specific_responsibilities.actor_id
+        #     WHERE(
+        #       strategy_id = <GIVEN_STRATEGY_ID>
+        #       AND role_id IN (<GIVEN_ROLE_IDS>)
+        #       AND actors.id BLAH BLAH BLAH
+        #     )
+        #   )
+        # )
+        #```
+      end
+
+      # @api public
+      #
+      # An ActiveRecord::Relation scope that meets the following criteria:
+      #
       # * Users that are directly associated with the given entity through on or
       #   more of the given roles
       # * Users that are indirectly associated with the given entity by group

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -89,14 +89,22 @@ module Sipity
         let(:user) { User.create!(username: 'user') }
         subject { test_repository.scope_entities_for_user_strategy_and_roles(user: user, strategy: entity.strategy, roles: role) }
         it "will resolve to an array of entities" do
-          Models::Processing::Entity.create!(proxy_for_id: 2, proxy_for_type: 'AnEntity', strategy: strategy, strategy_state: originating_state)
-          Models::Processing::Entity.create!(proxy_for_id: 3, proxy_for_type: 'AnEntity', strategy_id: 8675309, strategy_state: originating_state)
+          entity
+          other_entity = Models::Processing::Entity.create!(
+            proxy_for_id: 2, proxy_for_type: 'AnEntity', strategy: strategy, strategy_state: originating_state
+          )
+          Models::Processing::Entity.create!(
+            proxy_for_id: 3, proxy_for_type: 'AnEntity', strategy_id: 8_675_309, strategy_state: originating_state
+          )
           user_actor = Models::Processing::Actor.find_or_create_by!(proxy_for: user)
-          Models::Processing::EntitySpecificResponsibility.find_or_create_by!(strategy_role: strategy_role, actor: user_actor, entity: entity)
+          Models::Processing::EntitySpecificResponsibility.find_or_create_by!(
+            strategy_role: strategy_role, actor: user_actor, entity: entity
+          )
           Models::Processing::StrategyResponsibility.find_or_create_by!(strategy_role: strategy_role, actor: user_actor)
 
-          expect(subject).to eq([entity])
+          expect(subject).to eq([entity, other_entity])
         end
+        xit 'bombard this with more scenarios'
         it "will be a chainable scope" do
           expect(subject).to be_a(ActiveRecord::Relation)
         end

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -85,6 +85,23 @@ module Sipity
         end
       end
 
+      context '#scope_entities_for_user_strategy_and_roles' do
+        let(:user) { User.create!(username: 'user') }
+        subject { test_repository.scope_entities_for_user_strategy_and_roles(user: user, strategy: entity.strategy, roles: role) }
+        it "will resolve to an array of entities" do
+          Models::Processing::Entity.create!(proxy_for_id: 2, proxy_for_type: 'AnEntity', strategy: strategy, strategy_state: originating_state)
+          Models::Processing::Entity.create!(proxy_for_id: 3, proxy_for_type: 'AnEntity', strategy_id: 8675309, strategy_state: originating_state)
+          user_actor = Models::Processing::Actor.find_or_create_by!(proxy_for: user)
+          Models::Processing::EntitySpecificResponsibility.find_or_create_by!(strategy_role: strategy_role, actor: user_actor, entity: entity)
+          Models::Processing::StrategyResponsibility.find_or_create_by!(strategy_role: strategy_role, actor: user_actor)
+
+          expect(subject).to eq([entity])
+        end
+        it "will be a chainable scope" do
+          expect(subject).to be_a(ActiveRecord::Relation)
+        end
+      end
+
       context '#scope_users_for_entity_and_roles' do
         subject { test_repository.scope_users_for_entity_and_roles(entity: entity, roles: role) }
         it "will resolve to an array of users" do


### PR DESCRIPTION
## Spec-ing out queries for user strategy role scope

@dfdb03056d67eec4753c898c043d87334c96676f

Spending a bit of time solving the generalized problem.

## Adding scope_entities_for_user_strategy_and_roles

@dd914de843a8a1391473afd0f775c780b9e006d7

> An ActiveRecord::Relation scope that meets the following criteria:
>
> * Processing Entities with the given processing strategy
> * Processing Entities that the user has one or more roles associated
>   with, either:
>   * Directly via the StrategyResponsibility (and Processing::Actor)
>   * Indirectly via the EntitySpecificResponsibility (and
>     Processing::Actor)
>
> @param user [User]
> @param strategy [Sipity::Models::Processing::Strategy]
> @param roles [Array<Sipity::Models::Role>]
>
> @return ActiveRecord::Relation<Models::Processing::Entity>
