### PR TITLE
Renaming ETD to Doctoral Dissertation

### DIFF
--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -73,7 +73,7 @@ module Sipity
       def set_default_work_type
         # HACK: Given that we are first working on the ETD submission, this
         # is an acceptable hack. However, as we move forward, it may not be.
-        self.work_type ||= 'etd'
+        self.work_type ||= 'doctoral_dissertation'
       end
     end
   end

--- a/app/models/sipity/models/work_type.rb
+++ b/app/models/sipity/models/work_type.rb
@@ -9,7 +9,8 @@ module Sipity
       self.table_name = 'sipity_work_types'
 
       NAMED_WORK_TYPES_FOR_ENUM = {
-        'doctoral_dissertation' => 'doctoral_dissertation'
+        'doctoral_dissertation' => 'doctoral_dissertation',
+        'master_thesis' => 'master_thesis'
       }.freeze
 
       # As I don't have a means for assigning roles for a given processing type

--- a/app/models/sipity/models/work_type.rb
+++ b/app/models/sipity/models/work_type.rb
@@ -9,7 +9,7 @@ module Sipity
       self.table_name = 'sipity_work_types'
 
       NAMED_WORK_TYPES_FOR_ENUM = {
-        'etd' => 'etd'
+        'doctoral_dissertation' => 'doctoral_dissertation'
       }.freeze
 
       # As I don't have a means for assigning roles for a given processing type

--- a/app/state_machines/sipity/state_machines/doctoral_dissertation_state_machine.rb
+++ b/app/state_machines/sipity/state_machines/doctoral_dissertation_state_machine.rb
@@ -7,7 +7,7 @@ module Sipity
     # REVIEW: How is this different from crafting a handful of runners? Perhaps
     #   These should be codified as runners? Is there a symmetry of moving these
     #   to runners? Is symmetry worth pursuing?
