### PR TITLE
Adding thesis defense date form

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/defense_date_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/defense_date_form.rb
@@ -1,0 +1,31 @@
+module Sipity
+  module Forms
+    module WorkEnrichments
+      # Exposes a means defining the thesis defense date todo item.
+      class DefenseDateForm < Forms::WorkEnrichmentForm
+        def initialize(attributes = {})
+          super
+          @defense_date = attributes.fetch(:defense_date) { defense_date_from_work }
+        end
+
+        attr_accessor :defense_date
+        validates :defense_date, presence: true
+
+        private
+
+        def save(repository:, requested_by:)
+          super do
+            repository.update_work_attribute_values!(work: work, key: 'defense_date', values: defense_date)
+          end
+        end
+
+        def defense_date_from_work
+          return [] unless work
+          # REVIEW: I really need to derive this information from the repository.
+          # It is something that should be injected on form build.
+          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'defense_date').first
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/work_enrichments/describe_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/describe_form.rb
@@ -12,16 +12,16 @@ module Sipity
 
         validates :abstract, presence: true
 
-        def abstract_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'abstract').first
-        end
-
         private
 
         def save(repository:, requested_by:)
           super do
             repository.update_work_attribute_values!(work: work, key: 'abstract', values: abstract)
           end
+        end
+
+        def abstract_from_work
+          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'abstract').first
         end
       end
     end

--- a/app/views/sipity/controllers/work_enrichments/defense_date.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/defense_date.html.erb
@@ -1,0 +1,9 @@
+<!-- TODO: Internationalize the enrichment option -->
+<h2>Tell us about your advisors</h2>
+<%= simple_form_for(model, url: enrich_work_path(model.work, model.enrichment_type), method: :post, as: :work) do |f| %>
+  <%= f.error_notification %>
+  <%= field_set_tag do %>
+    <%= f.input :defense_date, as: :date %>
+    <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
         enrichment_type = request.params.fetch(:enrichment_type)
         # REVIEW: Magic strings! There is a canonical enrichment question; And
         #   the valid enrichments may not be available for all work ids
-        %(attach describe collaborators).include?(enrichment_type)
+        %(attach describe collaborators defense_date).include?(enrichment_type)
       end
       get 'works/:work_id/:enrichment_type', to: 'work_enrichments#edit', as: 'enrich_work', constraints: enrichment_constraint
       post 'works/:work_id/:enrichment_type', to: 'work_enrichments#update', constraints: enrichment_constraint

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,6 +76,7 @@ ActiveRecord::Base.transaction do
       ['describe', nil],
       ['attach', nil],
       ['collaborators', nil],
+      ['defense_date', nil],
       ['assign_a_doi', nil],
       ['assign_a_citation', nil],
       ['submit_for_review', 'under_advisor_review'],
@@ -93,7 +94,7 @@ ActiveRecord::Base.transaction do
     end
 
     {
-      'submit_for_review' => ['describe', 'attach', 'collaborators']
+      'submit_for_review' => ['describe', 'attach', 'collaborators', 'defense_date']
     }.each do |guarded_action_name, prereq_action_names|
       guarded_action = etd_actions.fetch(guarded_action_name)
       Array.wrap(prereq_action_names).each do |prereq_action_name|
@@ -111,6 +112,7 @@ ActiveRecord::Base.transaction do
       ['new', 'attach', ['creating_user', 'etd_reviewer']],
       ['new', 'collaborators', ['creating_user', 'etd_reviewer']],
       ['new', 'destroy', ['creating_user', 'etd_reviewer']],
