### PR TITLE
Adding approve for ingest form

### DIFF
--- a/app/forms/sipity/forms/etd/approve_for_ingest_form.rb
+++ b/app/forms/sipity/forms/etd/approve_for_ingest_form.rb
@@ -1,0 +1,40 @@
+module Sipity
+  module Forms
+    module Etd
+      # Responsible for submitting the final Grad School approval.
+      class ApproveForIngestForm < ProcessingActionForm
+        def initialize(attributes = {})
+          super
+          self.action = attributes.fetch(:processing_action_name) { default_processing_action_name }
+        end
+
+        attr_reader :action
+
+        def processing_action_name
+          action.name
+        end
+
+        private
+
+        def save(repository:, requested_by:)
+          super do
+            repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
+            repository.send_notification_for_entity_trigger(
+              notification: "confirmation_of_approve_for_ingest", entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor']
+            )
+          end
+        end
+
+        def enrichment_type
+          self.class.to_s.demodulize.underscore.sub(/_form\Z/i, '')
+        end
+        alias_method :default_processing_action_name, :enrichment_type
+
+        include Conversions::ConvertToProcessingAction
+        def action=(value)
+          @action = convert_to_processing_action(value, scope: to_processing_entity)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/etd/grad_school_signoff_form.rb
+++ b/app/forms/sipity/forms/etd/grad_school_signoff_form.rb
@@ -2,7 +2,7 @@ module Sipity
   module Forms
     module Etd
       # Responsible for submitting the final Grad School approval.
-      class ApproveForIngestForm < ProcessingActionForm
+      class GradSchoolSignoffForm < ProcessingActionForm
         def initialize(attributes = {})
           super
           self.action = attributes.fetch(:processing_action_name) { default_processing_action_name }
@@ -20,7 +20,7 @@ module Sipity
           super do
             repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
             repository.send_notification_for_entity_trigger(
-              notification: "confirmation_of_approve_for_ingest", entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor']
+              notification: "confirmation_of_grad_school_signoff", entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor']
             )
           end
         end

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -40,6 +40,11 @@ module Sipity
         @entity = entity
         mail(to: to, cc: cc, bcc: bcc)
       end
+
+      def confirmation_of_approve_for_ingest(entity:, to:, cc: [], bcc: [])
+        @entity = entity
+        mail(to: to, cc: cc, bcc: bcc)
+      end
     end
   end
 end

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -41,7 +41,7 @@ module Sipity
         mail(to: to, cc: cc, bcc: bcc)
       end
 
-      def confirmation_of_approve_for_ingest(entity:, to:, cc: [], bcc: [])
+      def confirmation_of_grad_school_signoff(entity:, to:, cc: [], bcc: [])
         @entity = entity
         mail(to: to, cc: cc, bcc: bcc)
       end

--- a/app/state_machines/sipity/state_machines/doctoral_dissertation_state_machine.rb
+++ b/app/state_machines/sipity/state_machines/doctoral_dissertation_state_machine.rb
@@ -16,7 +16,7 @@ module Sipity
         },
         'under_advisor_review' => {
           update?: ['etd_reviewer'], show?: ['creating_user', 'advisor', 'etd_reviewer'],
-          request_revision?: ['etd_reviewer'], approve_for_ingest?: ['etd_reviewer']
+          request_revision?: ['etd_reviewer'], grad_school_signoff?: ['etd_reviewer']
         },
         'ready_for_ingest' => { show?: ['creating_user', 'advisor', 'etd_reviewer'] },
         'ingesting' => { show?: ['creating_user', 'advisor', 'etd_reviewer'] },
@@ -64,7 +64,7 @@ module Sipity
         )
       end
 
-      def after_trigger_approve_for_ingest(_options)
+      def after_trigger_grad_school_signoff(_options)
         repository.submit_etd_student_submission_trigger!(entity: entity, trigger: :ingest, user: user)
       end
 
@@ -91,7 +91,7 @@ module Sipity
         state_machine = MicroMachine.new(entity.processing_state)
         state_machine.when(:submit_for_review, 'new' => 'under_advisor_review')
         state_machine.when(:request_revision, 'under_advisor_review' => 'under_advisor_review')
