### PR TITLE
Adding ability to capture advisor comments

### DIFF
--- a/app/controllers/sipity/controllers/work_event_triggers_controller.rb
+++ b/app/controllers/sipity/controllers/work_event_triggers_controller.rb
@@ -8,12 +8,12 @@ module Sipity
       self.runner_container = Runners::WorkEventTriggerRunners
 
       def new
-        _status, @model = run(work_id: work_id, processing_action_name: processing_action_name)
+        _status, @model = run(new_params)
         respond_with(@model)
       end
 
       def create
-        run(work_id: work_id, processing_action_name: processing_action_name) do |on|
+        run(create_params) do |on|
           on.success { |work| redirect_to work_path(work), notice: message_for("#{processing_action_name}_triggered", title: work.title) }
           on.failure do |model|
             @model = model
@@ -27,6 +27,11 @@ module Sipity
       helper_method :model
 
       private
+
+      def create_params
+        (params[:work] || {}).merge(work_id: work_id, processing_action_name: processing_action_name).with_indifferent_access
+      end
+      alias_method :new_params, :create_params
 
       def work_id
         params.require(:work_id)

--- a/app/forms/sipity/forms/etd/advisor_requests_changes_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_requests_changes_form.rb
@@ -17,6 +17,13 @@ module Sipity
           action.name
         end
 
+        # @param f SimpleFormBuilder
+        #
+        # @return String
+        def render(f:)
+          f.input(:comment, as: :text, autofocus: true)
+        end
+
         private
 
         def save(repository:, requested_by:)

--- a/app/forms/sipity/forms/processing_action_form.rb
+++ b/app/forms/sipity/forms/processing_action_form.rb
@@ -19,6 +19,9 @@ module Sipity
         to_param.nil? ? false : true
       end
 
+      def render(*)
+      end
+
       self.policy_enforcer = Policies::Processing::WorkProcessingPolicy
 
       def initialize(attributes = {})
@@ -28,6 +31,7 @@ module Sipity
       attr_reader :work
       delegate :to_processing_entity, to: :work
       delegate :strategy_id, :strategy, to: :to_processing_entity
+      alias_method :to_model, :work
 
       validates :work, presence: true
 

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -30,6 +30,11 @@ module Sipity
         @entity = entity
         mail(to: to, cc: cc, bcc: bcc)
       end
+
+      def advisor_has_requested_changes(entity:, to:, cc: [], bcc: [])
+        @entity = entity
+        mail(to: to, cc: cc, bcc: bcc)
+      end
     end
   end
 end

--- a/app/runners/sipity/runners/work_event_trigger_runners.rb
+++ b/app/runners/sipity/runners/work_event_trigger_runners.rb
@@ -7,9 +7,10 @@ module Sipity
         self.authentication_layer = :default
         self.authorization_layer = :default
 
-        def run(work_id:, processing_action_name:)
-          work = repository.find_work(work_id)
-          form = repository.build_event_trigger_form(work: work, processing_action_name: processing_action_name)
+        def run(attributes = {})
+          processing_action_name = attributes.fetch(:processing_action_name)
+          work = repository.find_work(attributes.fetch(:work_id))
+          form = repository.build_event_trigger_form(attributes.merge(work: work))
           authorization_layer.enforce!(processing_action_name => form) do
             callback(:success, form)
           end
@@ -21,9 +22,10 @@ module Sipity
         self.authentication_layer = :default
         self.authorization_layer = :default
 
-        def run(work_id:, processing_action_name:)
-          work = repository.find_work(work_id)
-          form = repository.build_event_trigger_form(work: work, processing_action_name: processing_action_name)
+        def run(attributes = {})
+          processing_action_name = attributes.fetch(:processing_action_name)
+          work = repository.find_work(attributes.fetch(:work_id))
+          form = repository.build_event_trigger_form(attributes.merge(work: work))
           authorization_layer.enforce!(processing_action_name => form) do
             if form.submit(repository: repository, requested_by: current_user)
               callback(:success, work)

--- a/app/views/sipity/controllers/work_event_triggers/new.html.erb
+++ b/app/views/sipity/controllers/work_event_triggers/new.html.erb
@@ -2,8 +2,12 @@
   <div itemprop="potentialAction" itemscope itemtype="http://schema.org/Action">
     <link itemprop="url" href="<%= event_trigger_for_work_path(model.work, model.processing_action_name) %>">
     <meta itemprop="name" content="confirm/event_trigger/submit_for_review">
-    <%= form_tag(event_trigger_for_work_path(model.work, model.processing_action_name), method: :post, itemscope: true, itemprop: 'target', itemtype: "http://schema.org/EntryPoint") do %>
-      <%= submit_tag("Submit", itemprop: 'name', autofocus: true) %>
-    <% end %>
+    <div itemscope itemprop="target" itemtype="http://schema.org/EntryPoint">
+      <%= simple_form_for(model, url: event_trigger_for_work_path(model.work, model.processing_action_name), method: :post) do |f| %>
+        <%= f.error_notification %>
+        <%= model.render(f: f) %>
+        <%= submit_tag("Submit", itemprop: 'name', autofocus: true) %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/spec/controllers/sipity/controllers/work_event_triggers_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_event_triggers_controller_spec.rb
@@ -4,6 +4,7 @@ require 'hesburgh/lib/mock_runner'
 module Sipity
   module Controllers
     RSpec.describe WorkEventTriggersController, type: :controller do
