### PR TITLE
Exposing the delete action

### DIFF
--- a/app/controllers/sipity/controllers/works_controller.rb
+++ b/app/controllers/sipity/controllers/works_controller.rb
@@ -37,6 +37,12 @@ module Sipity
         respond_with(@model)
       end
 
+      def destroy
+        status, model = run(work_id: work_id)
+        flash[:notice] = message_for(status, title: model.title)
+        redirect_to dashboard_path
+      end
+
       attr_reader :model
       protected :model
       helper_method :model

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -26,6 +26,12 @@ module Sipity
         end
       end
 
+      # This may look ridiculous, but I'd like to isolate the destruction so
+      # that I can associate any other actions with it (i.e. logging, emails, etc.)
+      def destroy_a_work(work:)
+        work.destroy
+      end
+
       def update_processing_state!(entity:, to:)
         Services::UpdateEntityProcessingState.call(entity: entity, processing_state: to)
       end

--- a/app/runners/sipity/runners/work_runners.rb
+++ b/app/runners/sipity/runners/work_runners.rb
@@ -58,8 +58,7 @@ module Sipity
         def run(work_id:)
           work = repository.find_work(work_id)
           authorization_layer.enforce!(action_name => work) do
-            # REVIEW: Do we want to do anything else?
-            work.destroy
+            repository.destroy_a_work(work: work)
             callback(:success, work)
           end
         end

--- a/app/runners/sipity/runners/work_runners.rb
+++ b/app/runners/sipity/runners/work_runners.rb
@@ -49,6 +49,22 @@ module Sipity
         end
       end
 
+      # Responsible for finding and destroying the given work.
+      class Destroy < BaseRunner
+        self.authentication_layer = :default
+        self.authorization_layer = :default
+        self.action_name = :destroy?
+
+        def run(work_id:)
+          work = repository.find_work(work_id)
+          authorization_layer.enforce!(action_name => work) do
+            # REVIEW: Do we want to do anything else?
+            work.destroy
+            callback(:success, work)
+          end
+        end
+      end
+
       # Responsible for providing an index of Works
       class Index < BaseRunner
         self.authentication_layer = :default

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,8 @@ en:
     action/update:
       failure: 'That update could not be made.'
       success: 'Update successful!'
+    action/destroy:
+      success: '"%{title}" has been deleted.'
     processing_state:
       new:
         can_advance: "You may submit your work for review when ready."

--- a/spec/controllers/sipity/controllers/works_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/works_controller_spec.rb
@@ -82,6 +82,7 @@ module Sipity
           expect(response).to redirect_to("/works/#{work.to_param}")
         end
       end
+
       context 'GET #show' do
         before { controller.runner = runner }
         let(:runner) do
@@ -96,6 +97,22 @@ module Sipity
           get 'show', id: work.to_param
           expect(assigns(:model)).to_not be_nil
           expect(response).to render_template('show')
+        end
+      end
+
+      context 'DELETE #destroy' do
+        before { controller.runner = runner }
+        let(:runner) do
+          Hesburgh::Lib::MockRunner.new(
+            yields: yields, callback_name: callback_name, run_with: { work_id: work.to_param }, context: controller
+          )
+        end
+
+        let(:yields) { work }
+        let(:callback_name) { :success }
+        it 'will redirect to the dashboard' do
+          delete 'destroy', id: work.to_param
+          expect(response).to redirect_to(dashboard_path)
         end
       end
 

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -8,6 +8,16 @@ module Sipity
         allow(Services::GrantProcessingPermission).to receive(:call)
       end
 
+      context '#destroy_a_work' do
+        let(:work) { Models::Work.new }
+        it 'will destroy the work in question' do
+          work.save! # so it is persisted
+          expect { test_repository.destroy_a_work(work: work) }.
+            to change { Models::Work.count }.by(-1)
+          expect { work.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
       context '#assign_collaborators_to' do
         let(:work) { Models::Work.new(id: 123) }
         let(:collaborator) do

--- a/spec/runners/sipity/runners/work_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_runners_spec.rb
@@ -129,7 +129,7 @@ module Sipity
         end
 
         it 'issues the :success callback' do
-          expect(work).to receive(:destroy)
+          expect(context.repository).to receive(:destroy_a_work).with(work: work)
           response = subject.run(work_id: 1234)
           expect(handler).to have_received(:invoked).with("SUCCESS", work)
           expect(response).to eq([:success, work])

--- a/spec/runners/sipity/runners/work_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_runners_spec.rb
@@ -109,6 +109,33 @@ module Sipity
         end
       end
 
+      RSpec.describe Destroy do
+        let(:work) { double(destroy: true) }
+        let(:user) { double('User') }
+        let(:context) { TestRunnerContext.new(find_work: work, current_user: user) }
+        let(:handler) { double(invoked: true) }
+        subject do
+          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
+            on.success { |a| handler.invoked("SUCCESS", a) }
+          end
+        end
+
+        it 'will require authentication by default' do
+          expect(described_class.authentication_layer).to eq(:default)
+        end
+
+        it 'enforces authorization' do
+          expect(described_class.authorization_layer).to eq(:default)
+        end
+
+        it 'issues the :success callback' do
+          expect(work).to receive(:destroy)
+          response = subject.run(work_id: 1234)
+          expect(handler).to have_received(:invoked).with("SUCCESS", work)
+          expect(response).to eq([:success, work])
+        end
+      end
+
       RSpec.describe Index do
         let(:work) { double('Work') }
         let(:user) { double('User') }

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -29,6 +29,10 @@ module Sipity
     def default_pid_minter
     end
 
+    # @see ./app/repositories/sipity/commands/work_commands.rb
+    def destroy_a_work(work:)
+    end
+
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def destroy_work_attribute_values!(work:, key:, values:)
     end


### PR DESCRIPTION
## Adding WorkRunners::Destroy

@b88790b3bf1778e4cca572eac5f91cf8f4cd4991

As identified, we are not able to delete Works; This exposes that
method.

## Expose the Works#destroy end-point

@6dc6e0b3a977de1003143252bebafc4a29109904

Making sure that the resourceful route resolves.

## Creating a #destroy_a_work method

@2e3f552a9b53e538d76660f5669315352c56e003

It is rather trivial to add a repository method, and while it may
appear to be overkill, I'd prefer to have such a "big" concept as
"destroy" be handled by the repository; Because there may be messages
that need to fire.

## Replacing explicit work.destroy with repo call

@abe621ab09ed8b6c7d84f93b4845bc29f78fc7af

Instead of assuming knowledge of the work, I'd rather make sure that
the repository again handles the destruction of the work. In this way
any "callbacks" can be handled.

## Adding destroy action text for works

@c24780017d5bee9a7961a12ddf56c6d14d4ba994

It is helpful to acknowledge that the object was deleted.
