### PR TITLE
Extracting repository collaborator

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,9 +13,9 @@ class ApplicationController < ActionController::Base
   # It is the repository that indicates what the application can and is doing.
   def repository
     if request.get?
-      @repository = Sipity::QueryRepository.new
+      Sipity::QueryRepository.new
     else
-      @repository = Sipity::CommandRepository.new
+      Sipity::CommandRepository.new
     end
   end
   helper_method :repository

--- a/app/forms/sipity/forms/assign_a_citation_form.rb
+++ b/app/forms/sipity/forms/assign_a_citation_form.rb
@@ -7,9 +7,11 @@ module Sipity
       def initialize(attributes = {})
         @work = attributes.fetch(:work)
         @type, @citation = attributes.values_at(:type, :citation)
+        @repository = attributes.fetch(:repository) { default_repository }
       end
       attr_accessor :type, :citation
-      attr_reader :work
+      attr_reader :work, :repository
+      private :repository
 
       def enrichment_type
         'assign_a_citation'
@@ -21,7 +23,7 @@ module Sipity
 
       delegate :to_processing_entity, to: :work
 
-      def submit(repository:, requested_by:)
+      def submit(requested_by:)
         super() do |_f|
           repository.update_work_attribute_values!(
             work: work, key: Models::AdditionalAttribute::CITATION_PREDICATE_NAME, values: citation
@@ -35,6 +37,10 @@ module Sipity
       end
 
       private
+
+      def default_repository
+        CommandRepository.new
+      end
 
       def event_name
         File.join(self.class.to_s.demodulize.underscore, 'submit')

--- a/app/forms/sipity/forms/etd/advisor_requests_change_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_requests_change_form.rb
@@ -26,7 +26,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             repository.record_processing_comment(entity: work, commenter: requested_by, comment: comment, action: action)
             repository.send_notification_for_entity_trigger(

--- a/app/forms/sipity/forms/etd/advisor_signoff_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_signoff_form.rb
@@ -25,7 +25,7 @@ module Sipity
           Services::AdvisorSignsOff
         end
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             signoff_service.call(form: self, requested_by: requested_by, repository: repository)
           end

--- a/app/forms/sipity/forms/etd/grad_school_requests_change_form.rb
+++ b/app/forms/sipity/forms/etd/grad_school_requests_change_form.rb
@@ -26,7 +26,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             repository.record_processing_comment(entity: work, commenter: requested_by, comment: comment, action: action)
             repository.send_notification_for_entity_trigger(

--- a/app/forms/sipity/forms/etd/grad_school_signoff_form.rb
+++ b/app/forms/sipity/forms/etd/grad_school_signoff_form.rb
@@ -16,7 +16,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
             repository.send_notification_for_entity_trigger(

--- a/app/forms/sipity/forms/etd/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/etd/submit_for_review_form.rb
@@ -17,7 +17,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
             repository.send_notification_for_entity_trigger(

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -29,7 +29,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             Array.wrap(files).compact.each do |file|
               repository.attach_file_to(work: work, file: file, user: requested_by)

--- a/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
@@ -38,7 +38,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super { repository.assign_collaborators_to(work: work, collaborators: collaborators) }
         end
 
@@ -54,7 +54,7 @@ module Sipity
 
         def build_collaborator_from_input(collection, attributes)
           return if !attributes[:name].present? && !attributes[:id].present?
-          collaborator = Queries::CollaboratorQueries.find_or_initialize_collaborators_by(work: work, id: attributes[:id])
+          collaborator = repository.find_or_initialize_collaborators_by(work: work, id: attributes[:id])
           collaborator.attributes = extract_collaborator_attributes(attributes)
           collection << collaborator
         end

--- a/app/forms/sipity/forms/work_enrichments/defense_date_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/defense_date_form.rb
@@ -13,7 +13,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             repository.update_work_attribute_values!(work: work, key: 'defense_date', values: defense_date)
           end
@@ -21,9 +21,7 @@ module Sipity
 
         def defense_date_from_work
           return nil unless work
-          # REVIEW: I really need to derive this information from the repository.
-          # It is something that should be injected on form build.
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'defense_date').first
+          Array.wrap(repository.work_attribute_values_for(work: work, key: 'defense_date')).first
         end
 
         def parse_input_defense_date(attributes = {})

--- a/app/forms/sipity/forms/work_enrichments/describe_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/describe_form.rb
@@ -14,7 +14,7 @@ module Sipity
 
         private
 
-        def save(repository:, requested_by:)
+        def save(requested_by:)
           super do
             repository.update_work_attribute_values!(work: work, key: 'abstract', values: abstract)
           end

--- a/app/repositories/sipity/command_repository.rb
+++ b/app/repositories/sipity/command_repository.rb
@@ -5,9 +5,14 @@ module Sipity
   end
 
   # The object you can use to interaction with the commands.
-  class CommandRepository < DelegateClass(QueryRepository)
-    def initialize(query_repository_instance: QueryRepository.new)
-      super(query_repository_instance)
+  class CommandRepository
+    # I was using a delegator but was encountering a problem when attempting to
+    # initialize a given form; I was losing the scope of the original
+    # CommandRepository. The following method assures that I get all of the
+    # Query modules included. It is possible that I will need
+    # ActiveSupport::Concern
+    QueryRepository.included_modules.each do |mod|
+      include mod if mod.to_s =~ /Sipity::Queries::/
     end
 
     include Commands::WorkCommands

--- a/app/repositories/sipity/queries/citation_queries.rb
+++ b/app/repositories/sipity/queries/citation_queries.rb
@@ -9,7 +9,7 @@ module Sipity
       end
 
       def build_assign_a_citation_form(attributes = {})
-        Forms::AssignACitationForm.new(attributes)
+        Forms::AssignACitationForm.new(attributes.merge(repository: self))
       end
     end
   end

--- a/app/repositories/sipity/queries/event_trigger_queries.rb
+++ b/app/repositories/sipity/queries/event_trigger_queries.rb
@@ -6,7 +6,7 @@ module Sipity
     module EventTriggerQueries
       def build_event_trigger_form(attributes = {})
         builder = Forms::WorkEventTriggers.find_event_trigger_form_builder(attributes.slice(:processing_action_name, :work))
-        builder.new(attributes)
+        builder.new(attributes.merge(repository: self))
       end
     end
   end

--- a/app/runners/sipity/runners/citation_runners.rb
+++ b/app/runners/sipity/runners/citation_runners.rb
@@ -50,7 +50,7 @@ module Sipity
           decorated_work = Decorators::WorkDecorator.decorate(work)
           form = repository.build_assign_a_citation_form(attributes.merge(work: decorated_work))
           authorization_layer.enforce!(action_name => form) do
-            if form.submit(repository: repository, requested_by: current_user)
+            if form.submit(requested_by: current_user)
               callback(:success, work)
             else
               callback(:failure, form)

--- a/app/runners/sipity/runners/work_enrichment_runners.rb
+++ b/app/runners/sipity/runners/work_enrichment_runners.rb
@@ -30,7 +30,7 @@ module Sipity
           decorated_work = Decorators::WorkDecorator.decorate(work)
           form = repository.build_enrichment_form(attributes.merge(work: decorated_work, enrichment_type: enrichment_type))
           authorization_layer.enforce!(enrichment_type => form) do
-            if form.submit(repository: repository, requested_by: current_user)
+            if form.submit(requested_by: current_user)
               callback(:success, work)
             else
               callback(:failure, form)

--- a/app/runners/sipity/runners/work_event_trigger_runners.rb
+++ b/app/runners/sipity/runners/work_event_trigger_runners.rb
@@ -27,7 +27,7 @@ module Sipity
           work = repository.find_work(attributes.fetch(:work_id))
           form = repository.build_event_trigger_form(attributes.merge(work: work))
           authorization_layer.enforce!(processing_action_name => form) do
-            if form.submit(repository: repository, requested_by: current_user)
+            if form.submit(requested_by: current_user)
               callback(:success, work)
             else
               callback(:failure, form)

--- a/lib/tasks/sipity.rake
+++ b/lib/tasks/sipity.rake
@@ -16,20 +16,23 @@ namespace :sipity do
     MethodDefinition = Struct.new(:name, :definition, :source_filename)
     method_definitions = []
 
-    dirname = File.expand_path('../../../app/repositories/sipity/commands/**/*.rb', __FILE__)
-
-    # Gather all of the command methods
-    Dir.glob(dirname).each do |filename|
-      File.read(filename).each_line do |line|
-        if line =~ /^ *def ([\w]*)[^\w].*$/
-          method_name = $1
-          # This is a potentially big problem that I want to address.
-          if method_definitions.detect { |m| m.name == method_name }
-            $stderr.puts "Duplicate method_name encountered. \"#{method_name}\" has been defined in multiple files."
-            exit(1)
-          else
-            filename.sub!(/^.*\/app\//, './app/')
-            method_definitions << MethodDefinition.new(method_name, line.strip, filename)
+    [
+      File.expand_path('../../../app/repositories/sipity/commands/**/*.rb', __FILE__),
+      File.expand_path('../../../app/repositories/sipity/queries/**/*.rb', __FILE__)
+    ].each do |dirname|
+      # Gather all of the command methods
+      Dir.glob(dirname).each do |filename|
+        File.read(filename).each_line do |line|
+          if line =~ /^ *def ([\w]*)[^\w].*$/
+            method_name = $1
+            # This is a potentially big problem that I want to address.
+            if method_definitions.detect { |m| m.name == method_name }
+              $stderr.puts "Duplicate method_name encountered. \"#{method_name}\" has been defined in multiple files."
+              exit(1)
+            else
+              filename.sub!(/^.*\/app\//, './app/')
+              method_definitions << MethodDefinition.new(method_name, line.strip, filename)
+            end
           end
         end
       end

--- a/spec/forms/sipity/forms/assign_a_citation_form_spec.rb
+++ b/spec/forms/sipity/forms/assign_a_citation_form_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 module Sipity
   module Forms
     RSpec.describe AssignACitationForm do
+      let(:repository) { CommandRepositoryInterface.new }
       let(:work) { Models::Work.new(id: '1234') }
-      subject { described_class.new(work: work) }
+      subject { described_class.new(work: work, repository: repository) }
 
       it { should respond_to :work }
       it { should respond_to :citation }
@@ -34,19 +35,17 @@ module Sipity
         subject { described_class.new(work: work, type: 'ala', citation: citation) }
         context 'on invalid data' do
           let(:citation) { '' }
-          let(:repository) { double }
           let(:user) { double }
           it 'returns false and does not assign a Citation' do
-            expect(subject.submit(repository: repository, requested_by: user)).to eq(false)
+            expect(subject.submit(requested_by: user)).to eq(false)
           end
         end
 
         context 'on valid data' do
           let(:citation) { 'citation:abc' }
-          let(:repository) { double(update_work_attribute_values!: true, log_event!: true) }
           let(:user) { User.new(id: '123') }
           it 'will assign the Citation to the work and create an event' do
-            response = subject.submit(repository: repository, requested_by: user)
+            response = subject.submit(requested_by: user)
             expect(response).to eq(work)
           end
         end

--- a/spec/forms/sipity/forms/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/advisor_requests_change_form_spec.rb
@@ -9,7 +9,7 @@ module Sipity
         let(:repository) { CommandRepositoryInterface.new }
         let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: 'hello') }
         let(:user) { User.new(id: 1) }
-        subject { described_class.new(work: work, processing_action_name: action) }
+        subject { described_class.new(work: work, processing_action_name: action, repository: repository) }
 
         its(:processing_action_name) { should eq(action.name) }
 
@@ -23,7 +23,7 @@ module Sipity
 
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do
-            subject = described_class.new(work: work, processing_action_name: action)
+            subject = described_class.new(work: work, processing_action_name: action, repository: repository)
             expect(subject.action).to eq(action)
           end
         end
@@ -33,31 +33,31 @@ module Sipity
 
           it 'will log the event' do
             expect(repository).to receive(:log_event!).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will register than the given action was taken on the entity' do
             expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will update the processing state' do
             strategy_state = action.build_resulting_strategy_state
             expect(repository).to receive(:update_processing_state!).
               with(entity: work, to: strategy_state).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will send creating user a note that the advisor has requested changes' do
             expect(repository).to receive(:send_notification_for_entity_trigger).
               with(notification: 'advisor_requests_change', entity: work, acting_as: ['creating_user']).
               and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will record the processing comment' do
             expect(repository).to receive(:record_processing_comment).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
         end
       end

--- a/spec/forms/sipity/forms/etd/advisor_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/advisor_signoff_form_spec.rb
@@ -10,7 +10,9 @@ module Sipity
         let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: 'hello') }
         let(:user) { User.new(id: 1) }
         let(:signoff_service) { double('Signoff Service', call: true) }
-        subject { described_class.new(work: work, processing_action_name: action, signoff_service: signoff_service) }
+        subject do
+          described_class.new(work: work, processing_action_name: action, signoff_service: signoff_service, repository: repository)
+        end
 
         context 'the default signoff service' do
           it 'will respond to :call' do
@@ -28,7 +30,7 @@ module Sipity
             expect(signoff_service).to_not receive(:call)
           end
           it 'will return the false' do
-            expect(subject.submit(repository: repository, requested_by: user)).to eq(false)
+            expect(subject.submit(requested_by: user)).to eq(false)
           end
         end
 
@@ -38,22 +40,22 @@ module Sipity
           end
 
           it 'will return the given work' do
-            expect(subject.submit(repository: repository, requested_by: user)).to eq(work)
+            expect(subject.submit(requested_by: user)).to eq(work)
           end
 
           it 'will log the event' do
             expect(repository).to receive(:log_event!).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will register that the given action was taken on the entity' do
             expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will call the AdvisorSignsOff service' do
             expect(signoff_service).to receive(:call)
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
         end
       end

--- a/spec/forms/sipity/forms/etd/grad_school_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/grad_school_requests_change_form_spec.rb
@@ -9,7 +9,7 @@ module Sipity
         let(:repository) { CommandRepositoryInterface.new }
         let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: 'hello') }
         let(:user) { User.new(id: 1) }