+      let(:attributes) { { 'hello' => 'world' } }
       let(:work) { double('Work', persisted?: true, title: 'Hello World') }
       let(:processing_action_name) { 'submit_for_review' }
       context 'GET #new' do
@@ -11,13 +12,13 @@ module Sipity
         let(:runner) do
           Hesburgh::Lib::MockRunner.new(
             yields: yielded_object, callback_name: callback_name, context: controller,
-            run_with: { processing_action_name: processing_action_name, work_id: work.to_param }
+            run_with: attributes.merge(processing_action_name: processing_action_name, work_id: work.to_param).with_indifferent_access
           )
         end
         let(:yielded_object) { work }
         let(:callback_name) { :success }
         it 'will render the new page' do
-          get 'new', work_id: work.to_param, processing_action_name: processing_action_name
+          get 'new', work_id: work.to_param, processing_action_name: processing_action_name, work: attributes
           expect(assigns(:model)).to_not be_nil
           expect(response).to render_template('new')
         end
@@ -29,7 +30,7 @@ module Sipity
         let(:runner) do
           Hesburgh::Lib::MockRunner.new(
             yields: yielded_object, callback_name: callback_name, context: controller,
-            run_with: { processing_action_name: processing_action_name, work_id: work.to_param }
+            run_with: attributes.merge(processing_action_name: processing_action_name, work_id: work.to_param).with_indifferent_access
           )
         end
         before { controller.runner = runner }
@@ -37,7 +38,7 @@ module Sipity
           let(:callback_name) { :success }
           let(:yielded_object) { work }
           it 'will redirect to the work' do
-            post 'create', work_id: work.to_param, processing_action_name: processing_action_name
+            post 'create', work_id: work.to_param, processing_action_name: processing_action_name, work: attributes
             expect(flash[:notice]).to_not be_empty
             expect(assigns(:model)).to be_nil
             expect(response).to redirect_to work_path(work.to_param)
@@ -48,7 +49,7 @@ module Sipity
           let(:callback_name) { :failure }
           let(:yielded_object) { form }
           it 'will render the work again' do
-            post 'create', work_id: work.to_param, processing_action_name: processing_action_name
+            post 'create', work_id: work.to_param, processing_action_name: processing_action_name, work: attributes
             expect(assigns(:model)).to be_present
             expect(response).to render_template('new')
           end

--- a/spec/forms/sipity/forms/etd/advisor_requests_changes_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/advisor_requests_changes_form_spec.rb
@@ -13,6 +13,14 @@ module Sipity
 
         its(:processing_action_name) { should eq(action.name) }
 
+        context '#render' do
+          let(:f) { double }
+          it 'will return an input text area' do
+            expect(f).to receive(:input).with(:comment, as: :text, autofocus: true)
+            subject.render(f: f)
+          end
+        end
+
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do
             subject = described_class.new(work: work, processing_action_name: action)

--- a/spec/forms/sipity/forms/processing_action_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_action_form_spec.rb
@@ -10,6 +10,8 @@ module Sipity
       its(:to_key) { should be_empty }
       its(:to_param) { should be_nil }
       its(:persisted?) { should eq(false) }
+      its(:to_model) { should eq(work) }
+      its(:render) { should be_nil }
 
       context 'the processing entity vs. "entity" differentiation' do
         let(:strategy) { Models::Processing::Strategy.new(id: 1) }

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -10,15 +10,6 @@ module Sipity
       after do
         ActionMailer::Base.deliveries.clear
       end
-      context '#confirmation_of_entity_submitted_for_review' do
-        let(:entity) { Models::Work.new }
-        let(:to) { 'test@example.com' }
-        it 'should send an email' do
-          described_class.confirmation_of_entity_submitted_for_review(entity: entity, to: to).deliver_now
-
-          expect(ActionMailer::Base.deliveries.count).to eq(1)
-        end
-      end
       context '#request_revisions_from_creator' do
         let(:entity) { Models::Work.new }
         let(:to) { 'test@example.com' }
@@ -78,6 +69,15 @@ module Sipity
         let(:to) { 'test@example.com' }
         it 'should send an email' do
           described_class.confirmation_of_entity_ingested(entity: entity, to: to).deliver_now
+
+          expect(ActionMailer::Base.deliveries.count).to eq(1)
+        end
+      end
+      context '#advisor_has_requested_changes' do
+        let(:entity) { Models::Work.new }
+        let(:to) { 'test@example.com' }
+        it 'should send an email' do
+          described_class.advisor_has_requested_changes(entity: entity, to: to).deliver_now
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end


### PR DESCRIPTION
## Adjusting WorkEventTriggers to accept attributes

@c885b5f03084fad89dcb2e237fb476d5cfa56b5a

Prior to this change, the application was not accepting any additional
payload. However, this is something that is required.

## Adjusting WorkEventTriggers form

@b70e81f4d72d7db2caec601a401c9caf5aa39f40

Now allowing attributes to be pased based on input

## Adding ability to render addition context

@78ccdf9495949fdd463c4fc483b20cb254fcbdb7

For the state changing event triggers, I want to be able to capture
additional information. The initial case is comments.

## Adding new email for advisors

@b2976c19f912024ceb72d3407188bcba41732536

Adding the basis for sending an advisor_has_requested_changes email.
