### PR TITLE
Restoring test coverage

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -54,6 +54,7 @@ module Sipity
           attr_reader :attachment
           private :attachment
         end
+        private_constant :AttachmentFormElement
       end
     end
   end

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -42,30 +42,17 @@ module Sipity
           # treated as a single model instead of as an enumeration of items.
           work.attachments.map { |attachment| AttachmentFormElement.new(attachment) }
         end
-      end
 
-      # Responsible for exposing a means of displaying and marking the object
-      # for deletion.
-      class AttachmentFormElement
-        THUMBNAIL_SIZE = '64x64#'
-        def initialize(attachment)
-          @attachment = attachment
-        end
-
-        def thumbnail_url(size = THUMBNAIL_SIZE)
-          thumbnail(size).url
-        end
-
-        delegate :id, :name, :persisted?, to: :attachment
-        attr_accessor :delete
-
-        private
-
-        attr_reader :attachment
-        private :attachment
-
-        def thumbnail(size = THUMBNAIL_SIZE)
-          attachment.file.thumb(size, format: 'png', frame: 0)
+        # Responsible for exposing a means of displaying and marking the object
+        # for deletion.
+        class AttachmentFormElement
+          def initialize(attachment)
+            @attachment = attachment
+          end
+          delegate :id, :name, :thumbnail_url, :persisted?, to: :attachment
+          attr_accessor :delete
+          attr_reader :attachment
+          private :attachment
         end
       end
     end

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -48,24 +48,24 @@ module Sipity
       # for deletion.
       class AttachmentFormElement
         THUMBNAIL_SIZE = '64x64#'
-        def initialize(object)
-          @object = object
+        def initialize(attachment)
+          @attachment = attachment
         end
 
         def thumbnail_url(size = THUMBNAIL_SIZE)
           thumbnail(size).url
         end
 
-        delegate :id, :name, :persisted?, to: :object
+        delegate :id, :name, :persisted?, to: :attachment
         attr_accessor :delete
 
         private
 
-        attr_reader :object
-        private :object
+        attr_reader :attachment
+        private :attachment
 
         def thumbnail(size = THUMBNAIL_SIZE)
-          object.file.thumb(size, format: 'png', frame: 0)
+          attachment.file.thumb(size, format: 'png', frame: 0)
         end
       end
     end

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -1,30 +1,6 @@
 module Sipity
   module Forms
     module WorkEnrichments
-      # Responsible for exposing a means of displaying and marking the object
-      # for deletion.
-      class AttachmentFormElement
-        THUMBNAIL_SIZE = '64x64#'
-        def initialize(object)
-          @object = object
-        end
-
-        def thumbnail_url(size = THUMBNAIL_SIZE)
-          thumbnail(size).url
-        end
-
-        delegate :id, :name, :persisted?, to: :object
-        attr_accessor :delete
-
-        private
-
-        attr_reader :object
-        private :object
-
-        def thumbnail(size = THUMBNAIL_SIZE)
-          object.file.thumb(size, format: 'png', frame: 0)
-        end
-      end
       # Exposes a means for attaching files to the associated work.
       class AttachForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
@@ -65,6 +41,31 @@ module Sipity
           # I don't want this to be draped because the collection appeared to be
           # treated as a single model instead of as an enumeration of items.
           work.attachments.map { |attachment| AttachmentFormElement.new(attachment) }
+        end
+      end
+
+      # Responsible for exposing a means of displaying and marking the object
+      # for deletion.
+      class AttachmentFormElement
+        THUMBNAIL_SIZE = '64x64#'
+        def initialize(object)
+          @object = object
+        end
+
+        def thumbnail_url(size = THUMBNAIL_SIZE)
+          thumbnail(size).url
+        end
+
+        delegate :id, :name, :persisted?, to: :object
+        attr_accessor :delete
+
+        private
+
+        attr_reader :object
+        private :object
+
+        def thumbnail(size = THUMBNAIL_SIZE)
+          object.file.thumb(size, format: 'png', frame: 0)
         end
       end
     end

--- a/app/models/sipity/models/attachment.rb
+++ b/app/models/sipity/models/attachment.rb
@@ -12,6 +12,11 @@ module Sipity
 
       belongs_to :work
       dragonfly_accessor :file
+
+      THUMBNAIL_SIZE = '64x64#'.freeze
+      def thumbnail_url(size = THUMBNAIL_SIZE)
+        file.thumb(size).url
+      end
     end
   end
 end

--- a/spec/models/sipity/models/attachment_spec.rb
+++ b/spec/models/sipity/models/attachment_spec.rb
@@ -22,6 +22,11 @@ module Sipity
           expect(subject.file.data).to eq(File.read(__FILE__))
         end
 
+        it 'has a thumbnail_url' do
+          subject.file = File.new(__FILE__)
+          expect(subject.thumbnail_url).to match(/\/#{File.basename(__FILE__)}/)
+        end
+
         it 'has an file_name via the dragonfly gem' do
           subject.file = File.new(__FILE__)
           expect(subject.file_name).to eq(File.basename(__FILE__))


### PR DESCRIPTION
## Moving class declaration for clarity

@68f1a61ea01411b45c57d786ac031b9dcbfc0ba6

The incorrect class was at the beginning of the file. This made the
code more confusing.

## Improving clarity of intent by renaming

@2f45288fed87d24a6f09b0b9ac104013d8fb771e

Instead of the less expressive object, refering to it as an
attachment.

## Exposing a method to ease presenter logic

@ed6ac1c151a1dc2e15ac180243f84e06ed4c3e3b

This method is to help a simple wrapping element not need to be so
very nosy about its neighbor.

## Reducing the presenter's knowledge

@700713c79645ba577031b71e298e1b2914bdd213

Instead of digging deep into an attachment, I'm exposing the basic
information that I need.

## Privatizing object to narrow exposure

@d3b74b14d8769b8c619a0a3f9bcab52fe96fc1f2

This object helps in the collaboration of form building and rendering.
Its primary function is to expose a `#delete` attribute along side a
handful of methods to help render an HTML form.