-        subject { described_class.new(work: work, processing_action_name: action) }
+        subject { described_class.new(work: work, processing_action_name: action, repository: repository) }
 
         its(:processing_action_name) { should eq(action.name) }
 
@@ -23,7 +23,7 @@ module Sipity
 
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do
-            subject = described_class.new(work: work, processing_action_name: action)
+            subject = described_class.new(work: work, processing_action_name: action, repository: repository)
             expect(subject.action).to eq(action)
           end
         end
@@ -33,31 +33,31 @@ module Sipity
 
           it 'will log the event' do
             expect(repository).to receive(:log_event!).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will register than the given action was taken on the entity' do
             expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will update the processing state' do
             strategy_state = action.build_resulting_strategy_state
             expect(repository).to receive(:update_processing_state!).
               with(entity: work, to: strategy_state).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will send creating user a note that the advisor has requested changes' do
             expect(repository).to receive(:send_notification_for_entity_trigger).
               with(notification: 'grad_school_requests_change', entity: work, acting_as: ['creating_user']).
               and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
 
           it 'will record the processing comment' do
             expect(repository).to receive(:record_processing_comment).and_call_original
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
         end
       end

--- a/spec/forms/sipity/forms/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/grad_school_signoff_form_spec.rb
@@ -9,38 +9,38 @@ module Sipity
         let(:repository) { CommandRepositoryInterface.new }
         let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id, name: "hello") }
         let(:user) { User.new(id: 1) }
