### PR TITLE
Reworking attach files

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -31,9 +31,7 @@ module Sipity
 
         def save(requested_by:)
           super do
-            Array.wrap(files).compact.each do |file|
-              repository.attach_file_to(work: work, file: file, user: requested_by)
-            end
+            repository.attach_files_to(work: work, files: files, user: requested_by)
             repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
             repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
           end

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -24,17 +24,24 @@ module Sipity
         # Exposed so that field_for will work
         def attachments_attributes=(value)
           @attachments_attributes = value
-          collect_files_for_deletion(value)
+          collect_files_for_deletion_and_update(value)
         end
 
         private
 
         def save(requested_by:)
           super do
+            # TODO: Validate that the attachment you are deleting is not also
+            # the representative image.
             repository.attach_files_to(work: work, files: files, user: requested_by)
             repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
             repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
+            repository.amend_files_metadata(work: work, user: requested_by, metadata: attachments_metadata)
           end
+        end
+
+        def attachments_metadata
+          @attachments_metadata || {}
         end
 
         def ids_for_deletion
@@ -43,11 +50,15 @@ module Sipity
 
         include Conversions::ConvertToBoolean
 
-        def collect_files_for_deletion(value)
+        def collect_files_for_deletion_and_update(value)
           @ids_for_deletion = []
+          @attachments_metadata = {}
           value.each do |_key, attributes|
-            next unless convert_to_boolean(attributes['delete'])
-            @ids_for_deletion << attributes.fetch('id')
+            if convert_to_boolean(attributes['delete'])
+              @ids_for_deletion << attributes.fetch('id')
+            else
+              @attachments_metadata[attributes.fetch('id')] = attributes.slice('name')
+            end
           end
         end
 

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -40,12 +40,14 @@ module Sipity
         Services::UpdateEntityProcessingState.call(entity: entity, processing_state: to)
       end
 
-      def attach_file_to(work:, file:, user:, pid_minter: default_pid_minter)
+      def attach_files_to(work:, files:, user:, pid_minter: default_pid_minter)
         # I know I want the user, but I'm not certain what we are doing with it
         # just yet.
         _user = user
-        pid = pid_minter.call
-        Models::Attachment.create!(work: work, file: file, pid: pid, predicate_name: 'attachment')
+        Array.wrap(files).each do |file|
+          pid = pid_minter.call
+          Models::Attachment.create!(work: work, file: file, pid: pid, predicate_name: 'attachment')
+        end
       end
 
       def remove_files_from(work:, user:, pids:)

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -55,6 +55,14 @@ module Sipity
         Models::Attachment.where(work: work, pid: Array.wrap(pids)).destroy_all
       end
 
+      def amend_files_metadata(work:, user:, metadata: {})
+        _work, _user, _files = work, user, metadata
+        metadata.each do |pid, data|
+          Models::Attachment.where(work: work).find(pid).
+            update_attributes!(data.with_indifferent_access.slice(:name))
+        end
+      end
+
       def mark_as_representative(work:, pid:, user: user)
         attachment = Models::Attachment.find_by(pid: pid)
         return true unless attachment.present?

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -53,6 +53,17 @@ module Sipity
             expect(repository).to receive(:remove_files_from).with(work: work, user: user, pids: ["i8tnddObffbIfNgylX7zSA=="])
             subject.submit(requested_by: user)
           end
+
+          it 'will amend any attachment metadata' do
+            expect(repository).to receive(:amend_files_metadata).
+              with(
+                work: work, user: user, metadata: {
+                  "y5Fm8YK9-ekjEwUMKeeutw==" => { "name" => "hotel.pdf" },
+                  "64Y9v5yGshHFgE6fS4FRew==" => { "name" => "code4lib.pdf" }
+                }
+              )
+            subject.submit(requested_by: user)
+          end
         end
 
         context '#submit' do
@@ -85,7 +96,7 @@ module Sipity
             end
 
             it 'will attach each file' do
-              expect(repository).to receive(:attach_file_to).and_call_original
+              expect(repository).to receive(:attach_files_to).and_call_original
               subject.submit(requested_by: user)
             end
 

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -89,13 +89,13 @@ module Sipity
         end
       end
 
-      context '#attach_file_to' do
+      context '#attach_files_to' do
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:user) { User.new(id: 1234) }
         let(:work) { Models::Work.create! }
         let(:pid_minter) { -> { 'abc123' } }
         it 'will increment the number of attachments in the system' do
-          expect { test_repository.attach_file_to(work: work, file: file, user: user, pid_minter: pid_minter) }.
+          expect { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }.
             to change { Models::Attachment.where(pid: 'abc123').count }.by(1)
         end
       end
@@ -106,7 +106,7 @@ module Sipity
         let(:user) { User.new(id: 1234) }
         let(:work) { Models::Work.create! }
         let(:pid_minter) { -> { 'abc123' } }
-        before { test_repository.attach_file_to(work: work, file: file, user: user, pid_minter: pid_minter) }
+        before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will decrease the number of attachments in the system' do
           expect { test_repository.remove_files_from(pids: pid_minter.call, work: work, user: user) }.
             to change { Models::Attachment.count }.by(-1)
@@ -119,7 +119,7 @@ module Sipity
         let(:user) { User.new(id: 1234) }
         let(:work) { Models::Work.create! }
         let(:pid_minter) { -> { 'abc123' } }
-        before { test_repository.attach_file_to(work: work, file: file, user: user, pid_minter: pid_minter) }
+        before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will mark the given attachments as representative in the system' do
           expect { test_repository.mark_as_representative(work: work, pid: pid_minter.call, user: user) }.
             to change { Models::Attachment.where(is_representative_file: true).count }.by(1)

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -113,6 +113,19 @@ module Sipity
         end
       end
 
+      context '#amend_files_metadata' do
+        let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
+        let(:file_name) { "hello-world.txt" }
+        let(:user) { User.new(id: 1234) }
+        let(:work) { Models::Work.create! }
+        let(:pid_minter) { -> { 'abc123' } }
+        before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
+        it 'will change the file name' do
+          test_repository.amend_files_metadata(work: work, user: user, metadata: { 'abc123' => { 'name' => 'Howdy' } })
+          expect(Models::Attachment.find('abc123').name).to eq('Howdy')
+        end
+      end
+
       context '#mark_as_representative' do
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:file_name) { "hello-world.txt" }

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -6,11 +6,15 @@
 module Sipity
   class CommandRepositoryInterface
     # @see ./app/repositories/sipity/commands/work_commands.rb
+    def amend_files_metadata(work:, user:, metadata: {})
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
     def assign_collaborators_to(work:, collaborators:)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def attach_file_to(work:, file:, user:, pid_minter: default_pid_minter)
+    def attach_files_to(work:, files:, user:, pid_minter: default_pid_minter)
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb


### PR DESCRIPTION
## Reworking attach_file_to -> attach_files_to

@d264b67a4119aa4a1c21729c0670a3c7aedc302d

In the AttachForm, I want to keep commands happening at the same level
of abstraction. This means that I do not handle array wrapping in the
form but instead push down to the repository.

## Handling update of attachments data

@f8d73f27b7db39979de97ef2f38811a2a215b485

Given that a user may want to change the name of the file
Then a means of capturing and persisting those changes must exist
