### PR TITLE
Fixing prereq action fulfillment answer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
   gem 'pry-rails'
   gem 'pry-byebug'
   gem 'letter_opener'
+  gem 'seed_dump'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,9 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    seed_dump (3.2.1)
+      activerecord (~> 4)
+      activesupport (~> 4)
     selenium-webdriver (2.44.0)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
@@ -492,6 +495,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 4.0.3)
+  seed_dump
   selenium-webdriver
   simple_form
   simplecov

--- a/app/decorators/sipity/decorators/processing/state_advancing_action_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/state_advancing_action_decorator.rb
@@ -26,10 +26,10 @@ module Sipity
         end
 
         def query_for_availability_state
-          if repository.are_all_of_the_required_todo_items_done_for_work?(work: entity)
-            ACTION_AVAILABLE
-          else
+          if repository.scope_strategy_actions_with_incomplete_prerequisites(entity: entity).include?(action)
             ACTION_UNAVAILABLE
+          else
+            ACTION_AVAILABLE
           end
         end
       end

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -484,7 +484,9 @@ module Sipity
         prerequisites = Models::Processing::StrategyActionPrerequisite.arel_table
         registers = Models::Processing::EntityActionRegister.arel_table
 
-        incomplete_prerequisites_subquery = prerequisites.project(prerequisites[:guarded_strategy_action_id]).join(registers,Arel::Nodes::OuterJoin).on(
+        incomplete_prerequisites_subquery = prerequisites.project(prerequisites[:guarded_strategy_action_id]).join(
+          registers, Arel::Nodes::OuterJoin
+        ).on(
           registers[:entity_id].eq(entity.id).and(
             registers[:strategy_action_id].eq(prerequisites[:prerequisite_strategy_action_id])
           )

--- a/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
+++ b/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
@@ -1,0 +1,166 @@
+# TODO: The purpose of this data is to establsih a set of data in which not
+# all of the pre-requisites have been achieved.
+#
+# This data was generated via rake db:seed:dump
+# It is used for a specific test.
+User.create!([
+  {email: nil, remember_created_at: nil, sign_in_count: 1, current_sign_in_at: "2015-02-23 15:05:46", last_sign_in_at: "2015-02-23 15:05:46", current_sign_in_ip: "::1", last_sign_in_ip: "::1", name: nil, role: nil, username: "jfriesen"}
+])
+Sipity::Models::Processing::Actor.create!([
+  {proxy_for_id: 1, proxy_for_type: "User", name_of_proxy: nil}
+])
+Sipity::Models::Processing::Entity.create!([
+  {proxy_for_id: 1, proxy_for_type: "Sipity::Models::Work", strategy_id: 1, strategy_state_id: "1"}
+])
+Sipity::Models::Processing::EntityActionRegister.create!([
+  {strategy_action_id: 4, entity_id: 1, requested_by_actor_id: 1, on_behalf_of_actor_id: 1}
+])
+Sipity::Models::Processing::EntitySpecificResponsibility.create!([
+  {strategy_role_id: 1, entity_id: 1, actor_id: 1}
+])
+Sipity::Models::Processing::Strategy.create!([
+  {name: "etd processing", description: nil, proxy_for_id: 1, proxy_for_type: "Sipity::Models::WorkType"}
+])
+Sipity::Models::Processing::StrategyAction.create!([
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "show", form_class_name: nil, completion_required: false, action_type: "resourceful_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "edit", form_class_name: nil, completion_required: false, action_type: "resourceful_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "destroy", form_class_name: nil, completion_required: false, action_type: "resourceful_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "describe", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "attach", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "collaborators", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "assign_a_doi", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "assign_a_citation", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 2, name: "submit_for_review", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 4, name: "advisor_signs_off", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 3, name: "advisor_requests_changes", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 2, name: "request_revisions", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 5, name: "approve_for_ingest", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 6, name: "ingest", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 7, name: "ingest_completed", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"}
+])
+Sipity::Models::Processing::StrategyActionPrerequisite.create!([
+  {guarded_strategy_action_id: 9, prerequisite_strategy_action_id: 4},
+  {guarded_strategy_action_id: 9, prerequisite_strategy_action_id: 5},
+  {guarded_strategy_action_id: 9, prerequisite_strategy_action_id: 6}
+])
+Sipity::Models::Processing::StrategyRole.create!([
+  {strategy_id: 1, role_id: 1},
+  {strategy_id: 1, role_id: 2},
+  {strategy_id: 1, role_id: 3}
+])
+Sipity::Models::Processing::StrategyState.create!([
+  {strategy_id: 1, name: "new"},
+  {strategy_id: 1, name: "under_advisor_review"},
+  {strategy_id: 1, name: "advisor_changes_requested"},
+  {strategy_id: 1, name: "under_grad_school_review"},
+  {strategy_id: 1, name: "ready_for_ingest"},
+  {strategy_id: 1, name: "ingesting"},
+  {strategy_id: 1, name: "done"}
+])
+Sipity::Models::Processing::StrategyStateAction.create!([
+  {originating_strategy_state_id: 1, strategy_action_id: 1},
+  {originating_strategy_state_id: 2, strategy_action_id: 1},
+  {originating_strategy_state_id: 3, strategy_action_id: 1},
+  {originating_strategy_state_id: 4, strategy_action_id: 1},
+  {originating_strategy_state_id: 5, strategy_action_id: 1},
+  {originating_strategy_state_id: 6, strategy_action_id: 1},
+  {originating_strategy_state_id: 7, strategy_action_id: 1},
+  {originating_strategy_state_id: 1, strategy_action_id: 2},
+  {originating_strategy_state_id: 3, strategy_action_id: 2},
+  {originating_strategy_state_id: 4, strategy_action_id: 2},
+  {originating_strategy_state_id: 1, strategy_action_id: 3},
+  {originating_strategy_state_id: 2, strategy_action_id: 3},
+  {originating_strategy_state_id: 3, strategy_action_id: 3},
+  {originating_strategy_state_id: 4, strategy_action_id: 3},
+  {originating_strategy_state_id: 1, strategy_action_id: 4},
+  {originating_strategy_state_id: 1, strategy_action_id: 5},
+  {originating_strategy_state_id: 1, strategy_action_id: 6},
+  {originating_strategy_state_id: 1, strategy_action_id: 7},
+  {originating_strategy_state_id: 2, strategy_action_id: 7},
+  {originating_strategy_state_id: 3, strategy_action_id: 7},
+  {originating_strategy_state_id: 4, strategy_action_id: 7},
+  {originating_strategy_state_id: 1, strategy_action_id: 8},
+  {originating_strategy_state_id: 2, strategy_action_id: 8},
+  {originating_strategy_state_id: 3, strategy_action_id: 8},
+  {originating_strategy_state_id: 4, strategy_action_id: 8},
+  {originating_strategy_state_id: 1, strategy_action_id: 9},
+  {originating_strategy_state_id: 2, strategy_action_id: 10},
+  {originating_strategy_state_id: 2, strategy_action_id: 11},
+  {originating_strategy_state_id: 4, strategy_action_id: 12}
+])
+Sipity::Models::Processing::StrategyStateActionPermission.create!([
+  {strategy_role_id: 1, strategy_state_action_id: 26},
+  {strategy_role_id: 1, strategy_state_action_id: 1},
+  {strategy_role_id: 1, strategy_state_action_id: 8},
+  {strategy_role_id: 1, strategy_state_action_id: 15},
+  {strategy_role_id: 1, strategy_state_action_id: 16},
+  {strategy_role_id: 1, strategy_state_action_id: 17},
+  {strategy_role_id: 1, strategy_state_action_id: 11},
+  {strategy_role_id: 1, strategy_state_action_id: 18},
+  {strategy_role_id: 1, strategy_state_action_id: 22},
+  {strategy_role_id: 1, strategy_state_action_id: 2},
+  {strategy_role_id: 1, strategy_state_action_id: 20},
+  {strategy_role_id: 1, strategy_state_action_id: 24},
+  {strategy_role_id: 1, strategy_state_action_id: 3},
+  {strategy_role_id: 1, strategy_state_action_id: 9},
+  {strategy_role_id: 1, strategy_state_action_id: 13},
+  {strategy_role_id: 1, strategy_state_action_id: 4},
+  {strategy_role_id: 1, strategy_state_action_id: 5},
+  {strategy_role_id: 1, strategy_state_action_id: 6},
+  {strategy_role_id: 1, strategy_state_action_id: 7},
+  {strategy_role_id: 2, strategy_state_action_id: 1},
+  {strategy_role_id: 2, strategy_state_action_id: 8},
+  {strategy_role_id: 2, strategy_state_action_id: 15},
+  {strategy_role_id: 2, strategy_state_action_id: 16},
+  {strategy_role_id: 2, strategy_state_action_id: 17},
+  {strategy_role_id: 2, strategy_state_action_id: 11},
+  {strategy_role_id: 2, strategy_state_action_id: 18},
+  {strategy_role_id: 2, strategy_state_action_id: 22},
+  {strategy_role_id: 2, strategy_state_action_id: 2},
+  {strategy_role_id: 2, strategy_state_action_id: 19},
+  {strategy_role_id: 2, strategy_state_action_id: 23},
+  {strategy_role_id: 2, strategy_state_action_id: 12},
+  {strategy_role_id: 2, strategy_state_action_id: 27},
+  {strategy_role_id: 2, strategy_state_action_id: 28},
+  {strategy_role_id: 2, strategy_state_action_id: 20},
+  {strategy_role_id: 2, strategy_state_action_id: 3},
+  {strategy_role_id: 2, strategy_state_action_id: 9},
+  {strategy_role_id: 2, strategy_state_action_id: 13},
+  {strategy_role_id: 2, strategy_state_action_id: 21},
+  {strategy_role_id: 2, strategy_state_action_id: 25},
+  {strategy_role_id: 2, strategy_state_action_id: 29},
+  {strategy_role_id: 2, strategy_state_action_id: 4},
+  {strategy_role_id: 2, strategy_state_action_id: 10},
+  {strategy_role_id: 2, strategy_state_action_id: 14},
+  {strategy_role_id: 2, strategy_state_action_id: 5},
+  {strategy_role_id: 2, strategy_state_action_id: 6},
+  {strategy_role_id: 2, strategy_state_action_id: 7},
+  {strategy_role_id: 3, strategy_state_action_id: 1},
+  {strategy_role_id: 3, strategy_state_action_id: 2},
+  {strategy_role_id: 3, strategy_state_action_id: 27},
+  {strategy_role_id: 3, strategy_state_action_id: 28},
+  {strategy_role_id: 3, strategy_state_action_id: 3},
+  {strategy_role_id: 3, strategy_state_action_id: 4},
+  {strategy_role_id: 3, strategy_state_action_id: 5},
+  {strategy_role_id: 3, strategy_state_action_id: 6},
+  {strategy_role_id: 3, strategy_state_action_id: 7}
+])
+Sipity::Models::Role.create!([
+  {name: "creating_user", description: nil},
+  {name: "etd_reviewer", description: nil},
+  {name: "advisor", description: nil}
+])
+Sipity::Models::TransientAnswer.create!([
+  {entity_id: 1, entity_type: "Sipity::Models::Work", question_code: "access_rights", answer_code: "private_access"}
+])
+Sipity::Models::Work.create!([
+  {work_publication_strategy: "will_not_publish", title: "Hello", work_type: "etd"}
+])
+Sipity::Models::WorkType.create!([
+  {name: "etd", description: nil}
+])
+Sipity::Models::WorkTypeTodoListConfig.create!([
+  {work_type: "etd", work_processing_state: "new", enrichment_type: "describe", enrichment_group: "required"},
+  {work_type: "etd", work_processing_state: "new", enrichment_type: "attach", enrichment_group: "required"},
+  {work_type: "etd", work_processing_state: "new", enrichment_type: "collaborators", enrichment_group: "required"}
+])

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -245,13 +245,9 @@ module Sipity
 
       context '#scope_strategy_actions_with_completed_prerequisites' do
         subject { test_repository.scope_strategy_actions_with_completed_prerequisites(entity: entity) }
-        let(:guarded_action) do
-          Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'with_completed_prereq')
-        end
-        let(:other_guarded_action) do
-          Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'without_completed_prereq')
-        end
         it "will include permitted strategy_state_actions" do