-        subject { described_class.new(work: work, processing_action_name: action) }
+        subject { described_class.new(work: work, processing_action_name: action, repository: repository) }
 
         its(:processing_action_name) { should eq(action.name) }
 
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do
-            subject = described_class.new(work: work, processing_action_name: action)
+            subject = described_class.new(work: work, processing_action_name: action, repository: repository)
             expect(subject.action).to eq(action)
           end
         end
 
         it 'will log the event' do
           expect(repository).to receive(:log_event!).and_call_original
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
 
         it 'will register than the given action was taken on the entity' do
           expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
 
         it 'will update the processing state' do
           strategy_state = action.build_resulting_strategy_state
           expect(repository).to receive(:update_processing_state!).
             with(entity: work, to: strategy_state).and_call_original
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
 
         it 'will send notifications to the creating user, etd reviewer, and advisor' do
           expect(repository).to receive(:send_notification_for_entity_trigger).
             with(notification: 'confirmation_of_grad_school_signoff', entity: work, acting_as: ['creating_user', 'etd_reviewer', 'advisor'])
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
       end
     end

--- a/spec/forms/sipity/forms/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/submit_for_review_form_spec.rb
@@ -9,30 +9,30 @@ module Sipity
         let(:repository) { CommandRepositoryInterface.new }
         let(:action) { Models::Processing::StrategyAction.new(strategy_id: processing_entity.strategy_id) }
         let(:user) { User.new(id: 1) }
