### PR TITLE
Enforcing at least one collaborator

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
@@ -16,6 +16,7 @@ module Sipity
         end
 
         validate :each_collaborator_must_be_valid
+        validate :at_least_one_collaborator_must_be_responsible_for_review
 
         # Mirroring the expected behavior/implementation of the
         # :accepts_nested_attributes_for Rails method and its sibling :fields_for
@@ -48,7 +49,7 @@ module Sipity
 
         def each_collaborator_must_be_valid
           return true if collaborators.all?(&:valid?)
-          errors.add(:collaborators_attributes, 'are incomplete')
+          errors.add(:collaborators_attributes, :are_incomplete)
         end
 
         def build_collaborator_from_input(collection, attributes)
@@ -63,6 +64,10 @@ module Sipity
           # Because Rails strong parameters may or may not be in play.
           permitted_attributes.permit! if permitted_attributes.respond_to?(:permit!)
           permitted_attributes
+        end
+
+        def at_least_one_collaborator_must_be_responsible_for_review
+          errors.add(:base, :at_least_one_collaborator_must_be_responsible_for_review) if collaborators.none?(&:responsible_for_review?)
         end
       end
     end

--- a/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
@@ -2,6 +2,7 @@
 <h2>Tell us about your advisors</h2>
 <%= simple_form_for(model, url: enrich_work_path(model.work, model.enrichment_type), method: :post, as: :work) do |f| %>
   <%= f.error_notification %>
+  <%= f.error :base, class: "base-errors", error_method: :to_sentence, error_tag: :div %>
   <%= field_set_tag do %>
     <%= f.fields_for :collaborators do |collaborator_form| %>
       <%= collaborator_form.input :name %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -60,7 +60,7 @@ SimpleForm.setup do |config|
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
   # Use :to_sentence to list all errors for each field.
-  # config.error_method = :first
+  config.error_method = :to_sentence
 
   # Default tag used for error notification helper.
   config.error_notification_tag = :div

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -60,7 +60,7 @@ SimpleForm.setup do |config|
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
   # Use :to_sentence to list all errors for each field.
-  config.error_method = :to_sentence
+  # config.error_method = :to_sentence
 
   # Default tag used for error notification helper.
   config.error_notification_tag = :div

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,16 +147,20 @@ en:
     name: 'Citation'
   sipity/forms:
     error_messages:
-      inclusion: 'Please select an option from the above list.'
+      inclusion: 'Please select an option from the above list'
     create_work_form:
       error_messages:
-        access_rights_answer: 'You must select an option.'
-        title: 'You must provide a title.'
-        work_publication_strategy: 'Please tell us if you intend to publish this work.'
-        work_type: 'Please select a work type.'
+        access_rights_answer: 'You must select an option'
+        title: 'You must provide a title'
+        work_publication_strategy: 'Please tell us if you intend to publish this work'
+        work_type: 'Please select a work type'
   simple_form:
     labels:
       doi:
         identifier: 'Existing DOI'
       citation:
         type: 'Citation format'
+
+  errors:
+    messages:
+      at_least_one_collaborator_must_be_responsible_for_review: 'At least one collaborator must be responsible for review'

--- a/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
@@ -19,6 +19,18 @@ module Sipity
           expect(subject.errors[:work]).to_not be_empty
         end
 
+        context 'responsibility for review' do
+          subject { described_class.new(work: work, collaborators_attributes: collaborators_attributes) }
+          let(:collaborators_attributes) do
+            { __sequence: { name: "Jeremy", role: "author", netid: "", email: "", responsible_for_review: "false", id: 11 } }
+          end
+
+          it 'will validate that at least one collaborator must be responsible for review' do
+            expect(subject).to_not be_valid
+            expect(subject.errors[:base]).to_not be_empty
+          end
+        end
+
         context '#submit' do
           let(:repository) { CommandRepositoryInterface.new }
           let(:user) { User.new(id: '1') }
@@ -44,7 +56,7 @@ module Sipity
           context 'with valid data' do
             subject { described_class.new(work: work, collaborators_attributes: collaborators_attributes) }
             let(:collaborators_attributes) do
-              { __sequence: { name: "Jeremy", role: "author", netid: "", email: "", responsible_for_review: "false", id: 11 } }
+              { __sequence: { name: "Jeremy", role: "author", netid: "jeremyf", email: "", responsible_for_review: "true", id: 11 } }
             end
 
             it 'will create a collaborator' do


### PR DESCRIPTION
## Adding validation for collaborators

@11d2dcfb819a4af522500680b0ecfdd86ee37266

I want to make sure that at least one of the collaborators has been
marked as "requires review"

## Marking error method as to_sentence

@908cce5a877be8d945981e5d4428be6a938d47ba

If there are multiple errors, I want them all to show up. This is how
we go about doing that.

## Removing periods from end of error messages

@ec2ee35288e0c97ca7287d09011c04ec2d00b672

Given that we are rendering sentences, I don't want to have periods in
those sentences.

## Reporting errors on base objects

@fcfa8960e178a7c7c1d164cf35c9d224e638542f

Given that I may have an error on the base object, I want a means of
reporting that information. This is the quickest way to do it. We
could craft a helper method to deal with this as well.

Or our own FormBuilder
