### PR TITLE
Adding ability to modify attachments

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_boolean.rb
+++ b/app/conversions/sipity/conversions/convert_to_boolean.rb
@@ -1,0 +1,39 @@
+module Sipity
+  module Conversions
+    # Exposes a conversion method to take an input and transform it into a
+    # boolean. This is important because user input can come in the form of
+    # 'true', 'false', '0', '1'.
+    #
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToBoolean
+      # A convenience method so that you don't need to include the conversion
+      # module in your base class.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Boolean
+      #
+      # @see #convert_to_boolean
+      def self.call(input)
+        convert_to_boolean(input)
+      end
+
+      # Does its best to convert the input into a Boolean.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Boolean
+      def convert_to_boolean(input)
+        case input
+        when false, 0, '0', 'false', 'no', nil then false
+        else
+          true
+        end
+      end
+
+      module_function :convert_to_boolean
+      private_class_method :convert_to_boolean
+      private :convert_to_boolean
+    end
+  end
+end

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -43,10 +43,12 @@ module Sipity
           @ids_for_deletion || []
         end
 
+        include Conversions::ConvertToBoolean
+
         def collect_files_for_deletion(value)
           @ids_for_deletion = []
           value.each do |_key, attributes|
-            next unless attributes['delete'] == '1' # Magic string; Craft a Boolean conversion
+            next unless convert_to_boolean(attributes['delete'])
             @ids_for_deletion << attributes.fetch('id')
           end
         end

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -22,7 +22,9 @@ module Sipity
         end
 
         # Exposed so that field_for will work
-        def attachments_attributes=(_value)
+        def attachments_attributes=(value)
+          @attachments_attributes = value
+          collect_files_for_deletion(value)
         end
 
         private
@@ -33,6 +35,19 @@ module Sipity
               repository.attach_file_to(work: work, file: file, user: requested_by)
             end
             repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
+            repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
+          end
+        end
+
+        def ids_for_deletion
+          @ids_for_deletion || []
+        end
+
+        def collect_files_for_deletion(value)
+          @ids_for_deletion = []
+          value.each do |_key, attributes|
+            next unless attributes['delete'] == '1' # Magic string; Craft a Boolean conversion
+            @ids_for_deletion << attributes.fetch('id')
           end
         end
 

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -44,8 +44,9 @@ module Sipity
         Models::Attachment.create!(work: work, file: file, pid: pid, predicate_name: 'attachment')
       end
 
-      def remove_files_from(pid:, user: user)
-        Models::Attachment.where(pid: pid).destroy_all
+      def remove_files_from(work:, user:, pids:)
+        _user = user # Don't need it yet, but it makes sense to capture this
+        Models::Attachment.where(work: work, pid: Array.wrap(pids)).destroy_all
       end
 
       def mark_as_representative(work:, pid:, user: user)

--- a/spec/conversions/sipity/conversions/convert_to_boolean_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_boolean_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToBoolean do
+      include ::Sipity::Conversions::ConvertToBoolean
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          expect(described_class.call('1')).to eq(true)
+        end
+      end
+
+      context '.convert_to_boolean' do
+        it 'will be private' do
+          expect { described_class.convert_to_boolean(true) }.
+            to raise_error(NoMethodError, /private method `convert_to_boolean'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_boolean' do
+
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_boolean)
+        end
+
+        [
+          ['1', true],
+          ["11", true],
+          ["0", false],
+          [0, false],
+          [1, true],
+          ['true', true],
+          ['false', false],
+          [nil, false],
+          [Object.new, true]
+        ].each_with_index do |(to_convert, expected), index|
+          it "will convert #{to_convert.inspect} to #{expected} (Scenario ##{index}" do
+            expect(convert_to_boolean(to_convert)).to eq(expected)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -33,6 +33,28 @@ module Sipity
           end
         end
 
+        context 'assigning attachments attributes' do
+          let(:user) { double('User') }
+          let(:repository) { CommandRepositoryInterface.new }
+          let(:attachments_attributes) do
+            {
+              "0" => { "name" => "code4lib.pdf", "delete" => "1", "id" => "i8tnddObffbIfNgylX7zSA==" },
+              "1" => { "name" => "hotel.pdf", "delete" => "0", "id" => "y5Fm8YK9-ekjEwUMKeeutw==" },
+              "2" => { "name" => "code4lib.pdf", "delete" => "0", "id" => "64Y9v5yGshHFgE6fS4FRew==" }
+            }
+          end
+          subject { described_class.new(work: work, repository: repository, attachments_attributes: attachments_attributes) }
+
+          before do
+            allow(subject).to receive(:valid?).and_return(true)
+          end
+
+          it 'will delete any attachments marked for deletion' do
+            expect(repository).to receive(:remove_files_from).with(work: work, user: user, pids: ["i8tnddObffbIfNgylX7zSA=="])
+            subject.submit(repository: repository, requested_by: user)
+          end
+        end
+
         context '#submit' do
           let(:repository) { CommandRepositoryInterface.new }
           let(:user) { double('User') }

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -108,8 +108,8 @@ module Sipity
         let(:pid_minter) { -> { 'abc123' } }
         before { test_repository.attach_file_to(work: work, file: file, user: user, pid_minter: pid_minter) }
         it 'will decrease the number of attachments in the system' do
-          expect { test_repository.remove_files_from(pid: pid_minter.call, user: user) }.
-            to change { Models::Attachment.count }.from(1).to(0)
+          expect { test_repository.remove_files_from(pids: pid_minter.call, work: work, user: user) }.
+            to change { Models::Attachment.count }.by(-1)
         end
       end
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -70,7 +70,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def remove_files_from(pid:, user: user)
+    def remove_files_from(work:, user:, pids:)
     end
 
     # @see ./app/repositories/sipity/commands/notification_commands.rb


### PR DESCRIPTION
## Reworking method signature

@3811514e9b43cd6c5194f34fa8df98615fbc093b

So we can delete enmasse

## Exposing method for deleting attachments

@031cabed012dc5d70043fbd77f98de742d3758b7

The present form implies that we can update the metadata (i.e. name
of the attached file). However, deletion is more important.

## Adding ConvertToBoolean conversion

@8c6a4ba5296c183a07edc9e66c8d0dd8fc2b39ef

> Exposes a conversion method to take an input and transform it into a
> boolean. This is important because user input can come in the form
> of 'true', 'false', '0', '1'.