-        subject { described_class.new(work: work, processing_action_name: action) }
+        subject { described_class.new(work: work, processing_action_name: action, repository: repository) }
 
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do
-            subject = described_class.new(work: work, processing_action_name: action)
+            subject = described_class.new(work: work, processing_action_name: action, repository: repository)
             expect(subject.action).to eq(action)
           end
         end
 
         it 'will log the event' do
           expect(repository).to receive(:log_event!).and_call_original
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
 
         it 'will register than the given action was taken on the entity' do
           expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
 
         it 'will update the processing state' do
           strategy_state = action.build_resulting_strategy_state
           expect(repository).to receive(:update_processing_state!).
             with(entity: work, to: strategy_state).and_call_original
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
 
         it 'will send differing notifications to the creating user, etd reviewer, and advisor' do
@@ -40,7 +40,7 @@ module Sipity
             with(notification: 'confirmation_of_entity_submitted_for_review', entity: work, acting_as: 'creating_user')
           expect(repository).to receive(:send_notification_for_entity_trigger).
             with(notification: 'entity_ready_for_review', entity: work, acting_as: ['etd_reviewer', 'advisor'])
-          subject.submit(repository: repository, requested_by: user)
+          subject.submit(requested_by: user)
         end
       end
     end

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -5,7 +5,8 @@ module Sipity
     module WorkEnrichments
       RSpec.describe AttachForm do
         let(:work) { Models::Work.new(id: '1234') }
