### PR TITLE
Removing some view logic

### DIFF
--- a/app/decorators/sipity/decorators/processing/resourceful_action_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/resourceful_action_decorator.rb
@@ -14,6 +14,16 @@ module Sipity
             view_context.new_work_path
           end
         end
+
+        def button_class
+          dangerous? ? 'btn-danger' : 'btn-primary'
+        end
+
+        private
+
+        def dangerous?
+          name.to_s == 'destroy'
+        end
       end
     end
   end

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -151,10 +151,8 @@
                 <li itemprop="potentialAction" itemscope itemtype="http://schema.org/Action" class="action-wrapper">
                   <meta itemprop="name" content="event_trigger/<%= action.name %>" />
                   <% if action.available? %>
-                    <% action_is_dangerous = ( action.name == 'destroy' ) %>
-                    <% button_class = action_is_dangerous ? 'btn-danger' : 'btn-primary' %>
                     <div itemprop='target' itemscope itemtype="http://schema.org/EntryPoint" class="action">
-                      <a itemprop="url" href="<%= action.path %>" class="btn <%= button_class %>">
+                      <a itemprop="url" href="<%= action.path %>" class="btn <%= action.button_class %>">
                         <%= t("sipity/works.resourceful_actions.label.#{ action.name }") %>
                         <meta itemprop="name" content="<%= action.name %>" />
                       </a>

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -141,9 +141,8 @@
             <% end %>
           </dl>
         </div>
-        <%# NOTE: Delete is not presently visible because it is defaulting to the "show" action %>
         <% resourceful_actions = model.resourceful_actions(user: current_user) %>
-        <% available_resourceful_actions = resourceful_actions.reject{ |action| current_page?(:action => action.name) } %>
+        <% available_resourceful_actions = resourceful_actions.reject{ |action| controller_name == 'works' && action_name == action.name } %>
         <% if available_resourceful_actions.present? %>
           <div class="panel-footer">
             <ul class="action-listing">

--- a/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
@@ -8,17 +8,23 @@ module Sipity
         let(:entity) { Models::Work.new(id: ENTITY_ID) }
 
         [
-          { name: 'show', expected_path: "/works/#{ENTITY_ID}" },
-          { name: 'new', expected_path: "/works/new" },
-          { name: 'create', expected_path: "/works/new" },
-          { name: 'edit', expected_path: "/works/#{ENTITY_ID}/edit" },
-          { name: 'update', expected_path: "/works/#{ENTITY_ID}/edit" },
-          { name: 'destroy', expected_path: "/works/#{ENTITY_ID}" }
+          { name: 'show', expected_path: "/works/#{ENTITY_ID}", button_class: 'btn-primary' },
+          { name: 'new', expected_path: "/works/new", button_class: 'btn-primary' },
+          { name: 'create', expected_path: "/works/new", button_class: 'btn-primary' },
+          { name: 'edit', expected_path: "/works/#{ENTITY_ID}/edit", button_class: 'btn-primary' },
+          { name: 'update', expected_path: "/works/#{ENTITY_ID}/edit", button_class: 'btn-primary' },
+          { name: 'destroy', expected_path: "/works/#{ENTITY_ID}", button_class: 'btn-danger' }
         ].each_with_index do |example, index|
           it "will have a path #{example[:expected_path].inspect} for action name #{example[:name].inspect} (Scenario ##{index})" do
             action = double(name: example.fetch(:name))
             subject = described_class.new(action: action, entity: entity)
             expect(subject.path).to eq(example.fetch(:expected_path))
+          end
+
+          it "will have a button_class #{example[:button_class].inspect} for action name #{example[:name].inspect} (Scenario ##{index})" do
+            action = double(name: example.fetch(:name))
+            subject = described_class.new(action: action, entity: entity)
+            expect(subject.button_class).to eq(example.fetch(:button_class))
           end
         end
       end


### PR DESCRIPTION
## Replacing view logic with decorator logic

@ed47461f6463d8ac203d1d9333eb0cbb05da6104


## Switching to not reject 'delete' based on URL

@51b8cf60c2946490906fdb8c9ff47899e04cca7c

The current_page? method returns true for the delete URL for the work.