+          other_guarded_action = Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'without_completed_prereq')
+          guarded_action = Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'with_completed_prereq')
           action.save unless action.persisted?
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: guarded_action.id, prerequisite_strategy_action_id: action.id

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -263,6 +263,25 @@ module Sipity
         end
       end
 
+      context '#scope_strategy_actions_with_incomplete_prerequisites' do
+        subject { test_repository.scope_strategy_actions_with_incomplete_prerequisites(entity: entity) }
+        context 'with some but not all of the prerequisites completed' do
+          before do
+            Sipity::SpecSupport.load_database_seeds!(
+              seeds_path: 'spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb'
+            )
+          end
+          let(:entity) { Sipity::Models::Processing::Entity.first! }
+          let(:incomplete_action) { Sipity::Models::Processing::StrategyAction.find_by(name: 'submit_for_review', strategy_id: entity.strategy_id) }
+          it 'will return only the actions with all prerequisites completed' do
+            expect(subject).to eq([incomplete_action])
+          end
+          it "will be a chainable scope" do
+            expect(subject).to be_a(ActiveRecord::Relation)
+          end
+        end
+      end
+
       context '#scope_strategy_actions_without_prerequisites' do
         subject { test_repository.scope_strategy_actions_without_prerequisites(entity: entity) }
         let(:guarded_action) { Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'with_prereq') }

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -246,7 +246,9 @@ module Sipity
       context '#scope_strategy_actions_with_completed_prerequisites' do
         subject { test_repository.scope_strategy_actions_with_completed_prerequisites(entity: entity) }
         it "will include permitted strategy_state_actions" do