-        subject { described_class.new(work: work) }
+        let(:repository) { CommandRepositoryInterface.new }
+        subject { described_class.new(work: work, repository: repository) }
 
         its(:policy_enforcer) { should be_present }
         its(:enrichment_type) { should eq('attach') }
@@ -14,7 +15,7 @@ module Sipity
 
         context 'validations' do
           it 'will require a work' do
-            subject = described_class.new(work: nil)
+            subject = described_class.new(work: nil, repository: repository)
             subject.valid?
             expect(subject.errors[:work]).to_not be_empty
           end
@@ -35,7 +36,6 @@ module Sipity
 
         context 'assigning attachments attributes' do
           let(:user) { double('User') }
-          let(:repository) { CommandRepositoryInterface.new }
           let(:attachments_attributes) do
             {
               "0" => { "name" => "code4lib.pdf", "delete" => "1", "id" => "i8tnddObffbIfNgylX7zSA==" },
@@ -43,7 +43,7 @@ module Sipity
               "2" => { "name" => "code4lib.pdf", "delete" => "0", "id" => "64Y9v5yGshHFgE6fS4FRew==" }
             }
           end
-          subject { described_class.new(work: work, repository: repository, attachments_attributes: attachments_attributes) }
+          subject { described_class.new(work: work, attachments_attributes: attachments_attributes, repository: repository) }
 
           before do
             allow(subject).to receive(:valid?).and_return(true)
@@ -51,28 +51,27 @@ module Sipity
 
           it 'will delete any attachments marked for deletion' do
             expect(repository).to receive(:remove_files_from).with(work: work, user: user, pids: ["i8tnddObffbIfNgylX7zSA=="])
-            subject.submit(repository: repository, requested_by: user)
+            subject.submit(requested_by: user)
           end
         end
 
         context '#submit' do
-          let(:repository) { CommandRepositoryInterface.new }
           let(:user) { double('User') }
           context 'with invalid data' do
             before do
               expect(subject).to receive(:valid?).and_return(false)
             end
             it 'will return false if not valid' do
-              expect(subject.submit(repository: repository, requested_by: user))
+              expect(subject.submit(requested_by: user))
             end
             it 'will not create any attachments' do
-              expect { subject.submit(repository: repository, requested_by: user) }.
+              expect { subject.submit(requested_by: user) }.
                 to_not change { Models::Attachment.count }
             end
           end
 
           context 'with valid data' do
-            subject { described_class.new(work: work, files: [file], remove_files: [remove_file])  }
+            subject { described_class.new(work: work, files: [file], remove_files: [remove_file], repository: repository) }
             let(:file) { double('A File') }
             let(:remove_file) { double('File to delete') }
 
@@ -81,28 +80,28 @@ module Sipity
             end
 
             it 'will return the work' do
-              returned_value = subject.submit(repository: repository, requested_by: user)
+              returned_value = subject.submit(requested_by: user)
               expect(returned_value).to eq(work)
             end
 
             it 'will attach each file' do
               expect(repository).to receive(:attach_file_to).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it "will transition the work's corresponding enrichment todo item to :done" do
               expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it 'will record the event' do
               expect(repository).to receive(:log_event!).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it 'will mark a file as representative' do
               expect(repository).to receive(:mark_as_representative).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
           end
         end

--- a/spec/forms/sipity/forms/work_enrichments/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/defense_date_form_spec.rb
@@ -6,7 +6,8 @@ module Sipity
       RSpec.describe DefenseDateForm do
         let(:work) { Models::Work.new(id: '1234') }
         let(:defense_date) { Date.today }
-        subject { described_class.new(work: work) }
+        let(:repository) { CommandRepositoryInterface.new }
+        subject { described_class.new(work: work, repository: repository) }
 
         its(:enrichment_type) { should eq('defense_date') }
         its(:policy_enforcer) { should eq Policies::Processing::WorkProcessingPolicy }
@@ -20,61 +21,62 @@ module Sipity
         end
 
         it 'will handle Rails defense_date that was input via Rails HTML multi-field date input' do
-          form = described_class.new(work: work, 'defense_date(1i)' => "2014", 'defense_date(2i)' => "10", 'defense_date(3i)' => "1")
+          form = described_class.new(
+            work: work, 'defense_date(1i)' => "2014", 'defense_date(2i)' => "10", 'defense_date(3i)' => "1", repository: repository
+          )
           expect(form.defense_date.month).to eq(10)
         end
 
         context '#defense_date' do
           context 'with data from the database' do
-            subject { described_class.new(work: work) }
+            subject { described_class.new(work: work, repository: repository) }
             it 'will return the defense_date of the work' do
