### PR TITLE
Updating processing query

### DIFF
--- a/spec/features/sipity/trigger_work_state_change_spec.rb
+++ b/spec/features/sipity/trigger_work_state_change_spec.rb
@@ -45,6 +45,8 @@ feature "Trigger Work State Change", :devise, :feature do
 
       on('work_page') do |the_page|
         expect(the_page.processing_state).to eq('new')
+        # I expect this named object to be there
+        expect { the_page.find_named_object('enrichment/optional/assign_a_doi') }.to_not raise_error
         # Because there are no required steps; I can continue
         the_page.take_named_action('event_trigger/submit_for_review')
       end
@@ -54,6 +56,8 @@ feature "Trigger Work State Change", :devise, :feature do
       end
 
       on('work_page') do |the_page|
+        # An action once available is no longer available
+        expect { the_page.find_named_object('enrichment/optional/assign_a_doi') }.to raise_error(Capybara::ElementNotFound)
         # The state was advanced
         expect(the_page.processing_state).to eq('under_advisor_review')
         expect { the_page.find_named_object('event_trigger/submit_for_review') }.

--- a/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
+++ b/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
@@ -1,0 +1,88 @@
+User.create!([
+  {email: "test@example.com", remember_created_at: nil, sign_in_count: 2, current_sign_in_at: "2015-02-24 18:32:52", last_sign_in_at: "2015-02-24 18:32:52", current_sign_in_ip: "127.0.0.1", last_sign_in_ip: "127.0.0.1", name: "Test User", role: nil, username: "test@example.com"}
+])
+Sipity::Models::AccessRight.create!([
+  {entity_id: 1, entity_type: "Sipity::Models::Work", access_right_code: "private_access", enforcement_start_date: "2015-02-24", enforcement_end_date: nil}
+])
+Sipity::Models::AdditionalAttribute.create!([
+  {work_id: 1, key: "abstract", value: "Lorem ipsum"}
+])
+Sipity::Models::EventLog.create!([
+  {user_id: 1, entity_id: 1, entity_type: "Sipity::Models::Work", event_name: "submit"},
+  {user_id: 1, entity_id: 1, entity_type: "Sipity::Models::Work", event_name: "work_enrichments/describe_form/submit"},
+  {user_id: 1, entity_id: 1, entity_type: "Sipity::Models::Work", event_name: "etd/submit_for_review_form/submit"}
+])
+Sipity::Models::Processing::Actor.create!([
+  {proxy_for_id: 1, proxy_for_type: "User", name_of_proxy: nil}
+])
+Sipity::Models::Processing::Entity.create!([
+  {proxy_for_id: 1, proxy_for_type: "Sipity::Models::Work", strategy_id: 1, strategy_state_id: "2"}
+])
+Sipity::Models::Processing::EntityActionRegister.create!([
+  {strategy_action_id: 2, entity_id: 1, requested_by_actor_id: 1, on_behalf_of_actor_id: 1},
+  {strategy_action_id: 4, entity_id: 1, requested_by_actor_id: 1, on_behalf_of_actor_id: 1}
+])
+Sipity::Models::Processing::EntitySpecificResponsibility.create!([
+  {strategy_role_id: 1, entity_id: 1, actor_id: 1}
+])
+Sipity::Models::Processing::Strategy.create!([
+  {name: "doctoral_dissertation processing", description: nil, proxy_for_id: 1, proxy_for_type: "Sipity::Models::WorkType"}
+])
+Sipity::Models::Processing::StrategyAction.create!([
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "show", form_class_name: nil, completion_required: false, action_type: "resourceful_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "describe", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: nil, name: "assign_a_doi", form_class_name: nil, completion_required: false, action_type: "enrichment_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 2, name: "submit_for_review", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"}
+])
+Sipity::Models::Processing::StrategyActionPrerequisite.create!([
+  {guarded_strategy_action_id: 4, prerequisite_strategy_action_id: 2}
+])
+Sipity::Models::Processing::StrategyRole.create!([
+  {strategy_id: 1, role_id: 1},
+  {strategy_id: 1, role_id: 2},
+  {strategy_id: 1, role_id: 3}
+])
+Sipity::Models::Processing::StrategyState.create!([
+  {strategy_id: 1, name: "new"},
+  {strategy_id: 1, name: "under_advisor_review"}
+])
+Sipity::Models::Processing::StrategyStateAction.create!([
+  {originating_strategy_state_id: 1, strategy_action_id: 1},
+  {originating_strategy_state_id: 2, strategy_action_id: 1},
+  {originating_strategy_state_id: 1, strategy_action_id: 2},
+  {originating_strategy_state_id: 1, strategy_action_id: 3},
+  {originating_strategy_state_id: 2, strategy_action_id: 3},
+  {originating_strategy_state_id: 1, strategy_action_id: 4}
+])
+Sipity::Models::Processing::StrategyStateActionPermission.create!([
+  {strategy_role_id: 1, strategy_state_action_id: 6},
+  {strategy_role_id: 1, strategy_state_action_id: 1},
+  {strategy_role_id: 1, strategy_state_action_id: 3},
+  {strategy_role_id: 1, strategy_state_action_id: 4},
+  {strategy_role_id: 1, strategy_state_action_id: 2},
+  {strategy_role_id: 2, strategy_state_action_id: 1},
+  {strategy_role_id: 2, strategy_state_action_id: 3},
+  {strategy_role_id: 2, strategy_state_action_id: 4},
+  {strategy_role_id: 2, strategy_state_action_id: 2},
+  {strategy_role_id: 2, strategy_state_action_id: 5},
+  {strategy_role_id: 3, strategy_state_action_id: 1},
+  {strategy_role_id: 3, strategy_state_action_id: 2}
+])
+Sipity::Models::Role.create!([
+  {name: "creating_user", description: nil},
+  {name: "etd_reviewer", description: nil},
+  {name: "advisor", description: nil}
+])
+Sipity::Models::TransientAnswer.create!([
+  {entity_id: 1, entity_type: "Sipity::Models::Work", question_code: "access_rights", answer_code: "private_access"}
+])
+Sipity::Models::Work.create!([
+  {work_publication_strategy: "do_not_know", title: "Hello World", work_type: "doctoral_dissertation"}
+])
+Sipity::Models::WorkType.create!([
+  {name: "doctoral_dissertation", description: nil},
+  {name: "master_thesis", description: nil}
+])
+Sipity::Models::WorkTypeTodoListConfig.create!([
+  {work_type: "doctoral_dissertation", work_processing_state: "new", enrichment_type: "describe", enrichment_group: "required"}
+])