-    class EtdStateMachine
+    class DoctoralDissertationStateMachine
       class_attribute :state_diagram, instance_writer: false
       self.state_diagram = StateDiagram.new(
         'new' => {

--- a/app/views/sipity/controllers/dashboards/index.html.erb
+++ b/app/views/sipity/controllers/dashboards/index.html.erb
@@ -5,7 +5,7 @@
       <%= select_tag(
             :processing_state,
             options_from_collection_for_select(
-              ::Sipity::StateMachines::EtdStateMachine.state_diagram.states, :to_s, :to_s, params[:processing_state]
+              ::Sipity::StateMachines::DoctoralDissertationStateMachine.state_diagram.states, :to_s, :to_s, params[:processing_state]
             ),
             include_blank: true
       ) %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -24,7 +24,7 @@ en:
           going_to_publish_html: 'I am <i>planning on publishing</i> this work in the future.'
           do_not_know: 'I don’t know.'
         work_type:
-          etd: 'ETD'
+          doctoral_dissertation: 'Doctoral Dissertation'
         access_rights_answer:
           open_access_html: '<b>Open Access:</b> freely viewable to the world'
           restricted_access_html: '<b>Restricted:</b> only specific groups or people can see it'

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -25,6 +25,7 @@ en:
           do_not_know: 'I don’t know.'
         work_type:
           doctoral_dissertation: 'Doctoral Dissertation'
+          master_thesis: "Master's Thesis"
         access_rights_answer:
           open_access_html: '<b>Open Access:</b> freely viewable to the world'
           restricted_access_html: '<b>Restricted:</b> only specific groups or people can see it'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,9 +13,9 @@ ActiveRecord::Base.transaction do
   $stdout.puts 'Configuring Work Type Todo List...'
 
   [
-    ['etd', 'new', 'describe', 'required'],
-    ['etd', 'new', 'attach', 'required'],
-    ['etd', 'new', 'collaborators', 'required']
+    ['doctoral_dissertation', 'new', 'describe', 'required'],
+    ['doctoral_dissertation', 'new', 'attach', 'required'],
+    ['doctoral_dissertation', 'new', 'collaborators', 'required']
   ].each do |work_type, processing_state, enrichment_type, enrichment_group|
     Sipity::Models::WorkTypeTodoListConfig.find_or_create_by!(
       work_type: work_type,
@@ -44,7 +44,7 @@ ActiveRecord::Base.transaction do
   end
 
   $stdout.puts 'Creating ETD State Diagram...'
-  work_types.fetch('etd').find_or_initialize_default_processing_strategy do |etd_strategy|
+  work_types.fetch('doctoral_dissertation').find_or_initialize_default_processing_strategy do |etd_strategy|
     etd_strategy_roles = {}
 
     [

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,107 +44,115 @@ ActiveRecord::Base.transaction do
   end
 
   $stdout.puts 'Creating ETD State Diagram...'
-  work_types.fetch('doctoral_dissertation').find_or_initialize_default_processing_strategy do |etd_strategy|
-    etd_strategy_roles = {}
+  ['doctoral_dissertation', 'master_thesis'].each do |work_type_name|
+    work_types.fetch(work_type_name).find_or_initialize_default_processing_strategy do |etd_strategy|
+      etd_strategy_roles = {}
 
-    [
-      'creating_user',
-      'etd_reviewer',
-      'advisor'
-    ].each do |role_name|
-      etd_strategy_roles[role_name] = etd_strategy.strategy_roles.find_or_initialize_by(role: roles.fetch(role_name))
-    end
-
-    etd_states = {}
-    [
-      'new',
-      'under_advisor_review',
-      'advisor_changes_requested',
-      'under_grad_school_review',
-      'ready_for_ingest',
-      'ingesting',
-      'done'
-    ].each do |state_name|
-      etd_states[state_name] = etd_strategy.strategy_states.find_or_initialize_by(name: state_name)
-    end
-
-    etd_actions = {}
-    [
-      ['show', nil],
-      ['edit', nil],
-      ['destroy', nil],
-      ['describe', nil],
-      ['attach', nil],
-      ['collaborators', nil],
-      ['defense_date', nil],
-      ['assign_a_doi', nil],
-      ['assign_a_citation', nil],
-      ['submit_for_review', 'under_advisor_review'],
-      ['advisor_signoff', 'under_grad_school_review'],
-      ['advisor_requests_changes', 'advisor_changes_requested'],
-      ['request_revisions', 'under_advisor_review'],
-      ['approve_for_ingest', 'ready_for_ingest'],
-      ['ingest', 'ingesting'],
-      ['ingest_completed', 'done']
-    ].each do |action_name, strategy_state_name|
-      resulting_state = strategy_state_name ? etd_states.fetch(strategy_state_name) : nil
-      etd_actions[action_name] = etd_strategy.strategy_actions.find_or_initialize_by(
-        name: action_name, resulting_strategy_state: resulting_state
-      )
-    end
-
-    {
-      'submit_for_review' => ['describe', 'attach', 'collaborators', 'defense_date']
-    }.each do |guarded_action_name, prereq_action_names|
-      guarded_action = etd_actions.fetch(guarded_action_name)
-      Array.wrap(prereq_action_names).each do |prereq_action_name|
-        prereq_action = etd_actions.fetch(prereq_action_name)
-        guarded_action.requiring_strategy_action_prerequisites.build(prerequisite_strategy_action: prereq_action)
+      [
+        'creating_user',
+        'etd_reviewer',
+        'advisor'
+      ].each do |role_name|
+        etd_strategy_roles[role_name] = etd_strategy.strategy_roles.find_or_initialize_by(role: roles.fetch(role_name))
       end
-    end
 
+      etd_states = {}
+      [
+        'new',
+        'under_advisor_review',
+        'advisor_changes_requested',
+        'under_grad_school_review',
+        'ready_for_ingest',
+        'ingesting',
+        'done'
+      ].each do |state_name|
+        etd_states[state_name] = etd_strategy.strategy_states.find_or_initialize_by(name: state_name)
+      end
 
-    [
-      ['new', 'submit_for_review', ['creating_user']],
-      ['new', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-      ['new', 'edit', ['creating_user', 'etd_reviewer']],
-      ['new', 'describe', ['creating_user', 'etd_reviewer']],
-      ['new', 'attach', ['creating_user', 'etd_reviewer']],
-      ['new', 'collaborators', ['creating_user', 'etd_reviewer']],
-      ['new', 'destroy', ['creating_user', 'etd_reviewer']],
-      ['new', 'defense_date', ['creating_user']],
-      ['new', 'assign_a_doi', ['creating_user', 'etd_reviewer']],
-      ['new', 'assign_a_citation', ['creating_user', 'etd_reviewer']],
-      ['under_advisor_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-      ['under_advisor_review', 'assign_a_doi', ['etd_reviewer']],
-      ['under_advisor_review', 'assign_a_citation', ['etd_reviewer']],
-      ['under_advisor_review', 'destroy', ['etd_reviewer']],
-      ['under_advisor_review', 'advisor_signoff', ['etd_reviewer', 'advisor']],
-      ['under_advisor_review', 'advisor_requests_changes', ['etd_reviewer', 'advisor']],
-      ['advisor_changes_requested', 'assign_a_doi', ['etd_reviewer', 'creating_user']],
-      ['advisor_changes_requested', 'assign_a_citation', ['creating_user']],
-      ['advisor_changes_requested', 'defense_date', ['creating_user']],
-      ['advisor_changes_requested', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-      ['advisor_changes_requested', 'edit', ['creating_user', 'etd_reviewer']],
-      ['advisor_changes_requested', 'destroy', ['creating_user', 'etd_reviewer']],
-      ['under_grad_school_review', 'assign_a_doi', ['etd_reviewer']],
-      ['under_grad_school_review', 'assign_a_citation', ['etd_reviewer']],
-      ['under_grad_school_review', 'request_revisions', ['etd_reviewer']],
-      ['under_grad_school_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-      ['under_grad_school_review', ['edit', 'destroy'], ['etd_reviewer']],
-      ['ready_for_ingest', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-      ['ingesting', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-      ['done', 'show', ['creating_user', 'advisor', 'etd_reviewer']]
-    ].each do |originating_state_name, action_names, role_names|
-      Array.wrap(action_names).each do |action_name|
-        action = etd_actions.fetch(action_name)
-        originating_state = etd_states.fetch(originating_state_name)
-        event = action.strategy_state_actions.find_or_initialize_by(originating_strategy_state: originating_state)
+      etd_actions = {}
+      [
+        ['show', nil],
+        ['edit', nil],
+        ['destroy', nil],
+        ['describe', nil],
+        ['attach', nil],
+        ['collaborators', nil],
+        ['defense_date', nil],
+        ['assign_a_doi', nil],
+        ['assign_a_citation', nil],
+        ['submit_for_review', 'under_advisor_review'],
+        ['advisor_signoff', 'under_grad_school_review'],
+        ['advisor_requests_changes', 'advisor_changes_requested'],
+        ['request_revisions', 'under_advisor_review'],
+        ['approve_for_ingest', 'ready_for_ingest'],
+        ['ingest', 'ingesting'],
+        ['ingest_completed', 'done']
+      ].each do |action_name, strategy_state_name|
+        resulting_state = strategy_state_name ? etd_states.fetch(strategy_state_name) : nil
+        etd_actions[action_name] = etd_strategy.strategy_actions.find_or_initialize_by(
+          name: action_name, resulting_strategy_state: resulting_state
+        )
+      end
 
-        Array.wrap(role_names).each do |role_name|
-          etd_strategy_roles.fetch(role_name).strategy_state_action_permissions.find_or_initialize_by(strategy_state_action: event)
+      pre_requisite_states =       {
+        'submit_for_review' => ['describe', 'attach', 'collaborators']
+      }
+
+      if work_type_name == 'doctoral_dissertation'
+        pre_requisite_states['submit_for_review'] << 'defense_date'
+      end
+
+      pre_requisite_states.each do |guarded_action_name, prereq_action_names|
+          guarded_action = etd_actions.fetch(guarded_action_name)
+          Array.wrap(prereq_action_names).each do |prereq_action_name|
+            prereq_action = etd_actions.fetch(prereq_action_name)
+            guarded_action.requiring_strategy_action_prerequisites.build(prerequisite_strategy_action: prereq_action)
+          end
         end
-      end
+
+
+        [
+          ['new', 'submit_for_review', ['creating_user']],
+          ['new', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+          ['new', 'edit', ['creating_user', 'etd_reviewer']],
+          ['new', 'describe', ['creating_user', 'etd_reviewer']],
+          ['new', 'attach', ['creating_user', 'etd_reviewer']],
+          ['new', 'collaborators', ['creating_user', 'etd_reviewer']],
+          ['new', 'destroy', ['creating_user', 'etd_reviewer']],
+          ['new', 'defense_date', ['creating_user']],
+          ['new', 'assign_a_doi', ['creating_user', 'etd_reviewer']],
+          ['new', 'assign_a_citation', ['creating_user', 'etd_reviewer']],
+          ['under_advisor_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+          ['under_advisor_review', 'assign_a_doi', ['etd_reviewer']],
+          ['under_advisor_review', 'assign_a_citation', ['etd_reviewer']],
+          ['under_advisor_review', 'destroy', ['etd_reviewer']],
+          ['under_advisor_review', 'advisor_signoff', ['etd_reviewer', 'advisor']],
+          ['under_advisor_review', 'advisor_requests_changes', ['etd_reviewer', 'advisor']],
+          ['advisor_changes_requested', 'assign_a_doi', ['etd_reviewer', 'creating_user']],
+          ['advisor_changes_requested', 'assign_a_citation', ['creating_user']],
+          ['advisor_changes_requested', 'defense_date', ['creating_user']],
+          ['advisor_changes_requested', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+          ['advisor_changes_requested', 'edit', ['creating_user', 'etd_reviewer']],
+          ['advisor_changes_requested', 'destroy', ['creating_user', 'etd_reviewer']],
+          ['under_grad_school_review', 'assign_a_doi', ['etd_reviewer']],
+          ['under_grad_school_review', 'assign_a_citation', ['etd_reviewer']],
+          ['under_grad_school_review', 'request_revisions', ['etd_reviewer']],
+          ['under_grad_school_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+          ['under_grad_school_review', ['edit', 'destroy'], ['etd_reviewer']],
+          ['ready_for_ingest', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+          ['ingesting', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+          ['done', 'show', ['creating_user', 'advisor', 'etd_reviewer']]
+        ].each do |originating_state_name, action_names, role_names|
+          Array.wrap(action_names).each do |action_name|
+            action = etd_actions.fetch(action_name)
+            originating_state = etd_states.fetch(originating_state_name)
+            event = action.strategy_state_actions.find_or_initialize_by(originating_strategy_state: originating_state)
+
+            Array.wrap(role_names).each do |role_name|
+              etd_strategy_roles.fetch(role_name).strategy_state_action_permissions.find_or_initialize_by(strategy_state_action: event)
+            end
+          end
+        end
+      end.save!
     end
-  end.save!
-end
+  end

--- a/spec/decorators/sipity/decorators/processing_actions_spec.rb
+++ b/spec/decorators/sipity/decorators/processing_actions_spec.rb
@@ -13,7 +13,7 @@ module Sipity
       let(:an_action) { double(action_type: Models::Processing::StrategyAction::ENRICHMENT_ACTION) }
 
       let!(:entity) do
-        work = repository.create_work!(title: 'Book', work_type: 'etd', work_publication_strategy: 'will_not_publish')
+        work = repository.create_work!(title: 'Book', work_type: 'doctoral_dissertation', work_publication_strategy: 'will_not_publish')
         repository.grant_creating_user_permission_for!(entity: work, user: user)
         work
       end

--- a/spec/features/sipity/enriching_a_work_spec.rb
+++ b/spec/features/sipity/enriching_a_work_spec.rb
@@ -13,7 +13,7 @@ feature 'Enriching a Work', :devise, :feature do
     on('new_work_page') do |the_page|
       expect(the_page).to be_all_there
       the_page.fill_in(:title, with: options.fetch(:title, 'Hello World'))
-      the_page.select(options.fetch(:work_type, 'etd'), from: :work_type)
+      the_page.select(options.fetch(:work_type, 'doctoral_dissertation'), from: :work_type)
       the_page.choose(:work_publication_strategy, with: options.fetch(:work_publication_strategy, 'do_not_know'))
       the_page.submit_button.click
     end
@@ -21,7 +21,7 @@ feature 'Enriching a Work', :devise, :feature do
 
   def attach_file_work
     login_as(user, scope: :user)
-    create_a_work(work_type: 'etd')
+    create_a_work(work_type: 'doctoral_dissertation')
 
     on('work_page') do |the_page|
       the_page.click_todo_item('enrichment/required/attach')
@@ -35,13 +35,13 @@ feature 'Enriching a Work', :devise, :feature do
 
   scenario 'User creates a work then sees it on their dashboard' do
     login_as(user, scope: :user)
-    create_a_work(work_type: 'etd', title: 'Hello World', work_publication_strategy: 'do_not_know')
+    create_a_work(work_type: 'doctoral_dissertation', title: 'Hello World', work_publication_strategy: 'do_not_know')
     visit '/dashboard'
   end
 
   scenario 'User can create a Work' do
     login_as(user, scope: :user)
-    create_a_work(work_type: 'etd', title: 'Hello World', work_publication_strategy: 'do_not_know')
+    create_a_work(work_type: 'doctoral_dissertation', title: 'Hello World', work_publication_strategy: 'do_not_know')
 
     on('work_page') do |the_page|
       expect(the_page.text_for('title')).to eq(['Hello World'])
@@ -78,7 +78,7 @@ feature 'Enriching a Work', :devise, :feature do
 
   scenario 'User can describe additional data' do
     login_as(user, scope: :user)
-    create_a_work(work_type: 'etd')
+    create_a_work(work_type: 'doctoral_dissertation')
 
     on('work_page') do |the_page|
       the_page.click_todo_item('enrichment/required/describe')
@@ -97,7 +97,7 @@ feature 'Enriching a Work', :devise, :feature do
 
   scenario 'User can attach files' do
     login_as(user, scope: :user)
-    create_a_work(work_type: 'etd')
+    create_a_work(work_type: 'doctoral_dissertation')
 
     on('work_page') do |the_page|
       the_page.click_todo_item('enrichment/required/attach')
@@ -115,7 +115,7 @@ feature 'Enriching a Work', :devise, :feature do
 
   scenario 'User can add collaborators' do
     login_as(user, scope: :user)
-    create_a_work(work_type: 'etd')
+    create_a_work(work_type: 'doctoral_dissertation')
 
     on('work_page') do |the_page|
       the_page.click_todo_item('enrichment/required/collaborators')

--- a/spec/features/sipity/trigger_work_state_change_spec.rb
+++ b/spec/features/sipity/trigger_work_state_change_spec.rb
@@ -21,7 +21,7 @@ feature "Trigger Work State Change", :devise, :feature do
       on('new_work_page') do |the_page|
         expect(the_page).to be_all_there
         the_page.fill_in(:title, with: 'Hello World')
-        the_page.select('etd', from: :work_type)
+        the_page.select('doctoral_dissertation', from: :work_type)
         the_page.choose(:work_publication_strategy, with: 'do_not_know')
         the_page.submit_button.click
       end

--- a/spec/fixtures/seeds/scope_processing_entities_for_the_user_and_proxy_for_type.rb
+++ b/spec/fixtures/seeds/scope_processing_entities_for_the_user_and_proxy_for_type.rb
@@ -12,7 +12,7 @@ roles = {}
   roles[role_name] = Sipity::Models::Role.find_or_create_by!(name: role_name)
 end
 
-work_types.fetch('etd').find_or_initialize_default_processing_strategy do |etd_strategy|
+work_types.fetch('doctoral_dissertation').find_or_initialize_default_processing_strategy do |etd_strategy|
   etd_strategy_roles = {}
 
   [

--- a/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
+++ b/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
@@ -154,13 +154,13 @@ Sipity::Models::TransientAnswer.create!([
   {entity_id: 1, entity_type: "Sipity::Models::Work", question_code: "access_rights", answer_code: "private_access"}
 ])
 Sipity::Models::Work.create!([
-  {work_publication_strategy: "will_not_publish", title: "Hello", work_type: "etd"}
+  {work_publication_strategy: "will_not_publish", title: "Hello", work_type: "doctoral_dissertation"}
 ])
 Sipity::Models::WorkType.create!([
-  {name: "etd", description: nil}
+  {name: "doctoral_dissertation", description: nil}
 ])
 Sipity::Models::WorkTypeTodoListConfig.create!([
-  {work_type: "etd", work_processing_state: "new", enrichment_type: "describe", enrichment_group: "required"},
-  {work_type: "etd", work_processing_state: "new", enrichment_type: "attach", enrichment_group: "required"},
-  {work_type: "etd", work_processing_state: "new", enrichment_type: "collaborators", enrichment_group: "required"}
+  {work_type: "doctoral_dissertation", work_processing_state: "new", enrichment_type: "describe", enrichment_group: "required"},
+  {work_type: "doctoral_dissertation", work_processing_state: "new", enrichment_type: "attach", enrichment_group: "required"},
+  {work_type: "doctoral_dissertation", work_processing_state: "new", enrichment_type: "collaborators", enrichment_group: "required"}
 ])

--- a/spec/fixtures/seeds/trigger_work_state_change.rb
+++ b/spec/fixtures/seeds/trigger_work_state_change.rb
@@ -1,5 +1,5 @@
 Sipity::Models::WorkTypeTodoListConfig.create!(
-  work_type: 'etd',
+  work_type: 'doctoral_dissertation',
   work_processing_state: 'new',
   enrichment_type: 'describe',
   enrichment_group: 'required'
@@ -19,7 +19,7 @@ roles = {}
   roles[role_name] = Sipity::Models::Role.find_or_create_by!(name: role_name)
 end
 
-work_types.fetch('etd').find_or_initialize_default_processing_strategy do |etd_strategy|
+work_types.fetch('doctoral_dissertation').find_or_initialize_default_processing_strategy do |etd_strategy|
   etd_strategy_roles = {}
 
   [

--- a/spec/models/sipity/models/work_spec.rb
+++ b/spec/models/sipity/models/work_spec.rb
@@ -34,8 +34,8 @@ module Sipity
           expect { subject.work_type = '__incorrect_work_type__' }.to raise_error(ArgumentError)
         end
 
-        it 'accepts "etd" as an acceptable work_type' do
-          expect { subject.work_type = 'etd' }.to_not raise_error
+        it 'accepts "doctoral_dissertation" as an acceptable work_type' do
+          expect { subject.work_type = 'doctoral_dissertation' }.to_not raise_error
         end
 
         it 'will not accept "ETD" as it is case sensitive' do

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -5,8 +5,8 @@ module Sipity
     RSpec.describe WorkType, type: :model do
       context '.[]' do
         it 'will have an ETD' do
-          described_class.create!(name: 'etd')
-          expect(described_class['etd']).to be_a(WorkType)
+          described_class.create!(name: 'doctoral_dissertation')
+          expect(described_class['doctoral_dissertation']).to be_a(WorkType)
         end
 
         it 'will raise an exception if the WorkType is invalid' do
@@ -32,7 +32,7 @@ module Sipity
       end
 
       context '#find_or_initialize_default_processing_strategy' do
-        subject { described_class.new(name: 'etd') }
+        subject { described_class.new(name: 'doctoral_dissertation') }
         it 'will create a processing strategy if none already exist' do
           expect { subject.find_or_initialize_default_processing_strategy }.
             to change { subject.default_processing_strategy }.from(nil)

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Sipity
   module Commands
     RSpec.describe TodoListCommands, type: :isolated_repository_module do
-      let(:work) { Models::Work.new(id: 1, work_type: 'etd', processing_state: 'new') }
+      let(:work) { Models::Work.new(id: 1, work_type: 'doctoral_dissertation', processing_state: 'new') }
       let(:user) { double }
 
       context '#register_action_taken_on_entity' do

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -37,7 +37,7 @@ module Sipity
       end
 
       context '#create_work!' do
-        let(:attributes) { { title: 'Hello', work_publication_strategy: 'do_not_know', work_type: 'etd' } }
+        let(:attributes) { { title: 'Hello', work_publication_strategy: 'do_not_know', work_type: 'doctoral_dissertation' } }
         it 'will create a work object' do
           expect do
             expect do

--- a/spec/repositories/sipity/queries/enrichment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/enrichment_queries_spec.rb
@@ -7,11 +7,11 @@ module Sipity
       let(:todo_list_configurator) do
         lambda do
           [
-            ['etd', 'new', 'describe', 'required'],
-            ['etd', 'new', 'attach', 'required'],
-            ['etd', 'new', 'mogrify', 'optional'],
-            ['etd', 'next', 'attach', 'required'],
-            ['etd', 'next', 'another', 'required']
+            ['doctoral_dissertation', 'new', 'describe', 'required'],
+            ['doctoral_dissertation', 'new', 'attach', 'required'],
+            ['doctoral_dissertation', 'new', 'mogrify', 'optional'],
+            ['doctoral_dissertation', 'next', 'attach', 'required'],
+            ['doctoral_dissertation', 'next', 'another', 'required']
           ].each do |work_type, processing_state, enrichment_type, enrichment_group|
             Sipity::Models::WorkTypeTodoListConfig.create!(
               work_type: work_type,

--- a/spec/repositories/sipity/queries/permission_queries_spec.rb
+++ b/spec/repositories/sipity/queries/permission_queries_spec.rb
@@ -5,7 +5,7 @@ module Sipity
     # Queries
     RSpec.describe PermissionQueries, type: :isolated_repository_module do
       context 'querying for augmented permission records' do
-        let(:entity) { Models::Work.new(id: 1, work_type: 'etd', processing_state: 'new') }
+        let(:entity) { Models::Work.new(id: 1, work_type: 'doctoral_dissertation', processing_state: 'new') }
         let(:user) { User.new(id: 2) }
         let(:group) { Models::Group.new(id: 3) }
         let(:direct_user_permission) do

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -100,8 +100,8 @@ module Sipity
         let(:commands) { CommandRepository.new }
 
         it "will resolve to an array of entities" do
-          work_one = commands.create_work!(title: 'Book', work_type: 'etd', work_publication_strategy: 'will_not_publish')
-          work_two = commands.create_work!(title: 'Book', work_type: 'etd', work_publication_strategy: 'will_not_publish')
+          work_one = commands.create_work!(title: 'Book', work_type: 'doctoral_dissertation', work_publication_strategy: 'will_not_publish')
+          work_two = commands.create_work!(title: 'Book', work_type: 'doctoral_dissertation', work_publication_strategy: 'will_not_publish')
 
           commands.grant_creating_user_permission_for!(entity: work_one, user: user)
           commands.grant_creating_user_permission_for!(entity: work_two, user: user)

--- a/spec/state_machines/sipity/state_machines/doctoral_dissertation_state_machine_spec.rb
+++ b/spec/state_machines/sipity/state_machines/doctoral_dissertation_state_machine_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 module Sipity
   module StateMachines
-    RSpec.describe EtdStateMachine do
+    RSpec.describe DoctoralDissertationStateMachine do
       let(:initial_processing_state) { 'new' }
-      let(:entity) { double('etd', processing_state: initial_processing_state) }
+      let(:entity) { double('doctoral_dissertation', processing_state: initial_processing_state) }
       let(:user) { double('User') }
       let(:repository) do
         double(
@@ -49,7 +49,7 @@ module Sipity
           end
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :under_advisor_review'  do
             expect(repository).to have_received(:update_processing_state!).
@@ -75,7 +75,7 @@ module Sipity
           end
           it 'will record the event for auditing purposes'  do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :revisions_needed' do
             expect(repository).to have_received(:update_processing_state!).
@@ -91,7 +91,7 @@ module Sipity
           let(:event) { :approve_for_ingest }
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :ready_for_ingest' do
             expect(repository).to have_received(:update_processing_state!).
@@ -112,7 +112,7 @@ module Sipity
           end
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :ingest_completed' do
             expect(repository).to have_received(:update_processing_state!).
@@ -141,7 +141,7 @@ module Sipity
           end
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :ready_for_cataloging' do
             expect(repository).to have_received(:update_processing_state!).
@@ -157,7 +157,7 @@ module Sipity
           let(:event) { :finish_cataloging }
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :cataloged' do
             expect(repository).to have_received(:update_processing_state!).
@@ -174,7 +174,7 @@ module Sipity
           let(:event) { :finish }
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
-              with(entity: entity, user: user, event_name: "etd_state_machine/#{event}")
+              with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")
           end
           it 'will update the ETDs processing_state to :done' do
             expect(repository).to have_received(:update_processing_state!).

--- a/spec/state_machines/sipity/state_machines_spec.rb
+++ b/spec/state_machines/sipity/state_machines_spec.rb
@@ -3,7 +3,7 @@ require 'sipity/state_machines'
 
 module Sipity
   RSpec.describe StateMachines::Interface do
-    let(:entity) { Models::Work.new(work_type: 'etd') }
+    let(:entity) { Models::Work.new(work_type: 'doctoral_dissertation') }
     let(:user) { double('user') }
     let(:repository) { double('repository') }
     it 'exposes the .trigger! interface' do
@@ -13,34 +13,34 @@ module Sipity
   end
   RSpec.describe StateMachines do
     context '.trigger! (public API)' do
-      let(:entity) { Models::Work.new(work_type: 'etd') }
+      let(:entity) { Models::Work.new(work_type: 'doctoral_dissertation') }
       let(:user) { double('user') }
       let(:repository) { double('repository') }
       let(:builder) { double('Builder', new: builder) }
       let(:state_machine) { double('State Machine') }
       it 'will instantiate the workflow and trigger the event' do
         allow(described_class).to receive(:find_state_machine_for).and_call_original
-        expect_any_instance_of(StateMachines::EtdStateMachine).to receive(:trigger!).with(:submit_for_review, {})
+        expect_any_instance_of(StateMachines::DoctoralDissertationStateMachine).to receive(:trigger!).with(:submit_for_review, {})
         described_class.trigger!(entity: entity, user: user, repository: repository, event_name: 'submit_for_review')
       end
     end
 
     context '.state_diagram_for' do
-      let(:valid_work_type) { 'etd' }
+      let(:valid_work_type) { 'doctoral_dissertation' }
       context 'with valid enrichment type' do
         subject { described_class.state_diagram_for(work_type: valid_work_type) }
         it { should be_a(StateMachines::StateDiagram) }
-        it { should eq(StateMachines::EtdStateMachine.state_diagram) }
+        it { should eq(StateMachines::DoctoralDissertationStateMachine.state_diagram) }
       end
     end
 
     context '.find_state_machine_for' do
-      let(:valid_work_type) { 'etd' }
+      let(:valid_work_type) { 'doctoral_dissertation' }
       let(:invalid_work_type) { '__very_much_not_valid__' }
       context 'with valid enrichment type' do
         subject { described_class.find_state_machine_for(work_type: valid_work_type) }
         it { should respond_to(:new) }
-        it { should eq(StateMachines::EtdStateMachine) }
+        it { should eq(StateMachines::DoctoralDissertationStateMachine) }
       end
       context 'with invalid enrichment type' do
         it 'will raise an exception' do


### PR DESCRIPTION
## Renaming ETD to Doctoral Dissertation

@9d8e8856785a492c0d76ef1d26e1d5e96d2fc7df

Given that ETD represented the Doctoral Dissertation and Master's
Thesis concept, and the DD and MT vary in required information that we
collect; Then we need to separate their definitions.

## Adding MasterThesis work type

@3c395542e5387c9713400d9d5eb0d254dc73cc74

The difference between MasterThesis and DoctoralDissertation is that
the DefenseDate is pre-requisite for submitting a DoctoralDissertation
for review; Whereas it is optional for a MasterThesis.
