### PR TITLE
Altering processing state dashboard query

### DIFF
--- a/app/decorators/sipity/decorators/dashboard_view.rb
+++ b/app/decorators/sipity/decorators/dashboard_view.rb
@@ -1,0 +1,50 @@
+module Sipity
+  module Decorators
+    # Responsible for collecting the logic related to rendering a user's
+    # dashboard.
+    class DashboardView
+      def initialize(repository: default_repository, user:, filter: {})
+        @repository = repository
+        @filter = filter
+        @user = user
+      end
+
+      attr_reader :repository, :user, :filter
+      private :repository, :user, :filter
+
+      def search_path
+        view_context.dashboard_path
+      end
+
+      def filterable_processing_states
+        # TODO: Move this to a repository question; After all don't we want
+        # to limit the filter to only objects that are for states in which the
+        # user can actually do something (ie see it, alter it, etc)
+        Models::Processing::StrategyState.all.pluck(:name).uniq.sort
+      end
+
+      def works
+        repository.find_works_for(user: user, processing_state: processing_state)
+      end
+
+      def each
+        works.each { |work| yield(work) }
+      end
+      deprecate :each
+
+      def processing_state
+        filter[:processing_state]
+      end
+
+      private
+
+      def view_context
+        Draper::ViewContext.current
+      end
+
+      def default_repository
+        QueryRepository.new
+      end
+    end
+  end
+end

--- a/app/policies/sipity/policies/work_policy.rb
+++ b/app/policies/sipity/policies/work_policy.rb
@@ -53,13 +53,10 @@ module Sipity
         private :user, :scope, :repository
 
         def resolve(options = {})
-          resolved_scope = repository.scope_proxied_objects_for_the_user_and_proxy_for_type(user: user, proxy_for_type: scope)
-          processing_state = options.fetch(:processing_state, nil)
-          if processing_state.present?
-            resolved_scope.where(processing_state: processing_state)
-          else
-            resolved_scope
-          end
+          repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
+            user: user,
+            proxy_for_type: scope, filter: { processing_state: options[:processing_state] }
+          )
         end
 
         private

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -7,6 +7,10 @@ module Sipity
         Models::Work.find(work_id)
       end
 
+      def build_dashboard_view(user:, filter: {})
+        Decorators::DashboardView.new(repository: self, user: user, filter: filter)
+      end
+
       def find_works_for(user:, processing_state: nil)
         Policies::WorkPolicy::Scope.resolve(user: user, scope: Models::Work, processing_state: processing_state)
       end

--- a/app/runners/sipity/runners/dashboard_runners.rb
+++ b/app/runners/sipity/runners/dashboard_runners.rb
@@ -8,8 +8,8 @@ module Sipity
         self.authorization_layer = :none
 
         def run(processing_state: nil)
-          works = repository.find_works_for(user: current_user, processing_state: processing_state)
-          callback(:success, works)
+          dashboard_view = repository.build_dashboard_view(user: current_user, filter: { processing_state: processing_state })
+          callback(:success, dashboard_view)
         end
       end
     end

--- a/app/views/sipity/controllers/dashboards/index.html.erb
+++ b/app/views/sipity/controllers/dashboards/index.html.erb
@@ -1,13 +1,11 @@
 <div class="row">
   <div class="col-xs-12">
-    <%= form_tag(dashboard_path, method: 'get', class: 'form-inline') do %>
+    <%= form_tag(view.search_path, method: 'get', class: 'form-inline') do %>
       <fieldset class="form-group">
         <%# This is the very specific case, to get things working. %>
         <%= select_tag(
               :processing_state,
-              options_from_collection_for_select(
-                ::Sipity::StateMachines::DoctoralDissertationStateMachine.state_diagram.states, :to_s, :humanize, params[:processing_state]
-              ),
+              options_from_collection_for_select(view.filterable_processing_states, :to_s, :humanize, view.processing_state),
               include_blank: true,
               class: 'form-control'
         ) %>

--- a/db/migrate/20150226160732_adding_index_to_strategy_state_name.rb
+++ b/db/migrate/20150226160732_adding_index_to_strategy_state_name.rb
@@ -1,0 +1,5 @@
+class AddingIndexToStrategyStateName < ActiveRecord::Migration
+  def change
+    add_index "sipity_processing_strategy_states", "name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150226134513) do
+ActiveRecord::Schema.define(version: 20150226160732) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -275,6 +275,7 @@ ActiveRecord::Schema.define(version: 20150226134513) do
     t.datetime "updated_at",  null: false
   end
 
+  add_index "sipity_processing_strategy_states", ["name"], name: "index_sipity_processing_strategy_states_on_name"
   add_index "sipity_processing_strategy_states", ["strategy_id", "name"], name: "sipity_processing_type_state_aggregate", unique: true
 
   create_table "sipity_roles", force: :cascade do |t|