-        state_machine.when(:approve_for_ingest, 'under_advisor_review' => 'ready_for_ingest')
+        state_machine.when(:grad_school_signoff, 'under_advisor_review' => 'ready_for_ingest')
         state_machine.when(:ingest, 'ready_for_ingest' => 'ingesting')
         state_machine.when(:ingest_completed, 'ingesting' => 'ready_for_cataloging')
         state_machine.when(:finish_cataloging, 'ready_for_cataloging' => 'cataloged')

--- a/artifacts/etd-submission-state-machine.dot
+++ b/artifacts/etd-submission-state-machine.dot
@@ -27,7 +27,7 @@ digraph "G" {
             advisor_requests_changes[label="{ Event: advisor_requests_changes | Available To: Advisor, Grad School | Send email to Grad School, Student Advisor | State: :advisor_changes_requested }"]
             student_submits_advisor_requested_changes[label="{ Event: student_submits_advisor_requested_changes | Available To: Student | Send email to Grad School, Student, Student Advisor | State: :under_advisor_review }"]
             request_revision[label="{ Event: request_revision | Available To: Grad School | Send email to student with comments | State: :under_grad_school_review }"]
-            approve_for_ingest[label="{ Event: approve_for_ingest | Available To: Grad School | Trigger :ingest event | State: :ready_for_ingest }"]
+            grad_school_signoff[label="{ Event: grad_school_signoff | Available To: Grad School | Trigger :ingest event | State: :ready_for_ingest }"]
             ingest[label="{ Event: ingest | Submit ETD for ingest | Available To: Ingester | State: :ingesting }"]
             ingest_completed[label="{ Event: ingest_completed | Available To: Ingester | Send email to Catalogers | Send email to Submitter, Grad School, Advisor | State: :done }"]
         }
@@ -38,7 +38,7 @@ digraph "G" {
         under_advisor_review -> advisor_requests_changes -> advisor_changes_requested
         advisor_changes_requested -> student_submits_advisor_requested_changes -> under_advisor_review
         under_grad_school_review -> request_revision -> under_grad_school_review
-        under_grad_school_review -> approve_for_ingest -> ready_for_ingest
+        under_grad_school_review -> grad_school_signoff -> ready_for_ingest
         ready_for_ingest -> ingest -> ingesting
         ingesting -> ingest_completed -> done
     }

