### PR TITLE
Working on advisor requests change form

### DIFF
--- a/app/decorators/sipity/decorators/emails/advisor_requests_change_decorator.rb
+++ b/app/decorators/sipity/decorators/emails/advisor_requests_change_decorator.rb
@@ -1,18 +1,22 @@
 module Sipity
   module Decorators
     module Emails
+      # Responsible for exposing methods required for email delivery. Nothing
+      # too fancy.
       class AdvisorRequestsChangeDecorator
         def initialize(processing_comment)
           @processing_comment = processing_comment
         end
 
         def name_of_commentor
+          actor.proxy_for.name
         end
 
         def document_type
+          entity.proxy_for.work_type
         end
 
-        delegate :comment, to: :@processing_comment
+        delegate :comment, :actor, :entity, to: :@processing_comment
       end
     end
   end

--- a/app/decorators/sipity/decorators/emails/advisor_requests_change_decorator.rb
+++ b/app/decorators/sipity/decorators/emails/advisor_requests_change_decorator.rb
@@ -1,0 +1,19 @@
+module Sipity
+  module Decorators
+    module Emails
+      class AdvisorRequestsChangeDecorator
+        def initialize(processing_comment)
+          @processing_comment = processing_comment
+        end
+
+        def name_of_commentor
+        end
+
+        def document_type
+        end
+
+        delegate :comment, to: :@processing_comment
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/etd/advisor_requests_change_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_requests_change_form.rb
@@ -28,11 +28,11 @@ module Sipity
 
         def save(requested_by:)
           super do
-            repository.record_processing_comment(entity: work, commenter: requested_by, comment: comment, action: action)
+            processing_comment = repository.record_processing_comment(
+              entity: work, commenter: requested_by, comment: comment, action: action
+            )
             repository.send_notification_for_entity_trigger(
-              notification: 'advisor_requests_change',
-              entity: work,
-              acting_as: ['creating_user']
+              notification: 'advisor_requests_change', entity: processing_comment, acting_as: ['creating_user']
             )
             repository.update_processing_state!(entity: work, to: action.resulting_strategy_state)
           end

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -59,7 +59,7 @@ module Sipity
       private
 
       def convert_entity_into_decorator(entity)
-        Sipity::Decorators::EmailNotificationDecorator.new(entity)
+        Decorators::EmailNotificationDecorator.new(entity)
       end
     end
   end

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -31,9 +31,10 @@ module Sipity
         mail(to: to, cc: cc, bcc: bcc)
       end
 
-      def advisor_requests_change(entity:, to:, cc: [], bcc: [])
-        @entity = convert_entity_into_decorator(entity)
-        mail(to: to, cc: cc, bcc: bcc)
+      def advisor_requests_change(options = {})
+        entity = options.fetch(:entity)
+        @entity = options.fetch(:decorator) { Decorators::Email::AdvisorRequestsChangeDecorator }.new(entity)
+        mail(options.slice(:to, :cc, :bcc))
       end
 
       def grad_school_requests_change(entity:, to:, cc: [], bcc: [])

--- a/app/views/sipity/mailers/email_notifier/advisor_requests_change.html.erb
+++ b/app/views/sipity/mailers/email_notifier/advisor_requests_change.html.erb
@@ -1,8 +1,8 @@
-<p>Your research director, <%= @entity.director %>, has indicated that updates are required to your <%= @entity.document_type %> or to the submission options you’ve chosen.  Once you have addressed the director’s concerns, please upload a revised PDF to this record. Your director will then be prompted to review the new file.</p>
-<p>Reviewer Comments:<br/>
-<% @entity.comments.each do |comment| %>
-  <p><%= comment %></p>
-<% end %>
+<p>Your research director, <%= @entity.name_of_commentor %>, has indicated that updates are required to your <%= @entity.document_type %> or to the submission options you’ve chosen.  Once you have addressed the director’s concerns, please upload a revised PDF to this record. Your director will then be prompted to review the new file.</p>
+<p><strong>Reviewer Comments:</strong></p>
+
+<p><%= @entity.comment %></p>
+
 <p>If you have not yet submitted the other items required, please refer to the Graduate School’s <a href="http://www.google.com/url?q=http%3A%2F%2Fgraduateschool.nd.edu%2Fresources-for-current-students%2Fdt%2Fdt-checklist%2F&sa=D&sntz=1&usg=AFQjCNGvwVT72W1yRY7b1cf01bMby9lmxw">submission checklist</a>. If you have questions about your ETD record or the other submission materials, please contact me or my assistant at <a href="mailto:dteditor@nd.edu" target="_top">dteditor@nd.edu</a> or 574-631-7545 for assistance.</p>
 
 <%= render partial: 'grad_school_email_signature' %>

