### PR TITLE
Adding advisor requests changes

### DIFF
--- a/app/forms/sipity/forms/etd/advisor_requests_changes_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_requests_changes_form.rb
@@ -1,0 +1,46 @@
+module Sipity
+  module Forms
+    module Etd
+      # Responsible for capturing advisor comments and forwarding them on to
+      # the student.
+      class AdvisorRequestsChangesForm < ProcessingActionForm
+        def initialize(attributes = {})
+          super
+          @comment = attributes[:comment]
+          self.action = attributes.fetch(:processing_action_name) { default_processing_action_name }
+        end
+
+        attr_reader :action, :comment
+        validates :comment, presence: true
+
+        def processing_action_name
+          action.name
+        end
+
+        private
+
+        def save(repository:, requested_by:)
+          super do
+            repository.send_notification_for_entity_trigger(
+              notification: 'advisor_has_requested_changes',
+              entity: work,
+              acting_as: ['creating_user']
+            )
+            repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
+            repository.record_processing_comment(entity: work, commenter: requested_by, comment: comment)
+          end
+        end
+
+        def enrichment_type
+          self.class.to_s.demodulize.underscore.sub(/_form\Z/i, '')
+        end
+        alias_method :default_processing_action_name, :enrichment_type
+
+        include Conversions::ConvertToProcessingAction
+        def action=(value)
+          @action = convert_to_processing_action(value, scope: to_processing_entity)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/etd/advisor_requests_changes_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_requests_changes_form.rb
@@ -21,13 +21,13 @@ module Sipity
 
         def save(repository:, requested_by:)
           super do
+            repository.record_processing_comment(entity: work, commenter: requested_by, comment: comment, action: action)
             repository.send_notification_for_entity_trigger(
               notification: 'advisor_has_requested_changes',
               entity: work,
               acting_as: ['creating_user']
             )
             repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
-            repository.record_processing_comment(entity: work, commenter: requested_by, comment: comment)
           end
         end
 

--- a/app/models/sipity/models/processing/comment.rb
+++ b/app/models/sipity/models/processing/comment.rb
@@ -1,0 +1,17 @@
+module Sipity
+  module Models
+    module Processing
+      # Responsible for capturing a :comment made by a given :actor on a given
+      # :entity at a given :originating_strategy_state as part of a given
+      # :originating_strategy_action.
+      class Comment < ActiveRecord::Base
+        self.table_name = 'sipity_processing_comments'
+
+        belongs_to :actor, class_name: 'Sipity::Models::Processing::Actor'
+        belongs_to :entity, class_name: 'Sipity::Models::Processing::Entity'
+        belongs_to :originating_strategy_action, class_name: 'Sipity::Models::Processing::StrategyAction'
+        belongs_to :originating_strategy_state, class_name: 'Sipity::Models::Processing::StrategyState'
+      end
+    end
+  end
+end

--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -2,9 +2,14 @@ module Sipity
   # :nodoc:
   module Commands
     # Responsible for interaction with the todo list.
+    # TODO: Rename to ProcessingCommands
     module TodoListCommands
       def register_action_taken_on_entity(work:, enrichment_type:, requested_by:)
         Services::RegisterActionTakenOnEntity.call(entity: work, action: enrichment_type, requested_by: requested_by)
+      end
+
+      # @api public
+      def record_processing_comment(*)
       end
     end
   end

--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -9,7 +9,30 @@ module Sipity
       end
 
       # @api public
-      def record_processing_comment(*)
+      #
+      # Responsible for capturing a :comment made by a given :commenter on a
+      # given :entity as part of a given :action.
+      #
+      # @param entity <can be converted to a Processing::Entity>
+      # @param commentor <can be converted to a Processing::Actor>
+      # @param action <can be converted to a Processing::StrategyAction>
+      # @param comment <String>
+      #
+      # @return Models::Processing::Comment
+      def record_processing_comment(entity:, commenter:, action:, comment:)
+        entity = Conversions::ConvertToProcessingEntity.call(entity)
+        actor = Conversions::ConvertToProcessingActor.call(commenter)
+        action = Conversions::ConvertToProcessingAction.call(action, scope: entity)
+
+        # Opting for IDs because I want my unit tests to not require all of the
+        # collaborating models to be built.
+        Models::Processing::Comment.create!(
+          entity_id: entity.id,
+          actor_id: actor.id,
+          originating_strategy_action_id: action.id,
+          originating_strategy_state_id: entity.strategy_state.id,
+          comment: comment
+        )
       end
     end
   end

--- a/db/migrate/20150225173436_create_sipity_models_processing_comments.rb
+++ b/db/migrate/20150225173436_create_sipity_models_processing_comments.rb
@@ -1,0 +1,21 @@
+class CreateSipityModelsProcessingComments < ActiveRecord::Migration
+  def change
+    create_table :sipity_processing_comments do |t|
+      t.integer :entity_id
+      t.integer :actor_id
+      t.text :comment
+      t.integer :originating_strategy_action_id
+      t.integer :originating_strategy_state_id
+
+      t.timestamps null: false
+    end
+    add_index :sipity_processing_comments, :entity_id
+    add_index :sipity_processing_comments, :actor_id
+    add_index :sipity_processing_comments, :originating_strategy_action_id, name: :sipity_processing_comments_action_index
+    add_index :sipity_processing_comments, :originating_strategy_state_id, name: :sipity_processing_comments_state_index
+    change_column_null :sipity_processing_comments, :entity_id, false
+    change_column_null :sipity_processing_comments, :actor_id, false
+    change_column_null :sipity_processing_comments, :originating_strategy_action_id, false
+    change_column_null :sipity_processing_comments, :originating_strategy_state_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150225132618) do
+ActiveRecord::Schema.define(version: 20150225173436) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -141,6 +141,21 @@ ActiveRecord::Schema.define(version: 20150225132618) do
   end
 
   add_index "sipity_processing_actors", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_actors_proxy_for", unique: true
