### PR TITLE
Renaming action for clarity

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,7 +68,7 @@ ActiveRecord::Base.transaction do
         ['advisor_signoff', 'under_grad_school_review'],
         ['advisor_requests_change', 'advisor_changes_requested'],
         ['grad_school_requests_change', 'under_grad_school_review'],
-        ['approve_for_ingest', 'ready_for_ingest'],
+        ['grad_school_signoff', 'ready_for_ingest'],
         ['ingest', 'ingesting'],
         ['ingest_completed', 'done']
       ].each do |action_name, strategy_state_name|
@@ -122,7 +122,7 @@ ActiveRecord::Base.transaction do
         ['under_grad_school_review', 'assign_a_citation', ['etd_reviewer']],
         ['under_grad_school_review', 'grad_school_requests_change', ['etd_reviewer']],
         ['under_grad_school_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
-        ['under_grad_school_review', 'approve_for_ingest', ['etd_reviewer']],
+        ['under_grad_school_review', 'grad_school_signoff', ['etd_reviewer']],
         ['under_grad_school_review', ['edit', 'destroy'], ['etd_reviewer']],
         ['ready_for_ingest', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
         ['ingesting', 'show', ['creating_user', 'advisor', 'etd_reviewer']],


### PR DESCRIPTION
Instead of the more obtuse "approve_for_ingest" make the action name
more clear by stating intent of approval not speculation on what
happens next.