### PR TITLE
Refactoring policy questions

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_processing_action_name.rb
+++ b/app/conversions/sipity/conversions/convert_to_processing_action_name.rb
@@ -1,0 +1,46 @@
+module Sipity
+  module Conversions
+    # Exposes a conversion method to take an input and transform it into a
+    # a processing action name.
+    #
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToProcessingActionName
+      RESOURCEFUL_ACTION_MAP = {
+        'update' => 'edit',
+        'create' => 'new'
+      }.freeze
+
+      # A convenience method so that you don't need to include the conversion
+      # module in your base class.
+      def self.call(input)
+        convert_to_processing_action_name(input)
+      end
+
+      # Does its best to convert the input into a processing action name.
+      #
+      # This is necessary as sometimes we will have paired controller action
+      # name (i.e. edit/update) that represent the same permission concept.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return String
+      # @see Sipity::Models::Processing::StrategyAction#name
+      def convert_to_processing_action_name(input)
+        return input.to_processing_action_name if input.respond_to?(:to_processing_action_name)
+        case input
+        when String, Symbol
+          input_without_punctuation = input.to_s.sub(/[\?\!]\Z/, '')
+          RESOURCEFUL_ACTION_MAP.fetch(input_without_punctuation, input_without_punctuation)
+        when Models::Processing::StrategyAction
+          input.name
+        else
+          fail Exceptions::ProcessingActionNameConversionError, input
+        end
+      end
+
+      module_function :convert_to_processing_action_name
+      private_class_method :convert_to_processing_action_name
+      private :convert_to_processing_action_name
+    end
+  end
+end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -94,6 +94,11 @@ module Sipity
       self.conversion_target = 'Models::Processing::StrategyAction'
     end
 
+    # Unable to convert the given object into a processing strategy action
+    class ProcessingActionNameConversionError < ProcessingConversionError
+      self.conversion_target = 'Models::Processing::StrategyAction#name'
+    end
+
     # As you are looking up something by name, within a given container.
     class ConceptNotFoundError < RuntimeError
       def initialize(name:, container:)

--- a/app/models/sipity/models/processing/strategy_action.rb
+++ b/app/models/sipity/models/processing/strategy_action.rb
@@ -44,6 +44,11 @@ module Sipity
 
         RESOURCEFUL_ACTION_NAMES = %w(new create show edit update destroy).freeze
 
+        include Conversions::ConvertToProcessingActionName
+        def name=(value)
+          super(convert_to_processing_action_name(value))
+        end
+
         private
 
         def set_action_type

--- a/app/policies/sipity/policies/processing/work_processing_policy.rb
+++ b/app/policies/sipity/policies/processing/work_processing_policy.rb
@@ -8,6 +8,9 @@ module Sipity
       #
       # @see [Pundit gem](http://rubygems.org/gems/pundit) for more on object
       #   oriented authorizaiton.
+      #
+      # @note This class implements method_missing in an attempt to splice in
+      #   this policy into Sipity's interactions.
       class WorkProcessingPolicy
         def initialize(user, work, repository: default_repository)
           @user = user
@@ -25,6 +28,10 @@ module Sipity
         private :repository
 
         private
+
+        def method_missing(method_name, *)
+          authorize?(method_name)
+        end
 
         def default_repository
           QueryRepository.new

--- a/app/policies/sipity/policies/processing/work_processing_policy.rb
+++ b/app/policies/sipity/policies/processing/work_processing_policy.rb
@@ -29,6 +29,7 @@ module Sipity
 
         private
 
+        # Means of preserving interface defined by Sipity::Policies::WorkPolicy
         def method_missing(method_name, *)
           authorize?(method_name)
         end