--- a/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
+++ b/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
@@ -34,7 +34,7 @@ Sipity::Models::Processing::StrategyAction.create!([
   {strategy_id: 1, resulting_strategy_state_id: 4, name: "advisor_signs_off", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
   {strategy_id: 1, resulting_strategy_state_id: 3, name: "advisor_requests_changes", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
   {strategy_id: 1, resulting_strategy_state_id: 2, name: "request_revision", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 5, name: "approve_for_ingest", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
+  {strategy_id: 1, resulting_strategy_state_id: 5, name: "grad_school_signoff", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
   {strategy_id: 1, resulting_strategy_state_id: 6, name: "ingest", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"},
   {strategy_id: 1, resulting_strategy_state_id: 7, name: "ingest_completed", form_class_name: nil, completion_required: false, action_type: "state_advancing_action"}
 ])

--- a/spec/forms/sipity/forms/etd/approve_for_ingest_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/approve_for_ingest_form_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+module Sipity
+  module Forms
+    module Etd
+      RSpec.describe ApproveForIngestForm do
+        let(:processing_entity) { Models::Processing::Entity.new(strategy_id: 1) }
+        let(:work) { double('Work', to_processing_entity: processing_entity) }
+        let(:repository) { CommandRepositoryInterface.new }
+        let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id) }
+        let(:user) { User.new(id: 1) }
+        subject { described_class.new(work: work, processing_action_name: action) }
+
+        context 'processing_action_name to action conversion' do
+          it 'will use the given action if the strategy matches' do
+            subject = described_class.new(work: work, processing_action_name: action)
+            expect(subject.action).to eq(action)
+          end
+        end
+
+        it 'will log the event' do
+          expect(repository).to receive(:log_event!).and_call_original
+          subject.submit(repository: repository, requested_by: user)
+        end
+
+        it 'will register than the given action was taken on the entity' do
+          expect(repository).to receive(:register_action_taken_on_entity).and_call_original
+          subject.submit(repository: repository, requested_by: user)
+        end
+
+        it 'will update the processing state' do
+          strategy_state = action.build_resulting_strategy_state
+          expect(repository).to receive(:update_processing_state!).
+            with(entity: work, to: strategy_state).and_call_original
+          subject.submit(repository: repository, requested_by: user)
+        end
+
+        it 'will send notifications to the creating user, etd reviewer, and advisor' do
+          expect(repository).to receive(:send_notification_for_entity_trigger).
+            with(notification: 'confirmation_of_approve_for_ingest', entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor'])
+          subject.submit(repository: repository, requested_by: user)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/grad_school_signoff_form_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Sipity
   module Forms
     module Etd
-      RSpec.describe ApproveForIngestForm do
+      RSpec.describe GradSchoolSignoffForm do
         let(:processing_entity) { Models::Processing::Entity.new(strategy_id: 1) }
         let(:work) { double('Work', to_processing_entity: processing_entity) }
         let(:repository) { CommandRepositoryInterface.new }
@@ -37,7 +37,7 @@ module Sipity
 
         it 'will send notifications to the creating user, etd reviewer, and advisor' do
           expect(repository).to receive(:send_notification_for_entity_trigger).
-            with(notification: 'confirmation_of_approve_for_ingest', entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor'])
+            with(notification: 'confirmation_of_grad_school_signoff', entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor'])
           subject.submit(repository: repository, requested_by: user)
         end
       end

--- a/spec/forms/sipity/forms/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/grad_school_signoff_form_spec.rb
@@ -7,9 +7,11 @@ module Sipity
         let(:processing_entity) { Models::Processing::Entity.new(strategy_id: 1) }
         let(:work) { double('Work', to_processing_entity: processing_entity) }
         let(:repository) { CommandRepositoryInterface.new }
-        let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id) }
+        let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: "hello") }
         let(:user) { User.new(id: 1) }
         subject { described_class.new(work: work, processing_action_name: action) }
+
+        its(:processing_action_name) { should eq(action.name) }
 
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -100,6 +100,15 @@ module Sipity
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
+      context '#confirmation_of_approve_for_ingest' do
+        let(:entity) { Models::Work.new }
+        let(:to) { 'test@example.com' }
+        it 'should send an email' do
+          described_class.confirmation_of_approve_for_ingest(entity: entity, to: to).deliver_now
+
+          expect(ActionMailer::Base.deliveries.count).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -100,11 +100,11 @@ module Sipity
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
-      context '#confirmation_of_approve_for_ingest' do
+      context '#confirmation_of_grad_school_signoff' do
         let(:entity) { Models::Work.new }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
-          described_class.confirmation_of_approve_for_ingest(entity: entity, to: to).deliver_now
+          described_class.confirmation_of_grad_school_signoff(entity: entity, to: to).deliver_now
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end

--- a/spec/state_machines/sipity/state_machines/doctoral_dissertation_state_machine_spec.rb
+++ b/spec/state_machines/sipity/state_machines/doctoral_dissertation_state_machine_spec.rb
@@ -86,9 +86,9 @@ module Sipity
           end
         end
 
-        context ':approve_for_ingest is triggered' do
+        context ':grad_school_signoff is triggered' do
           let(:initial_processing_state) { 'under_advisor_review' }
-          let(:event) { :approve_for_ingest }
+          let(:event) { :grad_school_signoff }
           it 'will record the event for auditing purposes' do
             expect(repository).to have_received(:log_event!).
               with(entity: entity, user: user, event_name: "doctoral_dissertation_state_machine/#{event}")


### PR DESCRIPTION
## Adding ApproveForIngest form

@235eecb9dd6763afa45d4ffec75358c711f43383

This form captures the final approval by the Grad School

## Renaming ApproveForIngest to GradSchoolSignoff

@fa9e44061be2a47aa59f1a6e75908e16af04e997

Building on @427e40973d3654a3f2a887588eae8a5658c1161e I want to
improve clarity of the actions intent, not foreshadow what comes next.

## Restoring code coverage to 100%

@b8ca08811df109758a638ce231c0b159519374aa
