### PR TITLE
Replacing > with / for Schema.org named actions

### DIFF
--- a/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
@@ -10,6 +10,6 @@
       <%= collaborator_form.input :email, as: :email %>
       <%= collaborator_form.input :responsible_for_review, as: :select %>
     <% end %>
-    <%= f.submit nil, name: "form>#{model.enrichment_type}>submit" %>
+    <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
   <% end %>
 <% end %>

--- a/app/views/sipity/controllers/work_enrichments/describe.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/describe.html.erb
@@ -23,7 +23,7 @@
     </fieldset>
 
     <%= model.work.with_action_pane('new_citation', 'panel-footer') do %>
-      <%= f.submit nil, name: "form>#{model.enrichment_type}>submit" %>
+      <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
     <% end %>
   <% end %>
 

--- a/app/views/sipity/controllers/work_event_triggers/new.html.erb
+++ b/app/views/sipity/controllers/work_event_triggers/new.html.erb
@@ -1,7 +1,7 @@
 <div itemscope itemtype="http://schema.org/CreativeWork">
   <div itemprop="potentialAction" itemscope itemtype="http://schema.org/Action">
     <link itemprop="url" href="<%= event_trigger_for_work_path(model.work, model.event_name) %>">
-    <meta itemprop="name" content="confirm>event_trigger>submit_for_review">
+    <meta itemprop="name" content="confirm/event_trigger/submit_for_review">
     <%= form_tag(event_trigger_for_work_path(model.work, model.event_name), method: :post, itemscope: true, itemprop: 'target', itemtype: "http://schema.org/EntryPoint") do %>
       <%= submit_tag("Submit", itemprop: 'name', autofocus: true) %>
     <% end %>

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -36,7 +36,7 @@
                   <span class="visuallyhidden">is <span itemprop="actionStatus"><%= action.state %></span></span>
                 </li>
               <% end %>
-            <ul>
+            </ul>
           </div>
         <% end %>
       </div>
@@ -80,11 +80,11 @@
       <div class="panel-body">
         <dl class="work attribute-listing">
           <dt class="predicate title"><%= model.human_attribute_name(:title) %></dt>
-          <dd class="value title"><%= model.title %></dt>
+          <dd class="value title"><%= model.title %></dd>
           <dt class="predicate work-type"><%= model.human_attribute_name(:work_type) %></dt>
-          <dd class="value work-type"><%= model.work_type %></dt>
+          <dd class="value work-type"><%= model.work_type %></dd>
           <dt class="predicate work_publication_strategy"><%= model.human_attribute_name(:work_publication_strategy) %></dt>
-          <dd class="value work_publication_strategy"><%= model.work_publication_strategy %></dt>
+          <dd class="value work_publication_strategy"><%= model.work_publication_strategy %></dd>
           <% if model.collaborators.any? %>
             <dt class="predicate collaborators"><%= model.human_attribute_name(:collaborators) %></dt>
             <dd class="value collaborators">

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -26,7 +26,7 @@
                       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
                     <% end %>
                   </span>
-                  <meta itemprop="name" content="todo><%= set %>><%= action.name %>">
+                  <meta itemprop="name" content="todo/<%= set %>/<%= action.name %>">
                   <span itemprop='target' itemscope itemtype="http://schema.org/EntryPoint">
                     <% button_class = is_done ? 'btn-default' : 'btn-primary' %>
                     <a itemprop="url" href="<%= action.path %>" class="btn <%= button_class %>">
@@ -47,7 +47,7 @@
           <% %w(doi citation).each do |recommendation_name| %>
             <% model.with_recommendation(recommendation_name) do |recommendation| %>
               <li itemprop="potentialAction" itemscope itemtype="http://schema.org/Action" class="todo-item">
-                <meta itemprop="name" content="recommendation><%= recommendation_name %>">
+                <meta itemprop="name" content="recommendation/<%= recommendation_name %>">
                 <span class="icon-wrapper-24">
                   <% if recommendation.done? %>
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
@@ -118,7 +118,7 @@
   <div class="row work-actions">
     <%# REVIEW: Do I want to be passing the current user to this? It seems as though there is a more elegant option. %>
     <div itemprop="hasPart" itemscope itemtype="http://schema.org/Enumeration/ProcessingState">