--- a/app/policies/sipity/policies/processing/work_processing_policy.rb
+++ b/app/policies/sipity/policies/processing/work_processing_policy.rb
@@ -1,0 +1,35 @@
+module Sipity
+  module Policies
+    module Processing
+      # Responsible for enforcing access to the processing of a given Sipity::Work
+      #
+      # This class answers can I take the given action based on the user and
+      # the work.
+      #
+      # @see [Pundit gem](http://rubygems.org/gems/pundit) for more on object
+      #   oriented authorizaiton.
+      class WorkProcessingPolicy
+        def initialize(user, work, repository: default_repository)
+          @user = user
+          @work = work
+          @repository = repository
+        end
+
+        attr_reader :user, :work
+
+        def authorize?(action)
+          repository.authorized_for_processing?(user: user, entity: work, action: action)
+        end
+
+        attr_reader :repository
+        private :repository
+
+        private
+
+        def default_repository
+          QueryRepository.new
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/sipity/queries/enrichment_queries.rb
+++ b/app/repositories/sipity/queries/enrichment_queries.rb
@@ -4,23 +4,10 @@ module Sipity
   module Queries
     # Queries
     module EnrichmentQueries
-      # This is a refactoring step. Remove once processing queries are spliced
-      # in.
-      include Queries::ProcessingQueries
-
       def build_enrichment_form(attributes = {})
         enrichment_type = attributes.fetch(:enrichment_type)
         builder = Forms::WorkEnrichments.find_enrichment_form_builder(enrichment_type: enrichment_type)
         builder.new(attributes)
-      end
-
-      def are_all_of_the_required_todo_items_done_for_work?(work:)
-        # TODO: Convert this into a single query instead of three queries.
-        (
-          scope_strategy_actions_for_current_state(entity: work).pluck(:id) -
-          scope_strategy_actions_with_completed_prerequisites(entity: work).pluck(:id) -
-          scope_strategy_actions_without_prerequisites(entity: work).pluck(:id)
-        ).empty?
       end
     end
   end

--- a/app/repositories/sipity/queries/permission_queries.rb
+++ b/app/repositories/sipity/queries/permission_queries.rb
@@ -2,7 +2,6 @@ module Sipity
   module Queries
     # Queries
     module PermissionQueries
-      include ProcessingQueries
       def emails_for_associated_users(acting_as:, entity:)
         # TODO: Remove the singleton query method behavior. Its ridiculous! It
         #   infects everything. This is a major code stink.
@@ -12,7 +11,7 @@ module Sipity
       public :emails_for_associated_users
 
       def can_the_user_act_on_the_entity?(user:, acting_as:, entity:)
-        scope_users_for_entity_and_roles(entity: entity, roles: acting_as).
+        Queries::ProcessingQueries.scope_users_for_entity_and_roles(entity: entity, roles: acting_as).
           where(id: user.id).any?
       end
     end

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -18,10 +18,21 @@ module Sipity
     #   public methods because they have been tested in isolation and are used
     #   to help compose the `@api public` methods.
     module ProcessingQueries
-      include Conversions::ConvertToProcessingEntity
-      include Conversions::ConvertToPolymorphicType
-      include Conversions::ConvertToRole
-      include Conversions::ConvertToProcessingActor
+
+      def authorized_for_processing?(user:, entity:, action:)
+
+      end
+
+      # @api public
+      def are_all_of_the_required_todo_items_done_for_work?(work:)
+        # TODO: Convert this into a single query instead of three queries.
+        (
+          scope_strategy_actions_for_current_state(entity: work).pluck(:id) -
+          scope_strategy_actions_with_completed_prerequisites(entity: work).pluck(:id) -
+          scope_strategy_actions_without_prerequisites(entity: work).pluck(:id)
+        ).empty?
+      end
+
       # @api public
       #
       # An ActiveRecord::Relation scope that meets the following criteria:
@@ -94,8 +105,8 @@ module Sipity
         memb_table = Models::GroupMembership.arel_table
         actor_table = Models::Processing::Actor.arel_table
 
-        group_polymorphic_type = convert_to_polymorphic_type(Models::Group)
-        user_polymorphic_type = convert_to_polymorphic_type(user)
+        group_polymorphic_type = Conversions::ConvertToPolymorphicType.call(Models::Group)
+        user_polymorphic_type = Conversions::ConvertToPolymorphicType.call(user)
 
         user_constraints = actor_table[:proxy_for_type].eq(user_polymorphic_type).and(actor_table[:proxy_for_id].eq(user.id))
 
