### PR TITLE
Working on attachment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,6 @@ pickle-email-*.html
 .powenv
 
 # Ignore application configuration
-/config/application.yml
 
 # Ignore documentation
 .yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -85,4 +85,5 @@ end
 group :production, :pre_production, :staging do
   gem 'unicorn'
   gem 'mysql2'
+  gem 'rack-cache', require: 'rack/cache'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,8 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.0)
+    rack-cache (1.2)
+      rack (>= 0.4)
     rack-test (0.6.2)
       rack (>= 1.0)
     railroady (1.3.0)
@@ -462,6 +464,7 @@ DEPENDENCIES
   pry-stack_explorer
   pundit
   quiet_assets
+  rack-cache
   railroady
   rails (= 4.2.0)
   rails_layout

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -1,17 +1,39 @@
 module Sipity
   module Forms
     module WorkEnrichments
+      # Responsible for exposing a means of displaying and marking the object
+      # for deletion.
+      class AttachmentFormElement
+        THUMBNAIL_SIZE = '64x64#'
+        def initialize(object)
+          @object = object
+        end
+
+        def thumbnail_url(size = THUMBNAIL_SIZE)
+          thumbnail(size).url
+        end
+
+        delegate :id, :name, :persisted?, to: :object
+        attr_accessor :delete
+
+        private
+
+        attr_reader :object
+        private :object
+
+        def thumbnail(size = THUMBNAIL_SIZE)
+          object.file.thumb(size, format: 'png', frame: 0)
+        end
+      end
       # Exposes a means for attaching files to the associated work.
       class AttachForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
           super
           @files = attributes[:files]
           @mark_as_representative = attributes[:mark_as_representative]
+          self.attachments_attributes = attributes.fetch(:attachments_attributes, {})
         end
 
-        # TODO: Write a custom file validator. There must be at least one file
-        #   uploaded.
-        validates :files, presence: true
         attr_accessor :files
         attr_accessor :mark_as_representative
 
@@ -20,7 +42,11 @@ module Sipity
         end
 
         def attachments
-          @attachments || attachments_from_work
+          @attachments ||= attachments_from_work
+        end
+
+        # Exposed so that field_for will work
+        def attachments_attributes=(_value)
         end
 
         private
@@ -36,7 +62,9 @@ module Sipity
 
         def attachments_from_work
           return [] unless work
-          work.attachments
+          # I don't want this to be draped because the collection appeared to be
+          # treated as a single model instead of as an enumeration of items.
+          work.attachments.map { |attachment| AttachmentFormElement.new(attachment) }
         end
       end
     end

--- a/app/views/sipity/controllers/work_enrichments/attach.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/attach.html.erb
@@ -11,8 +11,10 @@
       <%= f.input :mark_as_representative, as: :radio_buttons, collection: model.attachments, checked: model.representative_attachment %>
     <% end %>
     <%= field_set_tag do %>
-      <%= f.fields_for :attachments_attributes do |attachment_form| %>
-        <%# attachment_form.input :name %>
+      <%= f.fields_for :attachments do |attachment_form| %>
+        <%= attachment_form.input :name %>
+        <%= attachment_form.input :delete, as: :boolean %>
+        <%= image_tag attachment_form.object.thumbnail_url %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,9 @@
+# Dear curious person:
+#
+# These are not the real keys to the kingdom. They are, however, used during
+# development; Or more appropriately used as a frame of reference for our
+# development.
+#
+# They are included so we can share what the keys should be.
+DATABASE_PATH: db/development.sqlite3
+dragonfly_secret: "e03509c7cbee4f602ba6cf4bb088bda4891efabfffb6f122cc1e20c7e807e8b8"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
-  # config.action_dispatch.rack_cache = true
+  config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_files = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
-  # config.action_dispatch.rack_cache = true
+  config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_files = false

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -1,0 +1,26 @@
+require 'dragonfly'
+
+# Configure
+Dragonfly.app.configure do
+  plugin :imagemagick
+
+  secret Figaro.env.dragonfly_secret
+
+  url_format "/media/:job/:name"
+
+  datastore :file,
+    root_path: Rails.root.join('dragonfly', Rails.env),
+    server_root: Rails.root.join('public')
+end
+
+# Logger
+Dragonfly.logger = Rails.logger
+
+# Mount as middleware
+Rails.application.middleware.use Dragonfly::Middleware
+
+# Add model functionality
+if defined?(ActiveRecord::Base)
+  ActiveRecord::Base.extend Dragonfly::Model
+  ActiveRecord::Base.extend Dragonfly::Model::Validations
+end

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -18,11 +18,6 @@ module Sipity
             subject.valid?
             expect(subject.errors[:work]).to_not be_empty
           end
-          it 'will require at least one file' do
-            subject = described_class.new(files: [], work: work)
-            subject.valid?
-            expect(subject.errors[:files]).to_not be_empty
-          end
 
           let(:representative_for_attachment) { [double('Attachment')] }
           it 'will have #representative_for_attachment_id' do


### PR DESCRIPTION
## Adding Rack::Cache gem

@04380b4101ec964b5234a95ce9e4a6b51ddd9052

This is recommended for the Dragonfly gem, and is an all around good
idea for staging and development.

## Applying `rack_cache = true` to environments

@579803301e14a537fd78893bca56721abb0cc99a

Again, a recommendation for Dragonfly and caching in general

## Adding Dragonfly configuration

@fa1cc05190c8b35aa2d9ac472bc0dc55fa3f9d7f

@See http://markevans.github.io/dragonfly/configuration/

## Adding config/application.yml to repo

@924c3d803d856206b814cb2463e8f1c1d3099490

I want a way to share what are the names of the keys our application
is expecting. This also helps in the bootstrap process for our
application.

As a matter of deploys we update the secrets of our application, so
the keys you find within the config/application.yml are not the real
keys.

## Initial unverified stab at attachment deletion

@8dc0e4d06d24aabe4dececdaf53d0531e4dfdd8a

This is non-functioning code, but it does expose the correct
attributes for enabling deletion and rendering of existing
attachments.

## Removing validation of files

@76dd23e74dfe6612c64a937caeb8d7f85b0b8970

This is a somewhat silly requirement; Perhaps something that we can
enforce via an alternate method. What I am going for is "Is there at
least one file associated"; It can be either that I just uploaded or
it can be ones that are already uploaded.