-              expect(Queries::AdditionalAttributeQueries).to receive(:work_attribute_values_for).
+              expect(repository).to receive(:work_attribute_values_for).
                 with(work: work, key: 'defense_date').and_return([defense_date])
               expect(subject.defense_date).to eq defense_date
             end
           end
           context 'when initial date is given is bogus' do
-            subject { described_class.new(work: work, defense_date: '2014-02-31') }
+            subject { described_class.new(work: work, defense_date: '2014-02-31', repository: repository) }
             its(:defense_date) { should_not be_present }
           end
         end
 
         context '#submit' do
-          let(:repository) { CommandRepositoryInterface.new }
           let(:user) { double('User') }
           context 'with invalid data' do
             before do
               expect(subject).to receive(:valid?).and_return(false)
             end
             it 'will return false if not valid' do
-              expect(subject.submit(repository: repository, requested_by: user))
+              expect(subject.submit(requested_by: user))
             end
           end
 
           context 'with valid data' do
-            subject { described_class.new(work: work, defense_date: '2014-10-02') }
+            subject { described_class.new(work: work, defense_date: '2014-10-02', repository: repository) }
             before do
               expect(subject).to receive(:valid?).and_return(true)
             end
 
             it 'will return the work' do
-              returned_value = subject.submit(repository: repository, requested_by: user)
+              returned_value = subject.submit(requested_by: user)
               expect(returned_value).to eq(work)
             end
 
             it "will transition the work's corresponding enrichment todo item to :done" do
               expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it 'will add additional attributes entries' do
               expect(repository).to receive(:update_work_attribute_values!).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it 'will record the event' do
               expect(repository).to receive(:log_event!).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
           end
         end

--- a/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
@@ -5,7 +5,8 @@ module Sipity
     module WorkEnrichments
       RSpec.describe DescribeForm do
         let(:work) { Models::Work.new(id: '1234') }
-        subject { described_class.new(work: work) }
+        let(:repository) { CommandRepositoryInterface.new }
+        subject { described_class.new(work: work, repository: repository) }
 
         its(:enrichment_type) { should eq('describe') }
         its(:policy_enforcer) { should eq Policies::Processing::WorkProcessingPolicy }
@@ -36,45 +37,44 @@ module Sipity
         end
 
         context '#submit' do
-          let(:repository) { CommandRepositoryInterface.new }
           let(:user) { double('User') }
           context 'with invalid data' do
             before do
               expect(subject).to receive(:valid?).and_return(false)
             end
             it 'will return false if not valid' do
-              expect(subject.submit(repository: repository, requested_by: user))
+              expect(subject.submit(requested_by: user))
             end
             it 'will not create create any additional attributes entries' do
-              expect { subject.submit(repository: repository, requested_by: user) }.
+              expect { subject.submit(requested_by: user) }.
                 to_not change { Models::AdditionalAttribute.count }
             end
           end
 
           context 'with valid data' do
-            subject { described_class.new(work: work, abstract: 'Hello Dolly') }
+            subject { described_class.new(work: work, abstract: 'Hello Dolly', repository: repository) }
             before do
               expect(subject).to receive(:valid?).and_return(true)
             end
 
             it 'will return the work' do
-              returned_value = subject.submit(repository: repository, requested_by: user)
+              returned_value = subject.submit(requested_by: user)
               expect(returned_value).to eq(work)
             end
 
             it "will transition the work's corresponding enrichment todo item to :done" do
               expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it 'will add additional attributes entries' do
               expect(repository).to receive(:update_work_attribute_values!).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
 
             it 'will record the event' do
               expect(repository).to receive(:log_event!).and_call_original
-              subject.submit(repository: repository, requested_by: user)
+              subject.submit(requested_by: user)
             end
           end
         end

--- a/spec/repositories/sipity/command_repository_spec.rb
+++ b/spec/repositories/sipity/command_repository_spec.rb
@@ -2,24 +2,7 @@ require 'rails_helper'
 
 module Sipity
   RSpec.describe CommandRepository, type: :repository do
-    let(:query_repository_instance) { double(this_is_a_query_method: :returned_value) }
-    subject { CommandRepository.new(query_repository_instance: query_repository_instance) }
-
-    it 'will respond to the underlying query repository methods' do
-      expect(subject).to respond_to(:this_is_a_query_method)
-    end
-
-    it 'will call the underlying query methods' do
-      expect(subject.this_is_a_query_method).to eq(query_repository_instance.this_is_a_query_method)
-    end
-
-    it 'will be a Sipity::CommandRepository' do
-      expect(subject).to be_a(Sipity::CommandRepository)
-    end
-
-    it 'will not be a Sipity::QueryRepository' do
-      expect(subject).to_not be_a(Sipity::QueryRepository)
-    end
+    subject { CommandRepository.new }
 
     context '#submit_etd_student_submission_trigger!' do
       it 'is a placeholder until I can spend some time focusing on it' do
