### PR TITLE
Removing usage of deprecated method

### DIFF
--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -27,12 +27,7 @@ module Sipity
         class_name: 'Sipity::Models::Processing::Entity'
       )
 
-      def processing_state
-        processing_entity.present? ? processing_entity.processing_state : @processing_state
-      end
-
-      attr_writer :processing_state
-      deprecate :processing_state=
+      delegate :processing_state, to: :processing_entity, allow_nil: true
 
       def to_processing_entity
         # This is a bit of a short cut, perhaps I should check if its persisted?

--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -5,20 +5,13 @@ module Sipity
     class Work < ActiveRecord::Base
       self.table_name = 'sipity_works'
 
-      # @!attribute [rw] :processing_state The processing state of the work.
-      #   @return [String]
-      alias_attribute :processing_status, :processing_state
-
       has_many :collaborators, foreign_key: :work_id, dependent: :destroy
       has_many :additional_attributes, foreign_key: :work_id, dependent: :destroy
       has_many :attachments, foreign_key: :work_id, dependent: :destroy
       has_one :doi_creation_request, foreign_key: :work_id, dependent: :destroy
       has_many :access_rights, as: :entity, dependent: :destroy
-
       has_many :transient_answers, as: :entity, dependent: :destroy
-
       has_many :event_logs, as: :entity, class_name: 'Sipity::Models::EventLog'
-
       has_one(
         :processing_entity,
         -> { includes :strategy_state },
@@ -27,7 +20,10 @@ module Sipity
         class_name: 'Sipity::Models::Processing::Entity'
       )
 
+      # @!attribute [rw] :processing_state The processing state of the work.
+      #   @return [String]
       delegate :processing_state, to: :processing_entity, allow_nil: true
+      alias_attribute :processing_status, :processing_state
 
       def to_processing_entity
         # This is a bit of a short cut, perhaps I should check if its persisted?

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Sipity
   module Commands
     RSpec.describe TodoListCommands, type: :isolated_repository_module do
-      let(:work) { Models::Work.new(id: 1, work_type: 'doctoral_dissertation', processing_state: 'new') }
+      let(:work) { Models::Work.new(id: 1, work_type: 'doctoral_dissertation') }
       let(:user) { double }
 
       context '#register_action_taken_on_entity' do

--- a/spec/repositories/sipity/queries/enrichment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/enrichment_queries_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 module Sipity
   module Queries
     RSpec.describe EnrichmentQueries, type: :isolated_repository_module do
-      let(:work) { Models::Work.new(id: 123, processing_state: 'new') }
+      let(:work) { Models::Work.new(id: 123) }
 
       context '#build_enrichment_form' do
         let(:valid_enrichment_type) { 'attach' }


### PR DESCRIPTION
I continue to expose the Work#processing_state as a matter of
convenience. However the ability to write the processing_state is
removed.