--- a/spec/fixtures/seeds/trigger_work_state_change.rb
+++ b/spec/fixtures/seeds/trigger_work_state_change.rb
@@ -41,6 +41,7 @@ work_types.fetch('doctoral_dissertation').find_or_initialize_default_processing_
   [
     ['show', nil],
     ['describe', nil],
+    ['assign_a_doi', nil],
     ['submit_for_review', 'under_advisor_review'],
   ].each do |action_name, strategy_state_name, action_type|
     resulting_state = strategy_state_name ? etd_states.fetch(strategy_state_name) : nil
@@ -63,7 +64,9 @@ work_types.fetch('doctoral_dissertation').find_or_initialize_default_processing_
     ['new', 'submit_for_review', ['creating_user']],
     ['new', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
     ['new', 'describe', ['creating_user', 'etd_reviewer']],
+    ['new', 'assign_a_doi', ['creating_user', 'etd_reviewer']],
     ['under_advisor_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
+    ['under_advisor_review', 'assign_a_doi', ['etd_reviewer']],
   ].each do |originating_state_name, action_name, role_names|
     action = etd_actions.fetch(action_name)
     originating_state = etd_states.fetch(originating_state_name)

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -231,12 +231,17 @@ module Sipity
       end
 
       context '#scope_permitted_entity_strategy_actions_for_current_state' do
+        before do
+          Sipity::SpecSupport.load_database_seeds!(
+            seeds_path: 'spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb'
+          )
+        end
+        let(:user) { User.first! }
+        let(:entity) { Sipity::Models::Processing::Entity.first! }
+
         subject { test_repository.scope_permitted_entity_strategy_actions_for_current_state(user: user, entity: entity) }
-        it "will include permitted strategy_state_actions" do
-          user_processing_actor
-          entity_specific_responsibility
-          action_permission
-          expect(subject).to eq([action_permission.strategy_state_action.strategy_action])
+        it "will return the correct actions based on user and entity state" do
+          expect(subject.pluck(:name)).to eq(['show'])
         end
         it "will be a chainable scope" do
           expect(subject).to be_a(ActiveRecord::Relation)


### PR DESCRIPTION
## Adding spec for optional items visibility

@c5988b1238ee139954d35271339ac5ec5bc59fcf

Addresses a bug found on the punch list:

> Optional todo items are still available for completion while a work
> is under advisor review.

## Adding a query test to verify expected behavior

@7b6358093c870c35a6a91ce5a88d480f375b9d03

Addresses the following:

> Optional todo items are still available for completion while a work
> is under advisor review.

This was occuring because in the originating state, the optional
actions were visible to the creating user. Once the state advanced,
the available action query was not accounting for the state of the
entity.
