### PR TITLE
Adding advisor signoff form

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_processing_action.rb
+++ b/app/conversions/sipity/conversions/convert_to_processing_action.rb
@@ -1,0 +1,26 @@
+module Sipity
+  module Conversions
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToProcessingAction
+      def self.call(object, scope:)
+        convert_to_processing_action(object, scope: scope)
+      end
+
+      def convert_to_processing_action(object, scope:)
+        if object.is_a?(Models::Processing::StrategyAction)
+          strategy_id = ConvertToProcessingStrategyId.call(scope)
+          return object if object.strategy_id == strategy_id
+        elsif object.is_a?(String) || object.is_a?(Symbol)
+          strategy_id = ConvertToProcessingStrategyId.call(scope)
+          strategy_action = Models::Processing::StrategyAction.find_by(strategy_id: strategy_id, name: object.to_s)
+          return strategy_action if strategy_action.present?
+        end
+        fail Exceptions::ProcessingStrategyActionConversionError, { scope: scope, object: object }.inspect
+      end
+
+      module_function :convert_to_processing_action
+      private_class_method :convert_to_processing_action
+      private :convert_to_processing_action
+    end
+  end
+end

--- a/app/conversions/sipity/conversions/convert_to_processing_strategy_id.rb
+++ b/app/conversions/sipity/conversions/convert_to_processing_strategy_id.rb
@@ -1,0 +1,37 @@
+module Sipity
+  module Conversions
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToProcessingStrategyId
+      PERMANENT_URI_FORMAT = "https://change.me/show/%s".freeze
+
+      # A convenience method so that you don't need to include the conversion
+      # module in your base class.
+      def self.call(input)
+        convert_to_processing_strategy_id(input)
+      end
+
+      # Does its best to convert the input into a processing stategy_id.
+      #
+      # @note Why not the ProcessingStrategy? I'm thinking about reducing the
+      #   number of queries; I also understand that I will likely have a
+      #   Processing::Entity instead of a Strategy
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Integer
+      def convert_to_processing_strategy_id(input)
+        case input
+        when Models::Processing::Strategy then return input.id
+        when Integer then return input
+        when String then return input.to_i
+        end
+        return input.strategy_id if input.respond_to?(:strategy_id)
+        fail Exceptions::ProcessingStrategyIdConversionError, input
+      end
+
+      module_function :convert_to_processing_strategy_id
+      private_class_method :convert_to_processing_strategy_id
+      private :convert_to_processing_strategy_id
+    end
+  end
+end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -89,6 +89,11 @@ module Sipity
       self.conversion_target = 'Models::Processing::StrategyState'
     end
 
+    # Unable to convert the given object into a processing strategy id
+    class ProcessingStrategyIdConversionError < ProcessingConversionError
+      self.conversion_target = 'Models::Processing::Strategy#id'
+    end
+
     # Unable to convert the given object into a processing strategy action
     class ProcessingStrategyActionConversionError < ProcessingConversionError
       self.conversion_target = 'Models::Processing::StrategyAction'

--- a/app/forms/sipity/forms/etd/advisor_signoff_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_signoff_form.rb
@@ -1,0 +1,44 @@
+module Sipity
+  module Forms
+    module Etd
+      # Responsible for submitting the associated entity to the advisor
+      # for signoff.
+      class AdvisorSignoffForm < ProcessingActionForm
+        def initialize(attributes = {})
+          super
+          self.action = attributes.fetch(:processing_action_name) { default_processing_action_name }
+          @signoff_service = attributes.fetch(:signoff_service) { default_signoff_service }
+        end
+
+        attr_reader :action, :signoff_service
+
+        def processing_action_name
+          action.name
+        end
+
+        private
+
+        private :signoff_service
+        def default_signoff_service
+          Services::AdvisorSignsOff
+        end
+
+        def save(repository:, requested_by:)
+          super do
+            signoff_service.call(form: self, requested_by: requested_by, repository: repository)
+          end
+        end
+
+        def enrichment_type
+          self.class.to_s.demodulize.underscore.sub(/_form\Z/i, '')
+        end
+        alias_method :default_processing_action_name, :enrichment_type
+
+        include Conversions::ConvertToProcessingAction
+        def action=(value)
+          @action = convert_to_processing_action(value, scope: to_processing_entity)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/etd/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/etd/submit_for_review_form.rb
@@ -34,20 +34,9 @@ module Sipity
         end
         alias_method :default_processing_action_name, :enrichment_type
 
