### PR TITLE
Adding ability to conditionally run accessibility

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -38,6 +38,7 @@ MethodLength:
     - 'app/repositories/sipity/queries/enrichment_queries.rb'
     - 'app/repositories/sipity/queries/processing_queries.rb'
     - 'app/state_machines/sipity/state_machines/state_diagram.rb'
+    - 'spec/support/site_prism_support.rb'
 
 LineLength:
   Description: 'Limit lines to 140 characters.'
@@ -198,6 +199,7 @@ Metrics/PerceivedComplexity:
      - app/conversions/**/*.rb
      - app/state_machines/sipity/state_machines/state_diagram.rb
      - app/repositories/sipity/queries/processing_queries.rb
+     - spec/support/site_prism_support.rb
 
 Metrics/AbcSize:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ group :development do
   gem 'terminal-notifier'
   gem 'terminal-notifier-guard', '~> 1.6.4'
   gem 'pry-rails'
-  gem 'pry-rescue'
   gem 'pry-byebug'
   gem 'letter_opener'
 end
@@ -65,11 +64,15 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rspec-its'
   gem 'coveralls', require: false
+  gem 'pry-rescue', require: false
+  gem 'pry-stack_explorer', require: false
 end
 
 group :test do
   gem 'rspec-given'
   gem 'capybara'
+  gem "capybara-accessible", require: false
+  gem "poltergeist"
   gem 'database_cleaner'
   gem 'launchy'
   gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,10 +94,13 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-accessible (0.2.1)
+      capybara (~> 2.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     childprocess (0.5.5)
       ffi (~> 1.0, >= 1.0.11)
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -231,6 +234,11 @@ GEM
     parser (2.2.0.1)
       ast (>= 1.1, < 3.0)
       slop (~> 3.4, >= 3.4.5)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyamorous (1.1.0)
       activerecord (>= 3.0)
     powerpack (0.0.9)
@@ -246,6 +254,9 @@ GEM
     pry-rescue (1.4.1)
       interception (>= 0.5)
       pry
+    pry-stack_explorer (0.4.9.1)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     pundit (0.3.0)
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
@@ -411,6 +422,9 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket (1.2.1)
+    websocket-driver (0.5.1)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
@@ -428,6 +442,7 @@ DEPENDENCIES
   capistrano-rails-console
   capistrano-rvm (~> 0.1.1)
   capybara
+  capybara-accessible
   coffee-rails (~> 4.0.0)
   coveralls
   database_cleaner
@@ -454,9 +469,11 @@ DEPENDENCIES
   micromachine!
   mysql2
   net-ldap
+  poltergeist
   pry-byebug
   pry-rails
   pry-rescue
+  pry-stack_explorer
   pundit
   quiet_assets
   railroady

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,13 @@ namespace :spec do
     ENV['SPEC_OPTS'] ||= "--profile 5"
     Rake::Task['spec:all'].invoke
   end
+
+  desc "Run all features with accessibility checks"
+  RSpec::Core::RakeTask.new(:accessible) do |t|
+    ENV['ACCESSIBLE'] = 'true'
+    t.pattern = './spec/features/**/*_spec.rb'
+  end
+
 end
 
 Rake::Task["default"].clear

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,1 +1,19 @@
+require 'capybara/poltergeist'
+
+if ENV['ACCESSIBLE']
+  require 'capybara/accessible'
+
+  RSpec.configure do |config|
+    config.around(:each, inaccessible: true) do |example|
+      Capybara::Accessible.skip_audit { example.run }
+    end
+  end
+
+  Capybara.default_driver = :accessible_poltergeist
+  Capybara.javascript_driver = :accessible_poltergeist
+else
+  Capybara.default_driver = :rack_test
+end
+
+Capybara.ignore_hidden_elements = false
 Capybara.asset_host = 'http://localhost:3000'

--- a/spec/support/site_prism_support.rb
+++ b/spec/support/site_prism_support.rb
@@ -23,33 +23,42 @@ module SitePrism
 
       def find_named_object(name, itemprop: 'potentialAction')
         object_name_node = find("[itemprop='#{itemprop}'] [itemprop='name'][content='#{name.downcase}']")
-        # Because Capybara does not support an ancestors/parents find method, I
-        # need to dive into the native object.
-
+        # Because Capybara does not support an ancestors/parents find method (at
+        # least as expected), I need to dive into the native object.
         case object_name_node.native
         when Nokogiri::XML::Element
-          # Because Capybara does not support an ancestors find method, I need
-          # to dive into the native object (i.e. a Nokogiri node). The end goal
-          # is to find the named object element and thus be able to retrieve any
-          # of the underlying attributes.
-          parent_ng_node = object_name_node.native.ancestors('[itemscope]').first
-          find(parent_ng_node.css_path)
+          find_named_object_for_nokogiri(object_name_node.native)
         when Capybara::Poltergeist::Node
-          # This is a Poltergeist node. The end goal is to find the named object
-          # element and thus be able to retrieve any of the underlying
-          # attributes.
-          parent_native_node = object_name_node.native.parents.find('[itemscope]').first
-          # Smooshing this back into a Capybara::Node, because we have a
-          # Poltergeist node.
-          Capybara::Node::Element.new(
-            object_name_node.session,
-            parent_native_node,
-            parent_native_node.parents.first,
-            self
-          )
+          find_named_object_for_poltergeist(object_name_node.native)
         else
           fail "Unexpected #native value for #{object_name_node}"
         end
+      end
+
+      private
+
+      def find_named_object_for_nokogiri(nokogiri_node)
+        # Because Capybara does not support an ancestors find method, I need
+        # to dive into the native object (i.e. a Nokogiri node). The end goal
+        # is to find the named object element and thus be able to retrieve any
+        # of the underlying attributes.
+        parent_ng_node = nokogiri_node.ancestors('[itemscope]').first
+        find(parent_ng_node.css_path)
+      end
+
+      def find_named_object_for_poltergeist(poltergeist_node)
+        # This is a Poltergeist node. The end goal is to find the named object
+        # element and thus be able to retrieve any of the underlying
+        # attributes.
+        parent_native_node = poltergeist_node.parents.find('[itemscope]').first
+        # Smooshing this back into a Capybara::Node, because we have a
+        # Poltergeist node.
+        Capybara::Node::Element.new(
+          object_name_node.session,
+          parent_native_node,
+          parent_native_node.parents.first,
+          self
+        )
       end
     end
 


### PR DESCRIPTION
In an effort to ensure accessibility, I'm looking to automate that
behavior using the capybara-accessible gem. Out of the box, these
tests are slower (as they are using Poltergeist to interact via a
headless browser instead of with an HTML page).

I needed to make changes to allow for hidden elements to be found.
I also wanted an option to run choose whether to run with or without
accessibility.