### PR TITLE
Adjusting column definition

### DIFF
--- a/db/migrate/20150226134513_update_processing_entities_column_type.rb
+++ b/db/migrate/20150226134513_update_processing_entities_column_type.rb
@@ -1,0 +1,5 @@
+class UpdateProcessingEntitiesColumnType < ActiveRecord::Migration
+  def change
+    change_column(:sipity_processing_entities, :strategy_state_id, :integer)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150225173436) do
+ActiveRecord::Schema.define(version: 20150226134513) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -161,7 +161,7 @@ ActiveRecord::Schema.define(version: 20150225173436) do
     t.integer  "proxy_for_id",      null: false
     t.string   "proxy_for_type",    null: false
     t.integer  "strategy_id",       null: false
-    t.string   "strategy_state_id", null: false
+    t.integer  "strategy_state_id", null: false
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
   end


### PR DESCRIPTION
In a moment of copy/paste blindness, I set a foreign key as a string.
While this works, it is less than optimal for queries/joins.