+        include Conversions::ConvertToProcessingAction
         def action=(value)
-          @action = convert_to_processing_action(value)
-        end
-
-        # HACK: In a perfect world I would not need to convert the action;
-        # However to comply with the previous interface, this needs to be done.work_event_triggers_spec.rb
-        def convert_to_processing_action(object)
-          if object.is_a?(Models::Processing::StrategyAction)
-            return object if object.strategy_id == strategy_id
-          else
-            strategy_action = Models::Processing::StrategyAction.find_by(strategy_id: strategy_id, name: object.to_s)
-            return strategy_action if strategy_action.present?
-          end
-          fail Exceptions::ProcessingStrategyActionConversionError, { strategy_id: strategy_id, name: object }.inspect
+          @action = convert_to_processing_action(value, scope: to_processing_entity)
         end
       end
     end

--- a/app/forms/sipity/forms/processing_action_form.rb
+++ b/app/forms/sipity/forms/processing_action_form.rb
@@ -43,9 +43,9 @@ module Sipity
       private
 
       def save(repository:, requested_by:)
-        yield if block_given?
         repository.register_action_taken_on_entity(work: work, enrichment_type: enrichment_type, requested_by: requested_by)
         repository.log_event!(entity: work, user: requested_by, event_name: event_name)
+        yield if block_given?
         work
       end
 

--- a/app/repositories/sipity/queries/collaborator_queries.rb
+++ b/app/repositories/sipity/queries/collaborator_queries.rb
@@ -27,6 +27,15 @@ module Sipity
         Models::Collaborator.includes(:work).where(work: work, responsible_for_review: true)
       end
 