+      ['new', 'defense_date', ['creating_user']],
       ['new', 'assign_a_doi', ['creating_user', 'etd_reviewer']],
       ['new', 'assign_a_citation', ['creating_user', 'etd_reviewer']],
       ['under_advisor_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
@@ -121,6 +123,7 @@ ActiveRecord::Base.transaction do
       ['under_advisor_review', 'advisor_requests_changes', ['etd_reviewer', 'advisor']],
       ['advisor_changes_requested', 'assign_a_doi', ['etd_reviewer', 'creating_user']],
       ['advisor_changes_requested', 'assign_a_citation', ['creating_user']],
+      ['advisor_changes_requested', 'defense_date', ['creating_user']],
       ['advisor_changes_requested', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
       ['advisor_changes_requested', 'edit', ['creating_user', 'etd_reviewer']],
       ['advisor_changes_requested', 'destroy', ['creating_user', 'etd_reviewer']],

--- a/spec/forms/sipity/forms/work_enrichments/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/defense_date_form_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+module Sipity
+  module Forms
+    module WorkEnrichments
+      RSpec.describe DefenseDateForm do
+        let(:work) { Models::Work.new(id: '1234') }
+        let(:defense_date) { Date.today }
+        subject { described_class.new(work: work) }
+
+        its(:enrichment_type) { should eq('defense_date') }
+        its(:policy_enforcer) { should eq Policies::Processing::WorkProcessingPolicy }
+
+        it { should respond_to :work }
+        it { should respond_to :defense_date }
+        it { should respond_to :defense_date= }
+
+        it 'will require a defense_date' do
+          subject.valid?
+          expect(subject.errors[:defense_date]).to be_present
+        end
+
+        context '#defense_date' do
+          subject { described_class.new(work: work) }
+          it 'will return the defense_date of the work' do
+            expect(Queries::AdditionalAttributeQueries).to receive(:work_attribute_values_for).
+              with(work: work, key: 'defense_date').and_return([defense_date])
+            expect(subject.defense_date).to eq defense_date
+          end
+        end
+
+        context '#submit' do
+          let(:repository) { CommandRepositoryInterface.new }
+          let(:user) { double('User') }
+          context 'with invalid data' do
+            before do
+              expect(subject).to receive(:valid?).and_return(false)
+            end
+            it 'will return false if not valid' do
+              expect(subject.submit(repository: repository, requested_by: user))
+            end
+          end
+
+          context 'with valid data' do
+            subject { described_class.new(work: work, defense_date: '2014-10-02') }
+            before do
+              expect(subject).to receive(:valid?).and_return(true)
+            end
+
+            it 'will return the work' do
+              returned_value = subject.submit(repository: repository, requested_by: user)
+              expect(returned_value).to eq(work)
+            end
+
+            it "will transition the work's corresponding enrichment todo item to :done" do
+              expect(repository).to receive(:register_action_taken_on_entity).and_call_original
+              subject.submit(repository: repository, requested_by: user)
+            end
+
+            it 'will add additional attributes entries' do
+              expect(repository).to receive(:update_work_attribute_values!).and_call_original
+              subject.submit(repository: repository, requested_by: user)
+            end
+
+            it 'will record the event' do
+              expect(repository).to receive(:log_event!).and_call_original
+              subject.submit(repository: repository, requested_by: user)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
@@ -27,11 +27,11 @@ module Sipity
 
         context '#abstract' do
           let(:abstract) { ['Hello Dolly'] }
-          subject { described_class.new(work: work, abstract: abstract) }
+          subject { described_class.new(work: work) }
           it 'will return the abstract of the work' do
             expect(Queries::AdditionalAttributeQueries).to receive(:work_attribute_values_for).
               with(work: work, key: 'abstract').and_return(abstract)
-            expect(subject.abstract_from_work).to eq 'Hello Dolly'
+            expect(subject.abstract).to eq 'Hello Dolly'
           end
         end
 

--- a/spec/routing/work_flow_routing_spec.rb
+++ b/spec/routing/work_flow_routing_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'work flow routing spec' do
   let(:work_id) { "12" }
   context 'enrichment routes' do
-    ['collaborators', 'attach', 'describe'].each do |enrichment_type|
+    ['defense_date', 'collaborators', 'attach', 'describe'].each do |enrichment_type|
       it "will route GET /works/:work_id/#{enrichment_type}" do
         expect(get: "/works/#{work_id}/#{enrichment_type}").
           to route_to(controller: 'sipity/controllers/work_enrichments', action: 'edit', work_id: work_id, enrichment_type: enrichment_type)


### PR DESCRIPTION
## Tidying up spec and narrowing interface

@b02f88404657d176b3f24eba26c3385ee3958729

I don't want the abstract_from_work to be an exposed public method. It
is something that happens on initialization and should not be called
at a future point.

Also clarifying how the values are initialized if none are passed.

## Adding DefenseDateForm

@11993a4939d46c58f31e511b53180249ab2a05a9

Responsible for capturing information related to the defense date.

## Adding DefenseDate form and routes

@4b8460f56cd9feb094d2afc3d6fe728b865f27f8