@@ -31,10 +14,6 @@ module Sipity
       it 'is a placeholder until I can spend some time focusing on it' do
         expect { described_class.new.submit_ingest_etd }.to raise_error(NotImplementedError)
       end
-    end
-
-    xit 'will not include query modules' do
-      expect(Sipity::CommandRepository.included_modules.none? { |mod| mod.to_s =~ /Queries::/ }).to be_truthy
     end
 
     context 'verifying method definition interaction' do

--- a/spec/runners/sipity/runners/citation_runners_spec.rb
+++ b/spec/runners/sipity/runners/citation_runners_spec.rb
@@ -119,7 +119,7 @@ module Sipity
         context 'when the form submission fails' do
           it 'issues the :failure callback' do
             expect(form).to receive(:submit).
-              with(repository: context.repository, requested_by: context.current_user).
+              with(requested_by: context.current_user).
               and_return(false)
             response = subject.run(work_id: work_id, attributes: attributes)
             expect(handler).to have_received(:invoked).with("FAILURE", form)
@@ -130,7 +130,7 @@ module Sipity
         context 'when the form submission succeeds' do
           it 'issues the :success callback' do
             expect(form).to receive(:submit).
-              with(repository: context.repository, requested_by: context.current_user).
+              with(requested_by: context.current_user).
               and_return(true)
             response = subject.run(work_id: work_id, attributes: attributes)
             expect(handler).to have_received(:invoked).with("SUCCESS", work)

--- a/spec/runners/sipity/runners/work_enrichment_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_enrichment_runners_spec.rb
@@ -64,7 +64,7 @@ module Sipity
         context 'when the form submission fails' do
           it 'issues the :failure callback' do
             expect(form).to receive(:submit).
-              with(repository: context.repository, requested_by: context.current_user).
+              with(requested_by: context.current_user).
               and_return(false)
             response = subject.run(work_id: work.id, enrichment_type: enrichment_type, attributes: attributes)
             expect(handler).to have_received(:invoked).with("FAILURE", form)
@@ -75,7 +75,7 @@ module Sipity
         context 'when the form submission succeeds' do
           it 'issues the :success callback' do
             expect(form).to receive(:submit).
-              with(repository: context.repository, requested_by: context.current_user).
+              with(requested_by: context.current_user).
               and_return(true)
             response = subject.run(work_id: work.id, enrichment_type: enrichment_type, attributes: attributes)
             expect(handler).to have_received(:invoked).with("SUCCESS", work)

--- a/spec/runners/sipity/runners/work_event_trigger_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_event_trigger_runners_spec.rb
@@ -56,7 +56,7 @@ module Sipity
         context 'when the form submission fails' do
           it 'issues the :failure callback' do
             expect(form).to receive(:submit).
-              with(repository: context.repository, requested_by: context.current_user).
+              with(requested_by: context.current_user).
               and_return(false)
             response = subject.run(work_id: work.id, processing_action_name: 'processing_action_name')
             expect(context.handler).to have_received(:invoked).with("FAILURE", form)
@@ -67,7 +67,7 @@ module Sipity
         context 'when the form submission succeeds' do
           it 'issues the :success callback' do
             expect(form).to receive(:submit).