--- a/spec/decorators/sipity/decorators/dashboard_view_spec.rb
+++ b/spec/decorators/sipity/decorators/dashboard_view_spec.rb
@@ -1,0 +1,24 @@
+module Sipity
+  module Decorators
+    RSpec.describe DashboardView do
+      let(:repository) { double('Repository') }
+      let(:filter) { { processing_state: 'chicken' } }
+      let(:user) { double('User') }
+      subject { described_class.new(repository: repository, filter: filter, user: user) }
+      it 'will have a #search_path' do
+        expect(subject.search_path).to be_a(String)
+      end
+      it 'will have #filterable_processing_states' do
+        expect(subject.filterable_processing_states).to be_a(Array)
+      end
+      it 'will have #works' do
+        works = [double, double("Toil and Trouble")]
+        expect(repository).to receive(:find_works_for).and_return(works)
+        expect(subject.works).to eq(works)
+      end
+
+      its(:default_repository) { should respond_to(:find_works_for) }
+      its(:processing_state) { should eq(filter.fetch(:processing_state)) }
+    end
+  end
+end

--- a/spec/policies/sipity/policies/work_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_policy_spec.rb
@@ -37,8 +37,7 @@ module Sipity
         end
 
         it 'will handle a processing_state' do
-          expect(repository).to receive(:scope_proxied_objects_for_the_user_and_proxy_for_type).and_call_original
-          described_class.resolve(user: user, repository: repository, processing_state: 'new')
+          described_class.resolve(user: user, repository: repository, processing_state: 'new').first
         end
       end
     end

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -114,13 +114,13 @@ module Sipity
 
           expect(
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
-              user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'new'}
+              user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'new' }
             )
           ).to eq([work_one, work_two])
 
           expect(
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
-              user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'hello'}
+              user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'hello' }
             )
           ).to eq([])
 

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -113,6 +113,18 @@ module Sipity
           ).to eq([work_one, work_two])
 
           expect(
+            test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
+              user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'new'}
+            )
+          ).to eq([work_one, work_two])
+
+          expect(
+            test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
+              user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'hello'}
+            )
+          ).to eq([])
+
+          expect(
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(user: advisor, proxy_for_type: Sipity::Models::Work)
           ).to eq([work_one])
 

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -27,6 +27,15 @@ module Sipity
         end
       end
 
+      context '#build_dashboard_view' do
+        let(:user) { double }
+        let(:filter) { double }
+        subject { test_repository.build_dashboard_view(user: user, filter: filter) }
+        it { should respond_to :each }
+        it { should respond_to :filterable_processing_states }
+        it { should respond_to :search_path }
+      end
+
       context '#build_update_work_form' do
         let(:work) { Models::Work.new(title: 'Hello World', id: '123') }
         it 'will raise an exception if the work is not persisted' do

--- a/spec/runners/sipity/runners/dashboard_runners_spec.rb
+++ b/spec/runners/sipity/runners/dashboard_runners_spec.rb
@@ -7,7 +7,7 @@ module Sipity
       include RunnersSupport
       RSpec.describe Index do
         let(:user) { User.new }
-        let(:context) { TestRunnerContext.new(current_user: user, find_works_for: true) }
+        let(:context) { TestRunnerContext.new(current_user: user, build_dashboard_view: true) }
         subject do
           described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
             on.success { |a| context.handler.invoked("SUCCESS", a) }
@@ -24,7 +24,8 @@ module Sipity
 
         it 'issues the :success callback' do
           view_object = double
-          expect(context.repository).to receive(:find_works_for).with(user: user, processing_state: :hello_dolly).and_return(view_object)
+          expect(context.repository).to receive(:build_dashboard_view).with(user: user, filter: { processing_state: :hello_dolly }).
+            and_return(view_object)
           response = subject.run(processing_state: :hello_dolly)
           expect(context.handler).to have_received(:invoked).with("SUCCESS", view_object)
           expect(response).to eq([:success, view_object])


### PR DESCRIPTION
For @danhorst 

## Adding the DashboardView

@bf6147219a56e83464aad1c65c7e447419b40550

As the Dashboard gets more complicated, I want to make sure to
isolate those changes in a custom view object.

## Exposing a means for building a dashboard_view

@ca2e392baf124366dd45d4e63aa96e1fdbde4289


## Splicing in the new dashboard view object

@fbd22031e45453c9886c4e9a7f4afcbc6d01b28f


## Leveraging new dashboard view for encapsulation

@44274b5f3e50a8eb2917fc63e3156ebb30a3b38f

By utilizing the dashboard view object, instead of the call out to
diagram states, I can begin to adjust the visible filter options to
what is visible for the current user.

That is a future exercise; For now I need to get the filter query
working.

## Adding proper filter of processing state for Work

@96f2016f6a30ad4398af056d052aae6b63f7d0d6

Prior to this change, the queries were filtering on the now non-
existent :processing_state column of the Sipity::Model::Work. This
change makes sure to filter by Processing State name.

Note: I'm opting for "name" instead of ID, because different work
types can have a state with the same name, and from the users
perspective they are the same thing.

## Adding database index for query optimization

@d9a2c0d0122347f6aafa5dadaf6fb78639c3675d

Given the changes of @96f2016f6a30ad4398af056d052aae6b63f7d0d6, I want
to make sure that the queries are not attempting to filter on an
unindexed column.

## Appeasing the hound

@e86e421fd9ee61bf3461f332a90582963a0925d1