-          other_guarded_action = Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'without_completed_prereq')
+          other_guarded_action = Models::Processing::StrategyAction.find_or_create_by!(
+            strategy_id: strategy.id, name: 'without_completed_prereq'
+          )
           guarded_action = Models::Processing::StrategyAction.find_or_create_by!(strategy_id: strategy.id, name: 'with_completed_prereq')
           action.save unless action.persisted?
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
@@ -272,7 +274,9 @@ module Sipity
             )
           end
           let(:entity) { Sipity::Models::Processing::Entity.first! }
-          let(:incomplete_action) { Sipity::Models::Processing::StrategyAction.find_by(name: 'submit_for_review', strategy_id: entity.strategy_id) }
+          let(:incomplete_action) do
+            Sipity::Models::Processing::StrategyAction.find_by(name: 'submit_for_review', strategy_id: entity.strategy_id)
+          end
           it 'will return only the actions with all prerequisites completed' do
             expect(subject).to eq([incomplete_action])
           end


### PR DESCRIPTION
## Re-arranging test sequence

@ff717ba7d7da7b3f623dbbba1c2a4fd269b55df4

For clarity and less chattiness, making adjustments to the test.

## Adding seed_dump gem

@1812b9224d88ec1897c3e2d2aa953facfe8b7d45

This allows us to dump the data into seeds.

## Adding fixture data for ongoing tests

@d394f54560a2acb3a700fed07dfd2ac16411324a

This is, I hope, a stop gap for the long term data stewardship.

## Replacing broken query with fixed query

@c32bf57bb2682e0bfe56e9ff3569ee13423d38ca

This addresses the issue in which a user has completed one of the
prerequisite actions for a guarded action, but not all of them.

Prior to the fix, if the user completed one prerequisite action then
a guarded action would be available. After this fix a guarded action
is only available if all of the actions have been completed.

## Appeasing rubocop

@2d6df695bc12b6ffb01b17849985f7d5d76f684d