-      <meta itemprop="name" content="work>processing_state" />
+      <meta itemprop="name" content="work/processing_state" />
       <%# Opting to not use a meta-tag instead; If this becomes a meta-tag, then
       the underlying tests will need to change to find[:content] instead of
       find.text %>
@@ -129,7 +129,7 @@
       <ul class="action-listing">
         <% model.available_linked_actions(user: current_user, action_name: action_name).each do |action| %>
           <li itemprop="potentialAction" itemscope itemtype="http://schema.org/Action" class="action-wrapper">
-            <meta itemprop="name" content="event_trigger><%= action.name %>">
+            <meta itemprop="name" content="event_trigger/<%= action.name %>">
             <% if action.available? %>
               <div itemprop='target' itemscope itemtype="http://schema.org/EntryPoint" class="action">
                 <a itemprop="url" href="<%= action.path %>">

--- a/spec/features/sipity/enriching_a_work_spec.rb
+++ b/spec/features/sipity/enriching_a_work_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Enriching a Work', :devise do
+feature 'Enriching a Work', :devise, :feature do
   include Warden::Test::Helpers
   before do
     Sipity::SpecSupport.load_database_seeds!

--- a/spec/features/sipity/enriching_a_work_spec.rb
+++ b/spec/features/sipity/enriching_a_work_spec.rb
@@ -24,7 +24,7 @@ feature 'Enriching a Work', :devise do
     create_a_work(work_type: 'etd')
 
     on('work_page') do |the_page|
-      the_page.click_todo_item('todo>required>attach')
+      the_page.click_todo_item('todo/required/attach')
     end
 
     on('attach_page') do |the_page|
@@ -81,7 +81,7 @@ feature 'Enriching a Work', :devise do
     create_a_work(work_type: 'etd')
 
     on('work_page') do |the_page|
-      the_page.click_todo_item('todo>required>describe')
+      the_page.click_todo_item('todo/required/describe')
     end
 
     on('describe_page') do |the_page|
@@ -91,7 +91,7 @@ feature 'Enriching a Work', :devise do
     end
 
     on('work_page') do |the_page|
-      expect(the_page.todo_item_named_status_for('todo>required>describe')).to eq('done')
+      expect(the_page.todo_item_named_status_for('todo/required/describe')).to eq('done')
     end
   end
 
@@ -100,7 +100,7 @@ feature 'Enriching a Work', :devise do
     create_a_work(work_type: 'etd')
 
     on('work_page') do |the_page|
-      the_page.click_todo_item('todo>required>attach')
+      the_page.click_todo_item('todo/required/attach')
     end
 
     on('attach_page') do |the_page|
@@ -118,7 +118,7 @@ feature 'Enriching a Work', :devise do
     create_a_work(work_type: 'etd')
 
     on('work_page') do |the_page|
-      the_page.click_todo_item('todo>required>collaborators')
+      the_page.click_todo_item('todo/required/collaborators')
     end
 
     on('collaborators_page') do |the_page|

--- a/spec/features/sipity/trigger_work_state_change_spec.rb
+++ b/spec/features/sipity/trigger_work_state_change_spec.rb
@@ -29,12 +29,12 @@ feature "Trigger Work State Change", :devise do
       on('work_page') do |the_page|
         expect(the_page.processing_state).to eq('new')
         # Because there are no required steps; I can continue
-        expect { the_page.find_named_object('event_trigger>submit_for_review').find('[itemprop="url"]') }.
+        expect { the_page.find_named_object('event_trigger/submit_for_review').find('[itemprop="url"]') }.
           to raise_error(Capybara::ElementNotFound)
       end
 
       on('work_page') do |the_page|
-        the_page.click_todo_item('todo>required>describe')
+        the_page.click_todo_item('todo/required/describe')
       end
 
       on('describe_page') do |the_page|
@@ -46,17 +46,17 @@ feature "Trigger Work State Change", :devise do
       on('work_page') do |the_page|
         expect(the_page.processing_state).to eq('new')
         # Because there are no required steps; I can continue
-        the_page.take_named_action('event_trigger>submit_for_review')
+        the_page.take_named_action('event_trigger/submit_for_review')
       end
 
       on('event_trigger_page') do |the_page|