+
+  create_table "sipity_processing_comments", force: :cascade do |t|
+    t.integer  "entity_id",                      null: false
+    t.integer  "actor_id",                       null: false
+    t.text     "comment"
+    t.integer  "originating_strategy_action_id", null: false
+    t.integer  "originating_strategy_state_id",  null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+  end
+
+  add_index "sipity_processing_comments", ["actor_id"], name: "index_sipity_processing_comments_on_actor_id"
+  add_index "sipity_processing_comments", ["entity_id"], name: "index_sipity_processing_comments_on_entity_id"
+  add_index "sipity_processing_comments", ["originating_strategy_action_id"], name: "sipity_processing_comments_action_index"
+  add_index "sipity_processing_comments", ["originating_strategy_state_id"], name: "sipity_processing_comments_state_index"
 
   create_table "sipity_processing_entities", force: :cascade do |t|
     t.integer  "proxy_for_id",      null: false

--- a/spec/forms/sipity/forms/etd/advisor_requests_changes_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/advisor_requests_changes_form_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+module Sipity
+  module Forms
+    module Etd
+      RSpec.describe AdvisorRequestsChangesForm do
+        let(:processing_entity) { Models::Processing::Entity.new(strategy_id: 1) }
+        let(:work) { double('Work', to_processing_entity: processing_entity) }
+        let(:repository) { CommandRepositoryInterface.new }
+        let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: 'hello') }
+        let(:user) { User.new(id: 1) }
+        subject { described_class.new(work: work, processing_action_name: action) }
+
+        its(:processing_action_name) { should eq(action.name) }
+
+        context 'processing_action_name to action conversion' do
+          it 'will use the given action if the strategy matches' do
+            subject = described_class.new(work: work, processing_action_name: action)
+            expect(subject.action).to eq(action)
+          end
+        end
+
+        context 'with valid data' do
+          before { expect(subject).to receive(:valid?).and_return(true) }
+
+          it 'will log the event' do
+            expect(repository).to receive(:log_event!).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will register than the given action was taken on the entity' do
+            expect(repository).to receive(:register_action_taken_on_entity).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will update the processing state' do
+            strategy_state = action.build_resulting_strategy_state
+            expect(repository).to receive(:update_processing_state!).
+              with(entity: work, to: strategy_state).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will send creating user a note that the advisor has requested changes' do
+            expect(repository).to receive(:send_notification_for_entity_trigger).
+              with(notification: 'advisor_has_requested_changes', entity: work, acting_as: ['creating_user']).
+              and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will record the processing comment' do
+            expect(repository).to receive(:record_processing_comment).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/sipity/models/processing/comment_spec.rb
+++ b/spec/models/sipity/models/processing/comment_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+module Sipity
+  module Models
+    module Processing
+      RSpec.describe Comment do
+
+        context 'database configuration' do
+          subject { described_class }
+          its(:column_names) { should include('entity_id') }
+          its(:column_names) { should include('actor_id') }
+          its(:column_names) { should include('comment') }
+          its(:column_names) { should include('originating_strategy_action_id') }
+          its(:column_names) { should include('originating_strategy_state_id') }
+        end
+      end
+    end
+  end
+end

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -13,6 +13,20 @@ module Sipity
           test_repository.register_action_taken_on_entity(work: work, enrichment_type: existing_enrichment_type, requested_by: user)
         end
       end
+
+      context '#record_processing_comment' do
+        let(:entity) { Models::Processing::Entity.new(id: 1, strategy_id: strategy.id, strategy_state_id: state.id, strategy_state: state) }
+        let(:actor) { Models::Processing::Actor.new(id: 2) }
+        let(:action) { Models::Processing::StrategyAction.new(id: 3, strategy_id: strategy.id) }
+        let(:strategy) { Models::Processing::Strategy.new(id: 4) }
+        let(:state) { Models::Processing::StrategyState.new(id: 5) }
+        let(:comment) { 'Hello World' }
+        it "will create a Models::Processing::Comment" do
+          expect(
+            test_repository.record_processing_comment(entity: entity, commenter: actor, action: action, comment: comment)
+          ).to be_a(Models::Processing::Comment)
+        end
+      end
     end
   end
 end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -58,6 +58,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb
+    def record_processing_comment(*)
+    end
+
+    # @see ./app/repositories/sipity/commands/todo_list_commands.rb
     def register_action_taken_on_entity(work:, enrichment_type:, requested_by:)
     end
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -58,7 +58,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb
-    def record_processing_comment(*)
+    def record_processing_comment(entity:, commenter:, action:, comment:)
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb


### PR DESCRIPTION
## Initial commit regarding AdvisorRequestsChanges

@6b7ad367726feddf343d2cc6218ca1aa4d02187b

This highlights the behavior, however it calls attention to a few
interface changes that will need to occur.

## Adding Models::Processing::Comment

@db91ae6125d6681e04538bf38504d4d44f997b57

> Responsible for capturing a :comment made by a given :actor on a
> given :entity at a given :originating_strategy_state as part of a
> given :originating_strategy_action.

## Adding #record_processing_comment method

@15431dcbc8dbc7662bc140abc2e837b3433fdded

> Responsible for capturing a :comment made by a given :commenter on a
> given :entity as part of a given :action.