-              with(repository: context.repository, requested_by: context.current_user).
+              with(requested_by: context.current_user).
               and_return(true)
             response = subject.run(work_id: work.id, processing_action_name: 'processing_action_name')
             expect(context.handler).to have_received(:invoked).with("SUCCESS", work)

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -13,6 +13,50 @@ module Sipity
     def attach_file_to(work:, file:, user:, pid_minter: default_pid_minter)
     end
 
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def authorized_for_processing?(user:, entity:, action:)
+    end
+
+    # @see ./app/repositories/sipity/queries/citation_queries.rb
+    def build_assign_a_citation_form(attributes = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/doi_queries.rb
+    def build_assign_a_doi_form(attributes = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/account_placeholder_queries.rb
+    def build_create_orcid_account_placeholder_form(attributes: {})
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def build_create_work_form(attributes: {})
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def build_dashboard_view(user:, filter: {})
+    end
+
+    # @see ./app/repositories/sipity/queries/enrichment_queries.rb
+    def build_enrichment_form(attributes = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/event_trigger_queries.rb
+    def build_event_trigger_form(attributes = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/doi_queries.rb
+    def build_request_a_doi_form(attributes = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def build_update_work_form(work:, attributes: {})
+    end
+
+    # @see ./app/repositories/sipity/queries/citation_queries.rb
+    def citation_already_assigned?(work)
+    end
+
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def create_sipity_user_from(netid:)
     end
@@ -35,6 +79,50 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def destroy_work_attribute_values!(work:, key:, values:)
+    end
+
+    # @see ./app/repositories/sipity/queries/doi_queries.rb
+    def doi_already_assigned?(work)
+    end
+
+    # @see ./app/repositories/sipity/queries/doi_queries.rb
+    def doi_request_is_pending?(work)
+    end
+
+    # @see ./app/repositories/sipity/queries/permission_queries.rb
+    def emails_for_associated_users(acting_as:, entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def existing_work_attributes_for(work)
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def exposed_work_attribute_names_for(work:, additional_attribute_names: BASE_HEADER_ATTRIBUTES)
+    end
+
+    # @see ./app/repositories/sipity/queries/doi_queries.rb
+    def find_doi_creation_request(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/attachment_queries.rb
+    def find_or_initialize_attachments_by(work:, pid:)
+    end
+
+    # @see ./app/repositories/sipity/queries/collaborator_queries.rb
+    def find_or_initialize_collaborators_by(work:, id:, &block)
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def find_work(work_id)
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def find_works_for(user:, processing_state: nil)
+    end
+
+    # @see ./app/repositories/sipity/queries/doi_queries.rb
+    def gather_doi_creation_request_metadata(work:)
     end
 
     # @see ./app/repositories/sipity/commands/permission_commands.rb
@@ -73,8 +161,88 @@ module Sipity
     def remove_files_from(work:, user:, pids:)
     end
 
+    # @see ./app/repositories/sipity/queries/attachment_queries.rb
+    def representative_attachment_for(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_permitted_entity_strategy_actions_for_current_state(user:, entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_permitted_entity_strategy_state_actions(user:, entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_permitted_strategy_actions_available_for_current_state(user:, entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_processing_actors_for(user:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_processing_entities_for_the_user_and_proxy_for_type(user:, proxy_for_type:, filter: {})
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_processing_strategy_roles_for_user_and_entity(user:, entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_processing_strategy_roles_for_user_and_entity_specific(user:, entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_processing_strategy_roles_for_user_and_strategy(user:, strategy:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_proxied_objects_for_the_user_and_proxy_for_type(user:, proxy_for_type:, filter: {})
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_statetegy_actions_that_have_occurred(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_strategy_actions_available_for_current_state(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_strategy_actions_for_current_state(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_strategy_actions_that_are_prerequisites(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_strategy_actions_with_completed_prerequisites(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_strategy_actions_with_incomplete_prerequisites(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_strategy_actions_without_prerequisites(entity:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_users_for_entity_and_roles(entity:, roles:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def scope_users_from_actors(actors:)
+    end
+
     # @see ./app/repositories/sipity/commands/notification_commands.rb
     def send_notification_for_entity_trigger(notification:, entity:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/queries/event_log_queries.rb
+    def sequence_of_events_for(options = {})
     end
 
     # @see ./app/repositories/sipity/commands/doi_commands.rb
@@ -107,6 +275,54 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/doi_commands.rb
     def update_work_with_doi_predicate!(work:, values:)
+    end
+
+    # @see ./app/repositories/sipity/queries/collaborator_queries.rb
+    def usernames_of_those_that_are_collaborating_and_responsible_for_review(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def usernames_of_those_that_have_taken_the_action_on_the_entity(entity:, action:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def users_that_have_taken_the_action_on_the_entity(entity:, action:)
+    end
+
+    # @see ./app/repositories/sipity/queries/attachment_queries.rb
+    def work_attachments(options = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
+    def work_attribute_key_value_pairs(work:, keys: [])
+    end
+
+    # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
+    def work_attribute_keys_for(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
+    def work_attribute_values_for(work:, key:)
+    end
+
+    # @see ./app/repositories/sipity/queries/collaborator_queries.rb
+    def work_collaborating_users_responsible_for_review(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/collaborator_queries.rb
+    def work_collaborator_names_for(options = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/collaborator_queries.rb
+    def work_collaborators_for(options = {})
+    end
+
+    # @see ./app/repositories/sipity/queries/collaborator_queries.rb
+    def work_collaborators_responsible_for_review(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
+    def work_default_attribute_keys_for(*)
     end
 
   end


### PR DESCRIPTION
## Promoting :repository to proper collaborator

@244a8080b5eb4b35a5a2d2c543fbd4ce3d9e8697

I'm looking to promote the repository up into the initializer. It does
not make sense as part of the submit process; But instead as a
fundamental collaborator with a given form.

## Reworking method signature

@e30557c4592a3af7de470ee2487b21c414732c48

I do not like passing repository information in as part of the submit
behavior. It was a kludge. By pushing things towards initialization,
I believe I can introduce a container that has the repository
information.
