### PR TITLE
Working on exposing the delete action

### DIFF
--- a/app/decorators/sipity/decorators/processing/resourceful_action_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/resourceful_action_decorator.rb
@@ -4,9 +4,12 @@ module Sipity
       # An action that maps to the default Resourceful actions of a Rails model.
       # Its an overloaded word.
       class ResourcefulActionDecorator < BaseDecorator
+        DESTROY_ACTION_NAME = 'destroy'.freeze
+        VALID_ACTION_NAMES = %w(show destroy edit update new create).freeze
+
         def path
           case name.to_s
-          when 'show', 'destroy'
+          when 'show', DESTROY_ACTION_NAME
             view_context.work_path(entity)
           when 'edit', 'update'
             view_context.edit_work_path(entity)
@@ -22,7 +25,15 @@ module Sipity
         private
 
         def dangerous?
-          name.to_s == 'destroy'
+          name.to_s == DESTROY_ACTION_NAME
+        end
+
+        def action=(action)
+          if action.respond_to?(:name) && VALID_ACTION_NAMES.include?(action.name)
+            super(action)
+          else
+            fail Exceptions::UnprocessableResourcefulActionNameError, container: action
+          end
         end
       end
     end

--- a/app/decorators/sipity/decorators/processing/resourceful_action_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/resourceful_action_decorator.rb
@@ -18,11 +18,30 @@ module Sipity
           end
         end
 
+        alias_method :entry_point_path, :path
+
         def button_class
           dangerous? ? 'btn-danger' : 'btn-primary'
         end
 
+        def render_entry_point
+          view_context.content_tag('div', itemprop: 'target', itemscope: true, itemtype: "http://schema.org/EntryPoint", class: "action") do
+            view_context.link_to(entry_point_text, entry_point_path, entry_point_attributes)
+          end
+        end
+
         private
+
+        def entry_point_attributes
+          attributes = { itemprop: 'url', class: "btn #{button_class}" }
+          attributes[:method] = :delete if name == DESTROY_ACTION_NAME
+          attributes
+        end
+
+        def entry_point_text
+          view_context.t("sipity/works.resourceful_actions.label.#{ name }") +
+            %(<meta itemprop="name" content="#{name}" />).html_safe
+        end
 
         def dangerous?
           name.to_s == DESTROY_ACTION_NAME
@@ -32,7 +51,7 @@ module Sipity
           if action.respond_to?(:name) && VALID_ACTION_NAMES.include?(action.name)
             super(action)
           else
-            fail Exceptions::UnprocessableResourcefulActionNameError, container: action
+            fail Exceptions::UnprocessableResourcefulActionNameError, object: action, container: VALID_ACTION_NAMES
           end
         end
       end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -22,8 +22,8 @@ module Sipity
 
     # This is not a defined resourceful action
     class UnprocessableResourcefulActionNameError < RuntimeError
-      def initialize(name)
-        super("Received unexpected action name (#{name})")
+      def initialize(container:, object:)
+        super("Expected #{object} to have a #name that is within #{container}")
       end
     end
 

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -150,12 +150,7 @@
                 <li itemprop="potentialAction" itemscope itemtype="http://schema.org/Action" class="action-wrapper">
                   <meta itemprop="name" content="event_trigger/<%= action.name %>" />
                   <% if action.available? %>
-                    <div itemprop='target' itemscope itemtype="http://schema.org/EntryPoint" class="action">
-                      <a itemprop="url" href="<%= action.path %>" class="btn <%= action.button_class %>">
-                        <%= t("sipity/works.resourceful_actions.label.#{ action.name }") %>
-                        <meta itemprop="name" content="<%= action.name %>" />
-                      </a>
-                    </div>
+                    <%= action.render_entry_point %>
                   <% else %>
                     <div itemprop='target' itemscope itemtype="http://schema.org/EntryPoint" class="action">
                       <meta itemprop="name" content="<%= action.name %>" />

--- a/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
@@ -31,6 +31,23 @@ module Sipity
             subject = described_class.new(action: action, entity: entity)
             expect(subject.button_class).to eq(example.fetch(:button_class))
           end
+
+        end
+
+        it 'will render an entry point with data-method="delete" for :destroy action' do
+          action = double(name: 'destroy')
+          subject = described_class.new(action: action, entity: entity)
+          expect(subject.render_entry_point).to have_tag('.action[itemprop="target"][itemtype="http://schema.org/EntryPoint"]') do
+            with_tag("a[data-method='delete'][href='#{subject.path}']")
+          end
+        end
+
+        it 'will render an entry point with data-method="delete" for :destroy action' do
+          action = double(name: 'edit')
+          subject = described_class.new(action: action, entity: entity)
+          expect(subject.render_entry_point).to have_tag('.action[itemprop="target"][itemtype="http://schema.org/EntryPoint"]') do
+            with_tag("a[href='#{subject.path}']")
+          end
         end
       end
     end

--- a/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
@@ -7,6 +7,11 @@ module Sipity
         ENTITY_ID = '1234'
         let(:entity) { Models::Work.new(id: ENTITY_ID) }
 
+        it 'will not initialize with an invalid action name' do
+          action = double(name: 'bob')
+          expect { described_class.new(action: action, entity: entity) }.to raise_error(Exceptions::UnprocessableResourcefulActionNameError)
+        end
+
         [
           { name: 'show', expected_path: "/works/#{ENTITY_ID}", button_class: 'btn-primary' },
           { name: 'new', expected_path: "/works/new", button_class: 'btn-primary' },

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -20,7 +20,7 @@ module Sipity
     end
 
     RSpec.describe UnprocessableResourcefulActionNameError do
-      subject { described_class.new('hello') }
+      subject { described_class.new(container: 'Container', object: 'hello') }
       its(:message) { should be_a(String) }
     end
 


### PR DESCRIPTION
## Reworking exception to be more expressive

@89d4677af854b11748d6cd696edd86508af23500


## Guarding the resourceful action initialization

@e4b367d7d2ed17e7d80c60a4c5fd78435b255e20

As I was working on testing other things, I had a case of a poor
initialization that resulted in weird behavior. This fixes that by
throwing a noisy exception.

## Adding #render_entry_point

@14caf2eb82629603c2b3a7b5499cfdc245e97058

This method is useful for containing the logic regarding a resourceful
action. In theory, we may want to consider a confirmation action
as it relates to the destroy action; For now this will work.

## Splicing in use of render_entry_point

@2fe412635c34f0a5687b11b9b727caa87fcff28c

There is if logic that I'd like to step away from, but for now I'll be
happy to encapsulate the first part of the logic.