@@ -132,7 +143,7 @@ module Sipity
       #
       # @return ActiveRecord::Relation<proxy_for_types>
       def scope_proxied_objects_for_the_user_and_proxy_for_type(user:, proxy_for_type:)
-        proxy_for_type = convert_to_polymorphic_type(proxy_for_type)
+        proxy_for_type = Conversions::ConvertToPolymorphicType.call(proxy_for_type)
         processing_entities_scope = scope_processing_entities_for_the_user_and_proxy_for_type(user: user, proxy_for_type: proxy_for_type)
 
         proxy_for_type.where(
@@ -165,7 +176,7 @@ module Sipity
       #
       # @return ActiveRecord::Relation<Models::Processing::Entity>
       def scope_processing_entities_for_the_user_and_proxy_for_type(user:, proxy_for_type:)
-        proxy_for_type = convert_to_polymorphic_type(proxy_for_type)
+        proxy_for_type = Conversions::ConvertToPolymorphicType.call(proxy_for_type)
 
         entities = Models::Processing::Entity.arel_table
         strategy_state_actions = Models::Processing::StrategyStateAction.arel_table
@@ -296,7 +307,7 @@ module Sipity
         actor_table = Models::Processing::Actor.arel_table
         memb_table = Models::GroupMembership.arel_table
 
-        actor_ids = actors.map { |actor| convert_to_processing_actor(actor).id }
+        actor_ids = actors.map { |actor| Conversions::ConvertToProcessingActor.call(actor).id }
 
         group_polymorphic_type = Conversions::ConvertToPolymorphicType.call(Models::Group)
         user_polymorphic_type = Conversions::ConvertToPolymorphicType.call(User)
@@ -330,7 +341,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyRole>
       def scope_processing_strategy_roles_for_user_and_entity(user:, entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         strategy_scope = scope_processing_strategy_roles_for_user_and_strategy(user: user, strategy: entity.strategy)
 
         entity_specific_scope = scope_processing_strategy_roles_for_user_and_entity_specific(user: user, entity: entity)
@@ -379,7 +390,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyRole>
       def scope_processing_strategy_roles_for_user_and_entity_specific(user:, entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         actor_scope = scope_processing_actors_for(user: user)
         specific_resp_table = Models::Processing::EntitySpecificResponsibility.arel_table
         strategy_role_table = Models::Processing::StrategyRole.arel_table
@@ -408,7 +419,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyStateAction>
       def scope_permitted_entity_strategy_state_actions(user:, entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         strategy_state_actions = Models::Processing::StrategyStateAction
         permissions = Models::Processing::StrategyStateActionPermission
         role_scope = scope_processing_strategy_roles_for_user_and_entity(user: user, entity: entity)
@@ -439,7 +450,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyAction>
       def scope_strategy_actions_with_completed_prerequisites(entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         actions = Models::Processing::StrategyAction
         action_prereqs = Models::Processing::StrategyActionPrerequisite
         actions_that_occurred = scope_statetegy_actions_that_have_occurred(entity: entity)
@@ -465,7 +476,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyAction>
       def scope_strategy_actions_without_prerequisites(entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         actions = Models::Processing::StrategyAction
         action_prereqs = Models::Processing::StrategyActionPrerequisite
 
@@ -491,7 +502,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyAction>
       def scope_strategy_actions_for_current_state(entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         actions = Models::Processing::StrategyAction
         state_actions_table = Models::Processing::StrategyStateAction.arel_table
         actions.where(
@@ -513,7 +524,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyAction>
       def scope_strategy_actions_that_are_prerequisites(entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         actions = Models::Processing::StrategyAction
         prerequisite_actions = Models::Processing::StrategyActionPrerequisite.arel_table
         actions.where(
@@ -531,7 +542,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyAction>
       def scope_statetegy_actions_that_have_occurred(entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         actions = Models::Processing::StrategyAction
         register = Models::Processing::EntityActionRegister
 
@@ -558,7 +569,7 @@ module Sipity
       # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
       # @return ActiveRecord::Relation<Models::Processing::StrategyAction>
       def scope_strategy_actions_available_for_current_state(entity:)
-        entity = convert_to_processing_entity(entity)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
         strategy_actions_without_prerequisites = scope_strategy_actions_without_prerequisites(entity: entity)
         strategy_actions_with_completed_prerequisites = scope_strategy_actions_with_completed_prerequisites(entity: entity)
         strategy_actions_for_current_state = scope_strategy_actions_for_current_state(entity: entity)

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -18,9 +18,19 @@ module Sipity
     #   public methods because they have been tested in isolation and are used
     #   to help compose the `@api public` methods.
     module ProcessingQueries
-
+      # @api public
+      #
+      # Is the user authorized to take the processing action on the given
+      # entity?
+      #
+      # @param user [User]
+      # @param entity an object that can be converted into a Sipity::Models::Processing::Entity
+      # @param action an object that can be converted into a Sipity::Models::Processing::StrategyAction#name
+      # @return Boolean
       def authorized_for_processing?(user:, entity:, action:)
-
+        action_name = Conversions::ConvertToProcessingActionName.call(action)
+        scope_permitted_strategy_actions_available_for_current_state(user: user, entity: entity).
+          where(Models::Processing::StrategyAction.arel_table[:name].eq(action_name)).count > 0
       end
 
       # @api public

--- a/app/repositories/sipity/query_repository.rb
+++ b/app/repositories/sipity/query_repository.rb
@@ -15,5 +15,6 @@ module Sipity
     include Queries::PermissionQueries
     include Queries::EnrichmentQueries
     include Queries::EventTriggerQueries
+    include Queries::ProcessingQueries
   end
 end

--- a/spec/conversions/sipity/conversions/convert_to_processing_action_name_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_action_name_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToProcessingActionName do
+      include ::Sipity::Conversions::ConvertToProcessingActionName
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          expect(described_class.call(:show)).to be_a(String)
+        end
+      end
+
+      context '.convert_to_processing_action_name' do
+        it 'will be private' do
+          object = 1234
+          expect { described_class.convert_to_processing_action_name(object) }.
+            to raise_error(NoMethodError, /private method `convert_to_processing_action_name'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_processing_action_name' do
+
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_processing_action_name)
+        end
+
+        [
+          [:show, 'show'],
+          [:show?, 'show'],
+          [:new?, 'new'],
+          [:new, 'new'],
+          [:create?, 'new'],
+          [:create, 'new'],
+          [:edit?, 'edit'],
+          [:edit, 'edit'],
+          [:update?, 'edit'],
+          [:update, 'edit'],
+          [:submit, 'submit'],
+          [:submit?, 'submit'],
+          [:attach, 'attach'],
+          [Models::Processing::StrategyAction.new(name: 'hello'), 'hello']
+        ].each_with_index do |(original, expected), index|
+          it "will convert #{original.inspect} to #{expected.inspect} (scenario ##{index})" do
+            expect(convert_to_processing_action_name(original)).to eq(expected)
+          end
+        end
+
+        it 'will raise an exception if it is not processible' do
+          object = double('Bad Wolf')
+          expect { convert_to_processing_action_name(object) }.to raise_error(Exceptions::ProcessingActionNameConversionError)
+        end
+
+        it 'will leverage a short-circuit #to_processing_action_name' do
+          object = double(to_processing_action_name: 'bob')
+          expect(convert_to_processing_action_name(object)).to eq('bob')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/sipity/models/processing/strategy_action_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_spec.rb
@@ -19,6 +19,12 @@ module Sipity
           expect { subject.action_type = '__incorrect_type__' }.to raise_error(ArgumentError)
         end
 
+        context '#name' do
+          it 'will convert the action name on write' do
+            expect(described_class.new(name: :create?).name).to eq('new')
+          end
+        end
+
         context 'set action type' do
           it 'will set the action type if none is specified' do
             expect(subject.action_type).to be_present

--- a/spec/policies/sipity/policies/processing/work_processing_policy_spec.rb
+++ b/spec/policies/sipity/policies/processing/work_processing_policy_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module Sipity
+  module Policies
+    module Processing
+      RSpec.describe WorkProcessingPolicy do
+        let(:user) { User.new(id: '1') }
+        let(:work) { Models::Work.new(id: '2') }
+        let(:repository) { double('Repository') }
+        subject { described_class.new(user, work, repository: repository) }
+        it 'will query the underlying processing system for answers by :action_name' do
+          expect(repository).to receive(:authorized_for_processing?).with(user: user, entity: work, action: :show).and_return(true)
+          expect(subject.authorize?(:show)).to be_truthy
+        end
+
+        context 'default configuration' do
+          subject { described_class.new(user, work) }
+          its(:repository) { should respond_to(:authorized_for_processing?) }
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/sipity/policies/processing/work_processing_policy_spec.rb
+++ b/spec/policies/sipity/policies/processing/work_processing_policy_spec.rb
@@ -8,6 +8,12 @@ module Sipity
         let(:work) { Models::Work.new(id: '2') }
         let(:repository) { double('Repository') }
         subject { described_class.new(user, work, repository: repository) }
+
+        it 'will capture method missing and attempt an authorize?' do
+          expect(repository).to receive(:authorized_for_processing?).with(user: user, entity: work, action: :show?).and_return(true)
+          expect(subject.show?).to be_truthy
+        end
+
         it 'will query the underlying processing system for answers by :action_name' do
           expect(repository).to receive(:authorized_for_processing?).with(user: user, entity: work, action: :show).and_return(true)
           expect(subject.authorize?(:show)).to be_truthy

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -325,6 +325,13 @@ module Sipity
         end
       end
 
+      context '#authorized_for_processing?' do
+        it 'will return a boolean based on underlying interactions' do
+          expect(test_repository).to receive(:scope_permitted_strategy_actions_available_for_current_state).and_call_original
+          expect(test_repository.authorized_for_processing?(user: user, entity: entity, action: :show)).to eq(false)
+        end
+      end
+
       context '#scope_permitted_strategy_actions_available_for_current_state' do
         subject { test_repository.scope_permitted_strategy_actions_available_for_current_state(entity: entity, user: user) }
         let(:guarded_action) { Models::Processing::StrategyAction.find_or_create_by!(strategy: strategy, name: 'with_prereq') }

--- a/spec/repositories/sipity/query_repository_spec.rb
+++ b/spec/repositories/sipity/query_repository_spec.rb
@@ -15,7 +15,7 @@ module Sipity
         Sipity::QueryRepository.included_modules.select { |mod| mod.to_s =~ /\ASipity::/ }
       end
 
-      xit 'will have unique method names for its mixed in modules' do
+      it 'will have unique method names for its mixed in modules' do
         # NOTE: If you are making use of module mixin sequencing and the `super`
         #   method, this spec is going to fail. And if this spec fails, you
         #   broke the build. If you need to use `super` amongst the repository


### PR DESCRIPTION
## Restoring repository tests for duplication

@47436b36252f17d69a719d73d195921c582968a3

Moving methods around for organizational purposes. Restoring the test
to verify that repositories do not have colliding method definitions.

## Adding conversion for ProcessingActionName

@3c6f46d8aa241adb6104a82e9034c15555f789d6

Given that I am crossing boundaries between processing and the
controllers, and that I have cases of :update? when the corresponding
action name is 'edit', I want to have a codified location that
explains this mapping.

## Normalizing StrategyAction#name

@dd45f6d49c99b92dd2884695ae39de03bfa4a615

I want the data to be written in consistent measures so that
associated controller actions pairs (i.e. new/create and edit/update)
are treated similarly.

## Adding authorized_for_processing? behavior

@178ab9e75ff89e79577319618de36fea250c371c

This query leverages underlying behavior but tidies it up to be a
boolean response.

## Adding a WorkProcessingPolicy

@6599d55ac356652b1a0ee6c50d0df7c3349ce1e7

This processing policy quickly dives into the processing query
repository.

## Preserving external interface for WorkPolicy

@c94ef9f906707ebdd8ec231b4b7e49e05d59c484

I want to preserve the external interface of the work policy so that
I can replace its behavior going forward.