+      # @api public
+      #
+      # @see #work_collaborating_users_responsible_for_review
+      #
+      # @return Array of usernames
+      def usernames_of_those_that_are_collaborating_and_responsible_for_review(work:)
+        work_collaborating_users_responsible_for_review(work: work).pluck(:username)
+      end
+
       def work_collaborating_users_responsible_for_review(work:)
         collaborators_scope = work_collaborators_responsible_for_review(work: work)
         User.where(

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -64,6 +64,7 @@ module Sipity
         user_polymorphic_type = Conversions::ConvertToPolymorphicType.call(User)
         group_polymorphic_type = Conversions::ConvertToPolymorphicType.call(Sipity::Models::Group)
         entity = Conversions::ConvertToProcessingEntity.call(entity)
+        action = Conversions::ConvertToProcessingAction.call(action, scope: entity)
 
         action_registers_subquery_builder = lambda do |poly_type|
           actors.project(actors[:proxy_for_id]).where(

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -45,6 +45,15 @@ module Sipity
 
       # @api public
       #
+      # @see #users_that_have_taken_the_action_on_the_entity
+      #
+      # @return Array of usernames
+      def usernames_of_those_that_have_taken_the_action_on_the_entity(entity:, action:)
+        users_that_have_taken_the_action_on_the_entity(entity: entity, action: action).pluck(:username)
+      end
+
+      # @api public
+      #
       # An ActiveRecord::Relation scope that meets the following criteria:
       #
       # * Any user that has taken the action (or someone has taken it on their

--- a/app/services/sipity/services/advisor_signs_off.rb
+++ b/app/services/sipity/services/advisor_signs_off.rb
@@ -2,7 +2,11 @@ module Sipity
   module Services
     # This is what happens when the advisor signs off on a given form.
     class AdvisorSignsOff
-      def initialize(form:, requested_by:, repository:)
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def initialize(form:, requested_by:, repository: default_repository)
         @form = form
         @repository = repository
         @requested_by = requested_by
@@ -19,6 +23,10 @@ module Sipity
       end
 
       private
+
+      def default_repository
+        CommandRepository.new
+      end
 
       def handle_last_advisor_signoff
         repository.update_processing_state!(entity: form, to: form.resulting_strategy_state)
@@ -41,11 +49,11 @@ module Sipity
       end
 
       def usernames_for_those_that_have_acted
-        repository.users_that_have_taken_the_action_on_the_entity(entity: form, action: form.action).pluck(:username)
+        repository.usernames_of_those_that_have_taken_the_action_on_the_entity(entity: form, action: form.action)
       end
 
       def collaborating_reviewer_usernames
-        repository.work_collaborating_users_responsible_for_review(work: form.work).pluck(:username)
+        repository.usernames_of_those_that_are_collaborating_and_responsible_for_review(work: form.work)
       end
     end
   end

--- a/app/services/sipity/services/advisor_signs_off.rb
+++ b/app/services/sipity/services/advisor_signs_off.rb
@@ -1,0 +1,50 @@
+module Sipity
+  module Services
+    class AdvisorSignsOff
+      # REVIEW: Is this the correct way to be thinking about this? I have a
+      #   query that is crossing the boundaries of two systems. But for now
+      #   RED->GREEN->REFACTOR
+      include Queries::CollaboratorQueries
+      include Queries::ProcessingQueries
+
+      def initialize(form:, requested_by:, repository:)
+        @form = form
+        @repository = repository
+        @requested_by = requested_by
+      end
+
+      attr_reader :form, :repository, :requested_by
+
+      def call
+        if is_last_advisor_to_signoff?
+          handle_last_advisor_signoff
+        else
+          handle_more_advisors_require_signoff
+        end
+      end
+
+      private
+      def handle_last_advisor_signoff
+        repository.update_processing_state!(entity: form, to: form.resulting_strategy_state)
+        repository.send_notification_for_entity_trigger(
+          notification: 'entity_ready_for_review', entity: form, acting_as: 'etd_reviewer'
+        )
+        repository.send_notification_for_entity_trigger(
+          notification: 'all_advisors_have_signed_off', entity: form, acting_as: 'creating_user'
+        )
+      end
+
+      def handle_more_advisors_require_signoff
+        repository.send_notification_for_entity_trigger(
+          notification: "advisor_signoff_but_still_more_to_go", entity: form, acting_as: 'creating_user'
+        )
+      end
+
+      private
+
+      def is_last_advisor_to_signoff?
+        fail NotImplementedError, "Expected #{self.class} to define ##{__method__}"
+      end
+    end
+  end
+end

--- a/app/services/sipity/services/register_action_taken_on_entity.rb
+++ b/app/services/sipity/services/register_action_taken_on_entity.rb
@@ -15,8 +15,6 @@ module Sipity
       end
       attr_reader :entity, :action, :requesting_actor
 
-      delegate :strategy, to: :entity
-
       def call
         # TODO: Tease apart the requested_by and on_behalf_of
         Models::Processing::EntityActionRegister.create!(
@@ -33,22 +31,13 @@ module Sipity
         @entity = convert_to_processing_entity(entity_like_object)
       end
 
+      include Conversions::ConvertToProcessingAction
       def action=(object)
-        @action = convert_to_processing_action(strategy, object)
+        @action = convert_to_processing_action(object, scope: entity)
       end
 
       def requesting_actor=(actor_like_object)
         @requesting_actor = convert_to_processing_actor(actor_like_object)
-      end
-
-      def convert_to_processing_action(strategy, object)
-        if object.is_a?(Models::Processing::StrategyAction)
-          return object if object.strategy_id == strategy.id
-        else
-          strategy_action = Models::Processing::StrategyAction.where(strategy_id: strategy.id, name: object.to_s).first
-          return strategy_action if strategy_action.present?
-        end
-        fail Exceptions::ProcessingStrategyActionConversionError, { strategy_id: strategy.id, name: object }.inspect
       end
     end
   end

--- a/db/migrate/20150201002854_create_sipity_models_processing_entities.rb
+++ b/db/migrate/20150201002854_create_sipity_models_processing_entities.rb
@@ -4,7 +4,7 @@ class CreateSipityModelsProcessingEntities < ActiveRecord::Migration
       t.integer :proxy_for_id, null: false
       t.string :proxy_for_type, null: false
       t.integer :strategy_id, null: false
-      t.string :strategy_state_id, null: false
+      t.integer :strategy_state_id, null: false
 
       t.timestamps null: false
     end

--- a/spec/conversions/sipity/conversions/convert_to_processing_action_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_action_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToProcessingAction do
+      include ::Sipity::Conversions::ConvertToProcessingAction
+
+      let(:strategy_id) { 1 }
+      let(:action) { Models::Processing::StrategyAction.new(id: 4, name: 'show', strategy_id: strategy_id) }
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          expect(described_class.call(action, scope: strategy_id)).to eq(action)
+        end
+      end
+
+      context '.convert_to_processing_action' do
+        it 'will be private' do
+          object = double
+          expect { described_class.convert_to_processing_action(object, scope: object) }.
+            to raise_error(NoMethodError, /private method `convert_to_processing_action'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_processing_action' do
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_processing_action)
+        end
+
+        context "with strategy_id and action's strategy_id matching" do
+          it 'will return the object if it is a Processing::StrategyAction' do
+            expect(convert_to_processing_action(action, scope: strategy_id)).to eq(action)
+          end
+
+          it 'will raise an error if it cannot convert the object' do
+            object = double
+            expect { convert_to_processing_action(object, scope: strategy_id) }.
+              to raise_error(Exceptions::ProcessingStrategyActionConversionError)
+          end
+
+          it 'will use a found action based on the given string and strategy_id' do
+            expect(Models::Processing::StrategyAction).to receive(:find_by).and_return(action)
+            expect(convert_to_processing_action(action.name, scope: strategy_id)).to eq(action)
+          end
+
+          it 'will find the action by name and strategy_id' do
+            expect(Models::Processing::StrategyAction).to receive(:find_by).and_return(nil)
+            expect { convert_to_processing_action(action.name, scope: strategy_id) }.
+              to raise_error(Exceptions::ProcessingStrategyActionConversionError)
+          end
+        end
+        context "with mismatching strategy_id and action's strategy_id" do
+          it "will raise an error if the scope's strategy_id is different than the actions" do
+            expect { convert_to_processing_action(action, scope: strategy_id + 1) }.
+              to raise_error(Exceptions::ProcessingStrategyActionConversionError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/conversions/sipity/conversions/convert_to_processing_strategy_id_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_strategy_id_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToProcessingStrategyId do
+      include ::Sipity::Conversions::ConvertToProcessingStrategyId
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          expect(described_class.call(123)).to eq(123)
+        end
+      end
+
+      context '.convert_to_processing_strategy_id' do
+        it 'will be private' do
+          object = double(to_processing_entity: 1234)
+          expect { described_class.convert_to_processing_strategy_id(object) }.
+            to raise_error(NoMethodError, /private method `convert_to_processing_strategy_id'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_processing_strategy_id' do
+
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_processing_strategy_id)
+        end
+
+        [
+          [Models::Processing::Strategy.new(id: 12), 12],
+          ["11", 11],
+          [2, 2],
+          [Models::Processing::Entity.new(strategy_id: 37), 37]
+        ].each_with_index do |(to_convert, expected), index|
+          it "will convert #{to_convert.inspect} to #{expected} (Scenario ##{index}" do
+            expect(convert_to_processing_strategy_id(to_convert)).to eq(expected)
+          end
+        end
+
+        it 'will raise an exception if it cannot convert' do
+          expect { convert_to_processing_strategy_id(double) }.to raise_error(Exceptions::ProcessingStrategyIdConversionError)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/etd/advisor_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/advisor_signoff_form_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+module Sipity
+  module Forms
+    module Etd
+      RSpec.describe AdvisorSignoffForm do
+        let(:processing_entity) { Models::Processing::Entity.new(strategy_id: 1) }
+        let(:work) { double('Work', to_processing_entity: processing_entity) }
+        let(:repository) { CommandRepositoryInterface.new }
+        let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: 'hello') }
+        let(:user) { User.new(id: 1) }
+        let(:signoff_service) { double('Signoff Service', call: true) }
+        subject { described_class.new(work: work, processing_action_name: action, signoff_service: signoff_service) }
+
+        context 'the default signoff service' do
+          it 'will respond to :call' do
+            expect(described_class.new(work: work, processing_action_name: action).send(:default_signoff_service)).to respond_to(:call)
+          end
+        end
+
+        its(:work) { should eq work }
+        its(:processing_action_name) { should eq action.name }
+
+        context 'when not valid, #submit' do
+          before do
+            expect(subject).to receive(:valid?).and_return(false)
+            expect(signoff_service).to_not receive(:call)
+          end
+          it 'will return the false' do
+            expect(subject.submit(repository: repository, requested_by: user)).to eq(false)
+          end
+        end
+
+        context 'when valid, #submit' do
+          before do
+            expect(subject).to receive(:valid?).and_return(true)
+          end
+
+          it 'will return the given work' do
+            expect(subject.submit(repository: repository, requested_by: user)).to eq(work)
+          end
+
+          it 'will log the event' do
+            expect(repository).to receive(:log_event!).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will register that the given action was taken on the entity' do
+            expect(repository).to receive(:register_action_taken_on_entity).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will call the AdvisorSignsOff service' do
+            expect(signoff_service).to receive(:call)
+            subject.submit(repository: repository, requested_by: user)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/submit_for_review_form_spec.rb
@@ -16,22 +16,6 @@ module Sipity
             subject = described_class.new(work: work, processing_action_name: action)
             expect(subject.action).to eq(action)
           end
-
-          it 'will attempt to find the action based on name and strategy' do
-            expect(Models::Processing::StrategyAction).to receive(:find_by).
-              with(name: 'submit_for_review', strategy_id: processing_entity.strategy_id).
-              and_return(action)
-            subject = described_class.new(work: work, processing_action_name: 'submit_for_review')
-            expect(subject.action).to eq(action)
-          end
-
-          it 'will choke if the name is not found' do
-            expect(Models::Processing::StrategyAction).to receive(:find_by).
-              with(name: 'submit_for_review', strategy_id: processing_entity.strategy_id).
-              and_return(nil)
-            expect { described_class.new(work: work, processing_action_name: 'submit_for_review') }.
-              to raise_error(Exceptions::ProcessingStrategyActionConversionError)
-          end
         end
 
         it 'will log the event' do

--- a/spec/repositories/sipity/queries/collaborator_queries_spec.rb
+++ b/spec/repositories/sipity/queries/collaborator_queries_spec.rb
@@ -14,6 +14,11 @@ module Sipity
         end
       end
 
+      context '#usernames_of_those_that_are_collaborating_and_responsible_for_review' do
+        subject { test_repository.usernames_of_those_that_are_collaborating_and_responsible_for_review(work: work) }
+        it { should be_a(Enumerable) }
+      end
+
       context '#work_collaborating_users_responsible_for_review' do
         subject { test_repository.work_collaborating_users_responsible_for_review(work: work) }
         it { should be_a(ActiveRecord::Relation) }

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -324,6 +324,12 @@ module Sipity
         end
       end
 
+      context '#usernames_of_those_that_have_taken_the_action_on_the_entity' do
+        subject { test_repository.usernames_of_those_that_have_taken_the_action_on_the_entity(entity: entity, action: action) }
+        it "will be an enumerable" do
+          expect(subject).to be_a(Enumerable)
+        end
+      end
       context '#users_that_have_taken_the_action_on_the_entity' do
         subject { test_repository.users_that_have_taken_the_action_on_the_entity(entity: entity, action: action) }
         it "will include permitted strategy_state_actions" do

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -7,6 +7,14 @@ module Sipity
 
       subject { described_class.new(form: form, repository: repository, requested_by: requested_by) }
 
+      context '.call' do
+        it 'is a wrapper' do
+          expect_any_instance_of(described_class).to receive(:initialize)
+          expect_any_instance_of(described_class).to receive(:call)
+          described_class.call(form: form, repository: repository, requested_by: requested_by)
+        end
+      end
+
       context 'when there are other advisors that have not yet signed-off' do
         before { expect(subject).to receive(:last_advisor_to_signoff?).and_return(false) }
         it 'will NOT change the processing state' do
@@ -54,6 +62,20 @@ module Sipity
               and_return(example.fetch(:usernames_for_those_that_have_acted))
             expect(subject.send(:last_advisor_to_signoff?)).to eq(example.fetch(:expected))
           end
+        end
+      end
+
+      context 'default repository' do
+        let(:form) { double('Form', resulting_strategy_state: 'chubacabra', action: 'submit_for_review', work: double) }
+        subject { described_class.new(form: form, requested_by: requested_by) }
+        it 'exposes #usernames_of_those_that_have_taken_the_action_on_the_entity' do
+          expect(subject.send(:repository)).to receive(:usernames_of_those_that_have_taken_the_action_on_the_entity)
+          subject.send(:usernames_for_those_that_have_acted)
+        end
+
+        it 'exposes #usernames_of_those_that_are_collaborating_and_responsible_for_review' do
+          expect(subject.send(:repository)).to receive(:usernames_of_those_that_are_collaborating_and_responsible_for_review)
+          subject.send(:collaborating_reviewer_usernames)
         end
       end
     end

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -1,0 +1,39 @@
+module Sipity
+  module Services
+    RSpec.describe AdvisorSignsOff do
+      let(:form) { double('Form', resulting_strategy_state: 'chubacabra') }
+      let(:repository) { CommandRepositoryInterface.new }
+      let(:requested_by) { double('User') }
+
+      subject { described_class.new(form: form, repository: repository, requested_by: requested_by) }
+
+      context 'when there are other advisors that have not yet signed-off' do
+        before { expect(subject).to receive(:is_last_advisor_to_signoff?).and_return(false) }
+        it 'will NOT change the processing state' do
+          expect(repository).to_not receive(:update_processing_state!)
+          subject.call
+        end
+        it 'will send an email to the creating user' do
+          expect(repository).to receive(:send_notification_for_entity_trigger).
+            with(notification: 'advisor_signoff_but_still_more_to_go', entity: form, acting_as: 'creating_user')
+          subject.call
+        end
+      end
+
+      context 'when this is the last advisor to signoff' do
+        before { expect(subject).to receive(:is_last_advisor_to_signoff?).and_return(true) }
+        it 'will change the processing state' do
+          expect(repository).to receive(:update_processing_state!).and_call_original
+          subject.call
+        end
+        it 'will send emails to the etd_reviewers and creating user' do
+          expect(repository).to receive(:send_notification_for_entity_trigger).
+            with(notification: 'entity_ready_for_review', entity: form, acting_as: 'etd_reviewer')
+          expect(repository).to receive(:send_notification_for_entity_trigger).
+            with(notification: 'all_advisors_have_signed_off', entity: form, acting_as: 'creating_user')
+          subject.call
+        end
+      end
+    end
+  end
+end

--- a/spec/services/sipity/services/register_action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/register_action_taken_on_entity_spec.rb
@@ -9,7 +9,6 @@ module Sipity
       let(:action) { Models::Processing::StrategyAction.new(id: 3, strategy_id: strategy.id, name: 'wowza') }
 
       subject { described_class.new(entity: entity, requested_by: requested_by, action: action) }
-      its(:strategy) { should eq entity.strategy }
 
       context '.call' do
         it 'will delegate do the unerlying #initialize then #call' do
@@ -19,30 +18,9 @@ module Sipity
       end
 
       context '#call' do
-        context 'with an invalid action for the given strategy' do
-          let(:action) { '__invalid__' }
-          it 'will raise an exception if the action is not valid for the strategy' do
-            expect { subject.call }.to raise_error Exceptions::ProcessingStrategyActionConversionError
-          end
-        end
-        context 'with a valid action object for the given strategy' do
+        context 'with a valid action object for the given entity' do
           it 'will increment the registry' do
             expect { subject.call }.to change { Models::Processing::EntityActionRegister.count }.by(1)
-          end
-        end
-
-        context 'with a valid action name for the given strategy' do
-          it 'will increment the registry' do
-            action.save!
-            subject = described_class.new(entity: entity, requested_by: requested_by, action: action.name)
-            expect { subject.call }.to change { Models::Processing::EntityActionRegister.count }.by(1)
-          end
-        end
-
-        context 'with an action not associated with the given strategy' do
-          let(:action) { Models::Processing::StrategyAction.new(id: 3) }
-          it 'will raise an exception' do
-            expect { subject.call }.to raise_error Exceptions::ProcessingStrategyActionConversionError
           end
         end
       end


### PR DESCRIPTION
## Adding AdvisorSignsOff service

@39371253ddf88aa8a90bd44e61771a9ce9b06edf

There are some conditionals in this behavior. I want to make sure that
I'm isolating those decisions as the advisor signs off form is already
overworked.

One concern, however, is that I'm driving a querying decision off of
a thing that happens in an unrelated action; The
ProcessingActionForm's save method is registering that the action was
taken. This is buried in the implementation details, and has already
happened.

## Adding user query for actions taken

@e18142dc75ebf450ff1c7c4d92cfc467330a5345

> An ActiveRecord::Relation scope that meets the following criteria:
>
> * Any user that has taken the action (or someone has taken it on
>   their behalf)
> * Any user that is part of a group that has taken the action (you
>   know, because maybe we'll allow groups to take the action)
>
> @param entity an object that can be converted into a
>   Sipity::Models::Processing::Entity
> @param action an object that can be covnerted into a
>   Sipity::Models::Processing::Action given the entity
> @return ActiveRecord::Relation<User>

## Adding ability to convert strategy_id

@be0ddfa9be76de77b62f777db52d9e3323315a99

I'm doing this logic in a few places, so I'm working to make sure that
it is consolidated into a conversion module.

## Adding ability to convert to action

@3e3753445ee5bc87f932f3948396ee69ac81b89b

This logic was showing up in multiple places. So I opted to extract
the behavior into a conversion module.

## Splicing in #conversion_to_processing_action

@72d5cb50d9e0c552e500189294c64051d65724c0

As there were two places performing this logic, I wanted to tease them
apart so I can make sure everything is working properly.

## Adding action conversion

@8d748b4a427ed86e3bc8c6d6f91bfbf19d8e7607

As a matter of practice this is something I want to do to make sure
that the processing system is properly converted.

## Adding scenarios to explain state change

@40d6a1ed20d86439e2f66b483d00876c68359464

By teasing apart the methods, and I hope naming them better, I am
attempting to give a clear indication to the intent of when the state
can advance for an advisor's signoff.

This service object may get folded back into the form, but I'm
concerned that the forms are already doing too much.

## Rearranging block execution order

@170f8aae29cf267467f7243617d47d14bf98e21b

I'm not satisified with how this is working out, as it reflects a
temporal coupling and a difficulty in composing behavior.

## Adding query for usernames

@25ad607ee76fc34f277dd338ba850396024f410e


## Adding username queries for collaborators

@30e7d28723b1b48d6bbe690481a5afd68d14ab62


## Removing violation of law of demeter

@62140d1a08c1eac2de290a693c9907f4aa366a16

Allowing for dependency inject of a repository.

## Adding the AdvisorSignoffForm

@cbe9baeeb28ccdcf6b8ddd86c55bdb1e0745c149