--- a/app/views/sipity/mailers/email_notifier/advisor_requests_change.html.erb
+++ b/app/views/sipity/mailers/email_notifier/advisor_requests_change.html.erb
@@ -1,4 +1,4 @@
-<p>Your research director, <%= @entity.director %>, has indicated that updates are required to your <%= @entity.document_type %> or to the submission options you’ve chosen.  Once you have addressed the director’s concerns, please upload a revised PDF to this record. Your director will then be prompted to review the new file.</p> 
+<p>Your research director, <%= @entity.director %>, has indicated that updates are required to your <%= @entity.document_type %> or to the submission options you’ve chosen.  Once you have addressed the director’s concerns, please upload a revised PDF to this record. Your director will then be prompted to review the new file.</p>
 <p>Reviewer Comments:<br/>
 <% @entity.comments.each do |comment| %>
   <p><%= comment %></p>

--- a/spec/decorators/sipity/decorators/emails/advisor_requests_change_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/advisor_requests_change_decorator_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+module Sipity
+  module Decorators
+    module Emails
+      RSpec.describe AdvisorRequestsChangeDecorator do
+        let(:processing_comment) { Models::Processing::Comment.new(comment: 'hello') }
+        subject { described_class.new(processing_comment) }
+
+        its(:comment) { should eq processing_comment.comment }
+        it { should respond_to :name_of_commentor }
+        it { should respond_to :document_type }
+      end
+    end
+  end
+end

--- a/spec/decorators/sipity/decorators/emails/advisor_requests_change_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/advisor_requests_change_decorator_spec.rb
@@ -4,12 +4,16 @@ module Sipity
   module Decorators
     module Emails
       RSpec.describe AdvisorRequestsChangeDecorator do
-        let(:processing_comment) { Models::Processing::Comment.new(comment: 'hello') }
+        let(:user) { User.new(name: 'Hello World') }
+        let(:work) { Models::Work.new(work_type: 'doctoral_dissertation') }
+        let(:actor) { Models::Processing::Actor.new(proxy_for: user) }
+        let(:entity) { Models::Processing::Entity.new(proxy_for: work) }
+        let(:processing_comment) { Models::Processing::Comment.new(comment: 'hello', actor: actor, entity: entity) }
         subject { described_class.new(processing_comment) }
 
         its(:comment) { should eq processing_comment.comment }
-        it { should respond_to :name_of_commentor }
-        it { should respond_to :document_type }
+        its(:name_of_commentor) { should eq(user.name) }
+        its(:document_type) { should eq(work.work_type) }
       end
     end
   end

--- a/spec/forms/sipity/forms/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/advisor_requests_change_form_spec.rb
@@ -29,7 +29,11 @@ module Sipity
         end
 
         context 'with valid data' do
-          before { expect(subject).to receive(:valid?).and_return(true) }
+          let(:a_processing_comment) { double }
+          before do
+            allow(repository).to receive(:record_processing_comment).and_return(a_processing_comment)
+            expect(subject).to receive(:valid?).and_return(true)
+          end
 
           it 'will log the event' do
             expect(repository).to receive(:log_event!).and_call_original
@@ -50,13 +54,13 @@ module Sipity
 
           it 'will send creating user a note that the advisor has requested changes' do
             expect(repository).to receive(:send_notification_for_entity_trigger).
-              with(notification: 'advisor_requests_change', entity: work, acting_as: ['creating_user']).
+              with(notification: 'advisor_requests_change', entity: a_processing_comment, acting_as: ['creating_user']).
               and_call_original
             subject.submit(requested_by: user)
           end
 
           it 'will record the processing comment' do
-            expect(repository).to receive(:record_processing_comment).and_call_original
+            expect(repository).to receive(:record_processing_comment).and_return(a_processing_comment)
             subject.submit(requested_by: user)
           end
         end

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -83,10 +83,12 @@ module Sipity
         end
       end
       context '#advisor_requests_change' do
-        let(:entity) { Models::Work.new }
+        let(:entity) { double('Hello') }
+        let(:decorated) { double(name_of_commentor: 'A name', comment: "A comment", document_type: "A document_type") }
+        let(:decorator) { double(new: decorated) }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
-          described_class.advisor_requests_change(entity: entity, to: to).deliver_now
+          described_class.advisor_requests_change(entity: entity, to: to, decorator: decorator).deliver_now
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end


### PR DESCRIPTION
## Making sure we are sending the processing comment

@27ea55263f170b9769f986337ccffc847526acb0

Instead of the entity, of which we won't know what is the processing
comment, I'm opting to send the processing comment.

## Removing trailing blank space

@ef3342fdf03914e071b1f4a1e67af89a6328b43a

[skip ci]

## Removing un-needed module declration

@f4aaed26b38e081e92b8474596a85e42ab51f36b


## Extracting the AdvisorRequestsChangeDecorator

@6ac495b4c1dd52aa7f39c26bad6c4b6a1870169d

This is a requirement as we want to render a comment specific email.
So we will extract that information from the processing comment and
present it as appropriate.

## Refactoring #advisor_requests_change

@322b879974e2e6dc1daa85dc86dca9285eaed0ab

The one-size fits all decorator does not fit (but was helpful to get
us addressing the next important updates).

This is splicing in the new Email::AdvisorRequestsChangeDecorator.

## Fleshing out AdvisorRequestsChangesDecorator

@cf2fecf49f8bccfe4a8d71df46d851365c02c89b

Wiring in the required retrieval information