-        the_page.take_named_action('confirm>event_trigger>submit_for_review')
+        the_page.take_named_action('confirm/event_trigger/submit_for_review')
       end
 
       on('work_page') do |the_page|
         # The state was advanced
         expect(the_page.processing_state).to eq('under_review')
-        expect { the_page.find_named_object('event_trigger>submit_for_review') }.
+        expect { the_page.find_named_object('event_trigger/submit_for_review') }.
           to raise_error(Capybara::ElementNotFound)
       end
     end

--- a/spec/features/sipity/trigger_work_state_change_spec.rb
+++ b/spec/features/sipity/trigger_work_state_change_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Trigger Work State Change", :devise do
+feature "Trigger Work State Change", :devise, :feature do
   include Warden::Test::Helpers
   before do
     Sipity::SpecSupport.load_database_seeds!(seeds_path: 'spec/fixtures/seeds/trigger_work_state_change.rb')

--- a/spec/features/visitors/about_page_spec.rb
+++ b/spec/features/visitors/about_page_spec.rb
@@ -2,7 +2,7 @@
 #   As a visitor
 #   I want to visit an 'about' page
 #   So I can learn more about the website
-feature 'About page' do
+feature 'About page', :feature do
 
   # Scenario: Visit the 'about' page
   #   Given I am a visitor

--- a/spec/features/visitors/home_page_spec.rb
+++ b/spec/features/visitors/home_page_spec.rb
@@ -2,7 +2,7 @@
 #   As a visitor
 #   I want to visit a home page
 #   So I can learn more about the website
-feature 'Home page' do
+feature 'Home page', :feature do
 
   # Scenario: Visit the home page
   #   Given I am a visitor

--- a/spec/features/visitors/navigation_spec.rb
+++ b/spec/features/visitors/navigation_spec.rb
@@ -2,7 +2,7 @@
 #   As a visitor
 #   I want to see navigation links
 #   So I can find home, sign in, or sign up
-feature 'Navigation links', :devise do
+feature 'Navigation links', :devise, :feature do
 
   # Scenario: View navigation links
   #   Given I am a visitor

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, js:  true) do
+  config.before(:each, feature: true) do
     DatabaseCleaner.strategy = :truncation
   end
 

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -90,11 +90,11 @@ module SitePrism
       end
 
       def click_recommendation(recommendation)
-        take_action_on(find_named_object("recommendation>#{recommendation.downcase}"))
+        take_action_on(find_named_object("recommendation/#{recommendation.downcase}"))
       end
 
       def click_edit
-        take_action_on(find_named_object('event_trigger>edit'))
+        take_action_on(find_named_object('event_trigger/edit'))
       end
 
       def click_todo_item(name)
@@ -106,7 +106,7 @@ module SitePrism
       end
 
       def processing_state
-        find_named_object('work>processing_state', itemprop: 'hasPart').find("[itemprop='description']").text
+        find_named_object('work/processing_state', itemprop: 'hasPart').find("[itemprop='description']").text
       end
     end
 
@@ -117,7 +117,7 @@ module SitePrism
     class DescribePage < SitePrism::Page
       PARAM_NAME_CONTAINER = 'work'.freeze
       element :input_abstract, "form [name='#{PARAM_NAME_CONTAINER}[abstract]']"
-      element :submit_button, "form [name='form>describe>submit'][type='submit']"
+      element :submit_button, "form [name='form/describe/submit'][type='submit']"
 
       def fill_in(predicate, with: nil)
         find("form [name='#{PARAM_NAME_CONTAINER}[#{predicate}]']").set(with)
@@ -126,7 +126,7 @@ module SitePrism
 
     class CollaboratorsPage < SitePrism::Page
       PARAM_NAME_CONTAINER = 'work'.freeze
-      element :submit_button, "form [name='form>collaborators>submit'][type='submit']"
+      element :submit_button, "form [name='form/collaborators/submit'][type='submit']"
     end
 
     class AttachPage < SitePrism::Page


### PR DESCRIPTION
As I was working with capybara-accessible, I encountered the problem
where the HTML document was being sent off to Google's accessibility
validation service and would come back altered.

The service returned an HTML document that converted the META content
"todo>required" to "todo&gt;required". As I want to be able to run
these accessibility tests, this is a required change.

https://github.com/Casecommons/capybara-accessible