### PR TITLE
Working on accessible objects form

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_date.rb
+++ b/app/conversions/sipity/conversions/convert_to_date.rb
@@ -1,0 +1,51 @@
+module Sipity
+  module Conversions
+    # Exposes a conversion method to take an input and transform it into a
+    # date.
+    #
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToDate
+      # A convenience method so that you don't need to include the conversion
+      # module in your base class.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Date
+      #
+      # @see #convert_to_date
+      def self.call(input)
+        convert_to_date(input)
+      end
+
+      # Does its best to convert the input into a date.
+      #
+      # @example
+      #   convert_to_date(1) { Date.today }
+      #   => Date.today
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Date
+      # @yield If unable to parse you may yield the default
+      #
+      # @raise Exceptions::DateConversionError
+      def convert_to_date(input)
+        case input
+        when Date, DateTime then input
+        else
+          Date.parse(input, false)
+        end
+      rescue TypeError, ArgumentError
+        if block_given?
+          yield
+        else
+          raise Exceptions::DateConversionError, input
+        end
+      end
+
+      module_function :convert_to_date
+      private_class_method :convert_to_date
+      private :convert_to_date
+    end
+  end
+end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -69,6 +69,11 @@ module Sipity
       self.conversion_target = 'Models::Role'
     end
 
+    # Unable to convert the given object into a Date
+    class DateConversionError < ConversionError
+      self.conversion_target = 'Date'
+    end
+
     # Processing Conversion Errors; These may often mean a database entry is
     # missing.
     class ProcessingConversionError < ConversionError

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -1,0 +1,52 @@
+module Sipity
+  module Forms
+    module WorkEnrichments
+      # Exposes a means of assigning an access policy to each of the related
+      # items.
+      #
+      # TODO: We need to gather up the default data and apply it for form entry.
+      #   - When the form is submitted, parse the input and apply the changes
+      #     to each of the accessible objects
+      #   - When the form is first rendered make sure that the AccessibleObject
+      #     has the right values.
+      #   - Ensure that the AccessibleObject's date is properly parsed.
+      #   - Is there a default we want to "provide" for Embargos (1 year from
+      #     now)
+      class AccessPolicyForm < Forms::WorkEnrichmentForm
+        # Because I am using `#fields_for` for rendering
+        attr_writer :accessible_objects_attributes
+
+        def accessible_objects
+          ([work] + repository.work_attachments(work: work)).map { |obj| AccessibleObject.new(obj) }
+        end
+
+        # Responsible for translating user input into persistence concerns.
+        class AccessibleObject
+          def initialize(object)
+            @object = object
+          end
+          attr_accessor :access_right_code, :release_date
+
+          delegate :persisted?, :id, :to_s, to: :@object
+
+          def open_access_access_code
+            Models::AccessRight::OPEN_ACCESS
+          end
+
+          def restricted_access_access_code
+            Models::AccessRight::RESTRICTED_ACCESS
+          end
+
+          def private_access_access_code
+            Models::AccessRight::PRIVATE_ACCESS
+          end
+
+          def embargo_then_open_access_access_code
+            'embargo_then_open_access'
+          end
+        end
+        private_constant :AccessibleObject
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -39,13 +39,17 @@ module Sipity
         end
         private_constant :AccessibleObjectCodes
 
+        # Responsible for capturing and validating the accessible object from
+        # the user's input.
         class AccessibleObjectFromInput
           include AccessibleObjectCodes
           include ActiveModel::Validations
+          include Conversions::ExtractInputDateFromInput
+
           def initialize(persisted_object, attributes = {})
             @persisted_object = persisted_object
             @access_right_code = attributes[:access_right_code]
-            self.release_date = extract_release_date_from(attributes)
+            self.release_date = extract_input_date_from_input(:release_date, attributes) { nil }
           end
           attr_reader :access_right_code, :release_date, :persisted_object
 
@@ -70,10 +74,6 @@ module Sipity
 
           def valid_access_right_codes
             [open_access_access_code, restricted_access_access_code, private_access_access_code, embargo_then_open_access_access_code]
-          end
-
-          def extract_release_date_from(attributes)
-
           end
         end
 

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -13,11 +13,44 @@ module Sipity
       #   - Is there a default we want to "provide" for Embargos (1 year from
       #     now)
       class AccessPolicyForm < Forms::WorkEnrichmentForm
+
+        def initialize(attributes = {})
+          super
+          self.accessible_objects_attributes = attributes.fetch(:accessible_objects_attributes) { {} }
+        end
+
         # Because I am using `#fields_for` for rendering
-        attr_writer :accessible_objects_attributes
+        def accessible_objects_attributes=(values)
+          @accessible_objects_attributes = parse_accessible_objects_attributes(values)
+        end
 
         def accessible_objects
-          @accessible_objects ||= repository.accessible_objects(work: work).map { |obj| AccessibleObjectFromPersistence.new(obj) }
+          @accessible_objects ||= accessible_objects_from_repository
+        end
+
+        private
+
+        def save(requested_by:)
+          super do
+            repository.apply_access_policies_to(work: work, access_policies: access_objects_attributes_for_persistence)
+          end
+        end
+
+        def access_objects_attributes_for_persistence
+          @accessible_objects_attributes.map { |obj| obj.to_hash }
+        end
+
+        def accessible_objects_from_repository
+          repository.accessible_objects(work: work).map { |obj| AccessibleObjectFromPersistence.new(obj) }
+        end
+
+        def parse_accessible_objects_attributes(values = {})
+          from_persistence = accessible_objects_from_repository
+          values.map do |(_key, attrs)|
+            attributes = attrs.with_indifferent_access
+            persisted_object = from_persistence.detect { |obj| obj.id.to_s == attributes.fetch('id')  }
+            AccessibleObjectFromInput.new(persisted_object, attributes)
+          end
         end
 
         module AccessibleObjectCodes
@@ -53,7 +86,7 @@ module Sipity
           end
           attr_reader :access_right_code, :release_date, :persisted_object
 
-          delegate :persisted?, :id, :to_s, to: :persisted_object
+          delegate :persisted?, :entity_type, :to_param, :id, :to_s, to: :persisted_object
 
           def persisted?
             true
@@ -61,6 +94,15 @@ module Sipity
 
           validates :access_right_code, presence: true, inclusion: { in: :valid_access_right_codes, allow_nil: true }
           validates :release_date, presence: { if: :will_be_under_embargo? }
+
+          def to_hash
+            {
+              entity_id: id.to_s,
+              entity_type: entity_type,
+              access_right_code: access_right_code,
+              release_date: release_date
+            }
+          end
 
           private
 
@@ -84,7 +126,12 @@ module Sipity
             @object = object
           end
           attr_reader :access_right_code, :release_date
-          delegate :persisted?, :id, :to_s, to: :@object
+          delegate :persisted?, :id, :to_s, :to_param, to: :@object
+
+          include Conversions::ConvertToPolymorphicType
+          def entity_type
+            convert_to_polymorphic_type(@object)
+          end
         end
       end
     end

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -13,7 +13,6 @@ module Sipity
       #   - Is there a default we want to "provide" for Embargos (1 year from
       #     now)
       class AccessPolicyForm < Forms::WorkEnrichmentForm
-
         def initialize(attributes = {})
           super
           self.accessible_objects_attributes = attributes.fetch(:accessible_objects_attributes) { {} }
@@ -55,7 +54,7 @@ module Sipity
         end
 
         def access_objects_attributes_for_persistence
-          accessible_objects.map { |obj| obj.to_hash }
+          accessible_objects.map(&:to_hash)
         end
 
         def accessible_objects_from_repository
@@ -66,11 +65,13 @@ module Sipity
           from_persistence = accessible_objects_from_repository
           values.map do |(_key, attrs)|
             attributes = attrs.with_indifferent_access
-            persisted_object = from_persistence.detect { |obj| obj.id.to_s == attributes.fetch('id')  }
+            persisted_object = from_persistence.find { |obj| obj.id.to_s == attributes.fetch('id')  }
             AccessibleObjectFromInput.new(persisted_object, attributes)
           end
         end
 
+        # These are shared elements of the AccessibleObjects (both input and
+        # from persistence)
         module AccessibleObjectInterface
           def open_access_access_code
             Models::AccessRight::OPEN_ACCESS
@@ -96,7 +97,6 @@ module Sipity
               release_date: release_date
             }
           end
-
         end
         private_constant :AccessibleObjectInterface
 

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -17,11 +17,11 @@ module Sipity
         attr_writer :accessible_objects_attributes
 
         def accessible_objects
-          ([work] + repository.work_attachments(work: work)).map { |obj| AccessibleObject.new(obj) }
+          ([work] + repository.work_attachments(work: work)).map { |obj| AccessibleObjectFromPersistence.new(obj) }
         end
 
         # Responsible for translating user input into persistence concerns.
-        class AccessibleObject
+        class AccessibleObjectFromPersistence
           def initialize(object)
             @object = object
           end

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -3,15 +3,6 @@ module Sipity
     module WorkEnrichments
       # Exposes a means of assigning an access policy to each of the related
       # items.
-      #
-      # TODO: We need to gather up the default data and apply it for form entry.
-      #   - When the form is submitted, parse the input and apply the changes
-      #     to each of the accessible objects
-      #   - When the form is first rendered make sure that the AccessibleObject
-      #     has the right values.
-      #   - Ensure that the AccessibleObject's date is properly parsed.
-      #   - Is there a default we want to "provide" for Embargos (1 year from
-      #     now)
       class AccessPolicyForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
           super
@@ -58,7 +49,7 @@ module Sipity
         end
 
         def accessible_objects_from_repository
-          repository.accessible_objects(work: work).map { |obj| AccessibleObjectFromPersistence.new(obj) }
+          repository.access_rights_for_accessible_objects_of(work: work)
         end
 
         def parse_accessible_objects_attributes(values = {})
@@ -70,40 +61,9 @@ module Sipity
           end
         end
 
-        # These are shared elements of the AccessibleObjects (both input and
-        # from persistence)
-        module AccessibleObjectInterface
-          def open_access_access_code
-            Models::AccessRight::OPEN_ACCESS
-          end
-
-          def restricted_access_access_code
-            Models::AccessRight::RESTRICTED_ACCESS
-          end
-
-          def private_access_access_code
-            Models::AccessRight::PRIVATE_ACCESS
-          end
-
-          def embargo_then_open_access_access_code
-            Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS
-          end
-
-          def to_hash
-            {
-              entity_id: id.to_s,
-              entity_type: entity_type,
-              access_right_code: access_right_code,
-              release_date: release_date
-            }
-          end
-        end
-        private_constant :AccessibleObjectInterface
-
         # Responsible for capturing and validating the accessible object from
         # the user's input.
         class AccessibleObjectFromInput
-          include AccessibleObjectInterface
           include ActiveModel::Validations
           include Conversions::ExtractInputDateFromInput
 
@@ -117,12 +77,17 @@ module Sipity
 
           delegate :persisted?, :entity_type, :to_param, :id, :to_s, to: :persisted_object
 
-          def persisted?
-            true
-          end
-
           validates :access_right_code, presence: true, inclusion: { in: :valid_access_right_codes, allow_nil: true }
           validates :release_date, presence: { if: :will_be_under_embargo? }
+
+          def to_hash
+            {
+              entity_id: id.to_s,
+              entity_type: entity_type,
+              access_right_code: access_right_code,
+              release_date: release_date
+            }
+          end
 
           private
 
@@ -132,26 +97,11 @@ module Sipity
           end
 
           def will_be_under_embargo?
-            access_right_code == embargo_then_open_access_access_code
+            access_right_code == Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS
           end
 
           def valid_access_right_codes
-            [open_access_access_code, restricted_access_access_code, private_access_access_code, embargo_then_open_access_access_code]
-          end
-        end
-
-        # Responsible for translating user input into persistence concerns.
-        class AccessibleObjectFromPersistence
-          include AccessibleObjectInterface
-          def initialize(object)
-            @object = object
-          end
-          attr_reader :access_right_code, :release_date
-          delegate :persisted?, :id, :to_s, :to_param, to: :@object
-
-          include Conversions::ConvertToPolymorphicType
-          def entity_type
-            convert_to_polymorphic_type(@object)
+            Models::AccessRight.primative_acccess_right_codes
           end
         end
       end

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -85,7 +85,7 @@ module Sipity
           end
 
           def embargo_then_open_access_access_code
-            'embargo_then_open_access'
+            Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS
           end
 
           def to_hash

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -23,6 +23,10 @@ module Sipity
         def accessible_objects_attributes=(values)
           @accessible_objects_attributes = parse_accessible_objects_attributes(values)
         end
+        attr_reader :accessible_objects_attributes
+
+        validate :each_accessible_objects_attributes_are_valid
+        validate :at_lease_one_accessible_objects_attributes_entry
 
         def accessible_objects
           if @accessible_objects_attributes.present?
@@ -33,6 +37,16 @@ module Sipity
         end
 
         private
+
+        def each_accessible_objects_attributes_are_valid
+          return true if accessible_objects_attributes.all?(&:valid?)
+          errors.add(:accessible_objects_attributes, :invalid)
+        end
+
+        def at_lease_one_accessible_objects_attributes_entry
+          return true if accessible_objects_attributes.present?
+          errors.add(:base, :presence_of_access_policies_for_objects_required)
+        end
 
         def save(requested_by:)
           super do

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -126,8 +126,9 @@ module Sipity
 
           private
 
+          include Conversions::ConvertToDate
           def release_date=(value)
-            @release_date = value
+            @release_date = convert_to_date(value) { nil }
           end
 
           def will_be_under_embargo?

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -17,7 +17,7 @@ module Sipity
         attr_writer :accessible_objects_attributes
 
         def accessible_objects
-          ([work] + repository.work_attachments(work: work)).map { |obj| AccessibleObjectFromPersistence.new(obj) }
+          repository.accessible_objects(work: work).map { |obj| AccessibleObjectFromPersistence.new(obj) }
         end
 
         # Responsible for translating user input into persistence concerns.

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -50,7 +50,7 @@ module Sipity
 
         def save(requested_by:)
           super do
-            repository.apply_access_policies_to(work: work, access_policies: access_objects_attributes_for_persistence)
+            repository.apply_access_policies_to(work: work, user: requested_by, access_policies: access_objects_attributes_for_persistence)
           end
         end
 

--- a/app/forms/sipity/forms/work_enrichments/defense_date_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/defense_date_form.rb
@@ -25,19 +25,9 @@ module Sipity
           Array.wrap(repository.work_attribute_values_for(work: work, key: 'defense_date')).first
         end
 
+        include Conversions::ConvertToDate
         def defense_date=(value)
-          @defense_date = convert_to_date(value)
-        end
-
-        def convert_to_date(value)
-          case value
-          when Date, DateTime then value
-          when NilClass then value
-          else
-            Date.parse(value)
-          end
-        rescue TypeError, ArgumentError
-          nil
+          @defense_date = convert_to_date(value) { nil }
         end
       end
     end

--- a/app/models/sipity/models/access_right.rb
+++ b/app/models/sipity/models/access_right.rb
@@ -10,29 +10,23 @@ module Sipity
     # It is envisioned that the AccessRights will be contiguous non-overlapping
     # date ranges.
     class AccessRight < ActiveRecord::Base
-      # @attr_accessor [Date] enforcement_start_date the first day in which the
-      #   given access_right enforcement is in effect
-      # @attr_accessor [Date] enforcement_end_date the last day in which the
-      #   given access_right enforcement is in effect
+      # @attr_accessor [Date] transition_date the date in which a transition
+      #   would occur
       self.table_name = 'sipity_access_rights'
 
       OPEN_ACCESS = 'open_access'.freeze
       RESTRICTED_ACCESS = 'restricted_access'.freeze
       PRIVATE_ACCESS = 'private_access'.freeze
+      EMBARGO_THEN_OPEN_ACCESS = 'embargo_then_open_access'.freeze
 
       enum(
         acccess_right_code: {
           OPEN_ACCESS => OPEN_ACCESS,
           RESTRICTED_ACCESS => RESTRICTED_ACCESS,
-          PRIVATE_ACCESS => PRIVATE_ACCESS
+          PRIVATE_ACCESS => PRIVATE_ACCESS,
+          EMBARGO_THEN_OPEN_ACCESS => EMBARGO_THEN_OPEN_ACCESS
         }
       )
-
-      # This is not a valid persisted access_right_code, but is something that
-      # a user can specify via the UI.
-      #
-      # @see Servicess::ApplyAccessPoliciesTo for its usage
-      EMBARGO_THEN_OPEN_ACCESS = 'embargo_then_open_access'.freeze
 
       belongs_to :entity, polymorphic: true
 

--- a/app/models/sipity/models/access_right.rb
+++ b/app/models/sipity/models/access_right.rb
@@ -17,13 +17,13 @@ module Sipity
       self.table_name = 'sipity_access_rights'
 
       OPEN_ACCESS = 'open_access'.freeze
-      RESTRICTED_ACSESS = 'restricted_access'.freeze
+      RESTRICTED_ACCESS = 'restricted_access'.freeze
       PRIVATE_ACCESS = 'private_access'.freeze
 
       enum(
         acccess_right_code: {
           OPEN_ACCESS => OPEN_ACCESS,
-          RESTRICTED_ACSESS => RESTRICTED_ACSESS,
+          RESTRICTED_ACCESS => RESTRICTED_ACCESS,
           PRIVATE_ACCESS => PRIVATE_ACCESS
         }
       )

--- a/app/models/sipity/models/access_right.rb
+++ b/app/models/sipity/models/access_right.rb
@@ -28,6 +28,12 @@ module Sipity
         }
       )
 
+      # This is not a valid persisted access_right_code, but is something that
+      # a user can specify via the UI.
+      #
+      # @see Servicess::ApplyAccessPoliciesTo for its usage
+      EMBARGO_THEN_OPEN_ACCESS = 'embargo_then_open_access'.freeze
+
       belongs_to :entity, polymorphic: true
     end
   end

--- a/app/models/sipity/models/access_right.rb
+++ b/app/models/sipity/models/access_right.rb
@@ -35,6 +35,14 @@ module Sipity
       EMBARGO_THEN_OPEN_ACCESS = 'embargo_then_open_access'.freeze
 
       belongs_to :entity, polymorphic: true
+
+      # What do I mean by this? I mean that these are the most basic codes that
+      # we are capturing and persisting. There are others (e.g.
+      # EMBARGO_THEN_OPEN_ACCESS) that require additional logic to define how
+      # the corresponding data is persisted.
+      def self.primative_acccess_right_codes
+        acccess_right_codes.keys
+      end
     end
   end
 end

--- a/app/models/sipity/models/access_right.rb
+++ b/app/models/sipity/models/access_right.rb
@@ -30,6 +30,8 @@ module Sipity
 
       belongs_to :entity, polymorphic: true
 
+      alias_attribute :release_date, :transition_date
+
       # What do I mean by this? I mean that these are the most basic codes that
       # we are capturing and persisting. There are others (e.g.
       # EMBARGO_THEN_OPEN_ACCESS) that require additional logic to define how

--- a/app/models/sipity/models/access_right_facade.rb
+++ b/app/models/sipity/models/access_right_facade.rb
@@ -8,6 +8,8 @@ module Sipity
     # find_by_sql or some such thing that joins multiple models but pushes it
     # onto a single ActiveRecord object). But that could be confusing.
     class AccessRightFacade
+      include ActiveModel::Validations
+
       def initialize(accessible_object)
         self.accessible_object = accessible_object
       end

--- a/app/models/sipity/models/access_right_facade.rb
+++ b/app/models/sipity/models/access_right_facade.rb
@@ -1,0 +1,33 @@
+module Sipity
+  module Models
+    # Responsible for providing a bridge for managing an AccessRight indirectly.
+    # That is to say, I don't want to create AccessRights for everything only
+    # as needed and finalized.
+    #
+    # This behavior is achievable by way of ActiveRecord tomfoolery (i.e. a
+    # find_by_sql or some such thing that joins multiple models but pushes it
+    # onto a single ActiveRecord object). But that could be confusing.
+    class AccessRightFacade
+      def initialize(accessible_object)
+        self.accessible_object = accessible_object
+      end
+
+      delegate :to_param, :id, :persisted?, :to_s, to: :@accessible_object
+      delegate :access_right_code, :release_date, to: :access_right_object
+      alias_method :entity_id, :id
+      attr_reader :entity_type
+
+      private
+
+      include Conversions::ConvertToPolymorphicType
+      def accessible_object=(object)
+        @entity_type = convert_to_polymorphic_type(object)
+        @accessible_object = object
+      end
+
+      def access_right_object
+        @access_right_object ||= Models::AccessRight.find_or_initialize_by(entity_id: entity_id, entity_type: entity_type)
+      end
+    end
+  end
+end

--- a/app/models/sipity/models/attachment.rb
+++ b/app/models/sipity/models/attachment.rb
@@ -10,6 +10,10 @@ module Sipity
 
       alias_attribute :name, :file_name
 
+      def to_s
+        file_name
+      end
+
       belongs_to :work
       dragonfly_accessor :file
 

--- a/app/repositories/sipity/commands/transient_answer_commands.rb
+++ b/app/repositories/sipity/commands/transient_answer_commands.rb
@@ -18,7 +18,7 @@ module Sipity
         #   message to that container regarding application of the answer.
         case answer
         when 'open_access', 'restricted_access', 'private_access'
-          Models::AccessRight.create!(entity: entity, access_right_code: answer, enforcement_start_date: Date.today)
+          Models::AccessRight.create!(entity: entity, access_right_code: answer)
         end
         transient_answer
       end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -85,6 +85,9 @@ module Sipity
       def default_pid_minter
         -> { SecureRandom.urlsafe_base64(nil, true) }
       end
+
+      def apply_access_policies_to(*)
+      end
     end
   end
 end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -86,7 +86,8 @@ module Sipity
         -> { SecureRandom.urlsafe_base64(nil, true) }
       end
 
-      def apply_access_policies_to(*)
+      def apply_access_policies_to(work:, user:, access_policies:)
+        Services::ApplyAccessPoliciesTo.call(repository: self, work: work, user: user, access_policies: access_policies)
       end
     end
   end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -87,7 +87,7 @@ module Sipity
       end
 
       def apply_access_policies_to(work:, user:, access_policies:)
-        Services::ApplyAccessPoliciesTo.call(repository: self, work: work, user: user, access_policies: access_policies)
+        Services::ApplyAccessPoliciesTo.call(work: work, user: user, access_policies: access_policies)
       end
     end
   end

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -2,8 +2,8 @@ module Sipity
   module Queries
     # Queries
     module AttachmentQueries
-      def work_attachments(options = {})
-        Models::Attachment.includes(:work).where(options.slice(:work))
+      def work_attachments(work:)
+        Models::Attachment.includes(:work).where(work_id: work)
       end
 
       def find_or_initialize_attachments_by(work:, pid:)

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -6,6 +6,10 @@ module Sipity
         Models::Attachment.includes(:work).where(work_id: work)
       end
 
+      def accessible_objects(work:)
+        [work] + work_attachments(work: work)
+      end
+
       def find_or_initialize_attachments_by(work:, pid:)
         Models::Attachment.find_or_initialize_by(work_id: work.id, pid: pid)
       end

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -11,9 +11,7 @@ module Sipity
       end
 
       def access_rights_for_accessible_objects_of(work:)
-        accessible_objects(work: work).map do |object|
-          Models::AccessRight.find_or_initialize_by(entity_id: object.id, entity_type: Conversions::ConvertToPolymorphicType.call(object))
-        end
+        accessible_objects(work: work).map { |object| Models::AccessRightFacade.new(object) }
       end
 
       def find_or_initialize_attachments_by(work:, pid:)

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -10,6 +10,12 @@ module Sipity
         [work] + work_attachments(work: work)
       end
 
+      def access_rights_for_accessible_objects_of(work:)
+        accessible_objects(work: work).map do |object|
+          Models::AccessRight.find_or_initialize_by(entity_id: object.id, entity_type: Conversions::ConvertToPolymorphicType.call(object))
+        end
+      end
+
       def find_or_initialize_attachments_by(work:, pid:)
         Models::Attachment.find_or_initialize_by(work_id: work.id, pid: pid)
       end

--- a/app/repositories/sipity/query_repository.rb
+++ b/app/repositories/sipity/query_repository.rb
@@ -16,5 +16,6 @@ module Sipity
     include Queries::EnrichmentQueries
     include Queries::EventTriggerQueries
     include Queries::ProcessingQueries
+    include Queries::AttachmentQueries
   end
 end

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -27,7 +27,7 @@ module Sipity
       def find_or_create_access_right_from(attributes)
         Models::AccessRight.find_or_initialize_by(attributes.slice(:entity_id, :entity_type)) do |access_right|
           access_right.access_right_code = attributes.fetch(:access_right_code)
-          access_right.transition_date = convert_to_date(attributes.fetch(:release_date)) { nil }
+          access_right.release_date = convert_to_date(attributes.fetch(:release_date)) { nil }
         end.save!
       end
     end

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -1,0 +1,53 @@
+module Sipity
+  module Services
+    # Responsible for rebuilding access policies for accessible objects
+    # associated with the given work.
+    class ApplyAccessPoliciesTo
+      def initialize(user:, work:, access_policies:)
+        @user = user
+        @work = work
+        @access_policies = Array.wrap(access_policies)
+      end
+      attr_reader :user, :work, :access_policies, :repository
+
+      def call
+        access_policies.each do |attributes|
+          expunge_previous_access_rights(attributes)
+          access_right_code = attributes.fetch(:access_right_code)
+          case access_right_code
+          when 'embargo_then_open_access'
+            handle_embargo_based_access_right(attributes)
+          else
+            handle_non_embargo_based_access_right(attributes)
+          end
+        end
+      end
+
+      private
+
+      def handle_embargo_based_access_right(attributes)
+        Models::AccessRight.create!(attributes.slice(:entity_id, :entity_type)) do |embargoed|
+          embargoed.access_right_code = Models::AccessRight::PRIVATE_ACCESS
+          embargoed.enforcement_start_date = Date.today
+          embargoed.enforcement_end_date = attributes.fetch(:release_date)
+        end
+        Models::AccessRight.create!(attributes.slice(:entity_id, :entity_type)) do |open_access|
+          open_access.access_right_code = Models::AccessRight::OPEN_ACCESS
+          open_access.enforcement_start_date = attributes.fetch(:release_date)
+          open_access.enforcement_end_date = nil
+        end
+      end
+
+      def handle_non_embargo_based_access_right(attributes)
+        Models::AccessRight.create!(attributes.slice(:entity_id, :access_right_code, :entity_type)) do |access_right|
+          access_right.enforcement_start_date = Date.today
+          access_right.enforcement_end_date = nil
+        end
+      end
+
+      def expunge_previous_access_rights(attributes)
+        Models::AccessRight.where(attributes.slice(:entity_id, :entity_type)).destroy_all
+      end
+    end
+  end
+end

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -15,7 +15,7 @@ module Sipity
           expunge_previous_access_rights(attributes)
           access_right_code = attributes.fetch(:access_right_code)
           case access_right_code
-          when 'embargo_then_open_access'
+          when Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS
             handle_embargo_based_access_right(attributes)
           else
             handle_non_embargo_based_access_right(attributes)

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -36,7 +36,6 @@ module Sipity
         Models::AccessRight.create!(attributes.slice(:entity_id, :entity_type)) do |open_access|
           open_access.access_right_code = Models::AccessRight::OPEN_ACCESS
           open_access.enforcement_start_date = release_date
-          open_access.enforcement_end_date = nil
         end
       end
 

--- a/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
@@ -32,10 +32,13 @@
         <%= f.fields_for :accessible_objects do |field| %>
           <tr>
             <td><%= field.object %></td>
-            <td><%= field.radio_button(:access_right_code, field.object.open_access_access_code) %></td>
-            <td><%= field.radio_button(:access_right_code, field.object.restricted_access_access_code) %></td>
-            <td><%= field.radio_button(:access_right_code, field.object.private_access_access_code) %></td>
-            <td><%= field.radio_button(:access_right_code, field.object.embargo_then_open_access_access_code) %> with released on <%= field.input :release_date, as: :date %></td>
+            <td><%= field.radio_button(:access_right_code, Sipity::Models::AccessRight::OPEN_ACCESS) %></td>
+            <td><%= field.radio_button(:access_right_code, Sipity::Models::AccessRight::RESTRICTED_ACCESS) %></td>
+            <td><%= field.radio_button(:access_right_code, Sipity::Models::AccessRight::PRIVATE_ACCESS) %></td>
+            <td>
+              <%= field.radio_button(:access_right_code, Sipity::Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS) %>
+              with released on <%= field.input :release_date, as: :date %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
@@ -1,0 +1,54 @@
+<%= content_tag :h1, t("sipity/decorators/entitiy_enrichments.call_to_action.#{model.enrichment_type}") %>
+<% description = t("sipity/decorators/entitiy_enrichments.description.#{model.enrichment_type}") %>
+<%= content_tag( :p, description) if description.present? %>
+
+<div class="panel-tiles">
+
+  <%= simple_form_for(
+    model,
+    url: enrich_work_path(model.work, model.enrichment_type),
+    method: :post,
+    as: :work,
+    html: { class: 'panel panel-primary with-footer' }
+  ) do |f| %>
+  <legend class="panel-heading">
+    <%= content_tag :h3, t("sipity/decorators/entitiy_enrichments.panels.access_policy.title_html"), class: 'panel-title' %>
+  </legend>
+
+  <fieldset class="panel-body">
+    <%= content_tag :p, t("sipity/decorators/entitiy_enrichments.panels.access_policy.hint_html"), class: 'panel-hint' %>
+    <%= f.error_notification %>
+    <table>
+      <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th>Open Access</th>
+          <th>Restricted to Notre Dame</th>
+          <th>Private</th>
+          <th>Embargo then Open Access</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= f.fields_for :accessible_objects do |field| %>
+          <tr>
+            <td><%= field.object %></td>
+            <td><%= field.radio_button(:access_right_code, field.object.open_access_access_code) %></td>
+            <td><%= field.radio_button(:access_right_code, field.object.restricted_access_access_code) %></td>
+            <td><%= field.radio_button(:access_right_code, field.object.private_access_access_code) %></td>
+            <td><%= field.radio_button(:access_right_code, field.object.embargo_then_open_access_access_code) %> with released on <%= field.input :release_date, as: :date %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+
+  <%= model.work.with_action_pane('new_defense_date', 'panel-footer') do %>
+    <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
+  <% end %>
+<% end %>
+
+</div>
+
+<%= model.work.with_action_pane('actions') do %>
+  <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
         enrichment_type = request.params.fetch(:enrichment_type)
         # REVIEW: Magic strings! There is a canonical enrichment question; And
         #   the valid enrichments may not be available for all work ids
-        %(attach describe collaborators defense_date).include?(enrichment_type)
+        %(attach describe collaborators defense_date access_policy).include?(enrichment_type)
       end
       get 'works/:work_id/:enrichment_type', to: 'work_enrichments#edit', as: 'enrich_work', constraints: enrichment_constraint
       post 'works/:work_id/:enrichment_type', to: 'work_enrichments#update', constraints: enrichment_constraint

--- a/db/migrate/20150303152259_update_sipity_access_rights_indices.rb
+++ b/db/migrate/20150303152259_update_sipity_access_rights_indices.rb
@@ -1,0 +1,6 @@
+class UpdateSipityAccessRightsIndices < ActiveRecord::Migration
+  def change
+    remove_index :sipity_access_rights, [:entity_id, :entity_type]
+    add_index :sipity_access_rights, [:entity_id, :entity_type]
+  end
+end

--- a/db/migrate/20150303172902_modify_access_right.rb
+++ b/db/migrate/20150303172902_modify_access_right.rb
@@ -6,7 +6,7 @@ class ModifyAccessRight < ActiveRecord::Migration
       t.integer :entity_id
       t.string :entity_type
       t.string :access_right_code
-      t.string :transition_date
+      t.date :transition_date
 
       t.timestamps null: false
     end

--- a/db/migrate/20150303172902_modify_access_right.rb
+++ b/db/migrate/20150303172902_modify_access_right.rb
@@ -1,0 +1,19 @@
+class ModifyAccessRight < ActiveRecord::Migration
+  def change
+    drop_table :sipity_access_rights
+
+    create_table :sipity_access_rights do |t|
+      t.integer :entity_id
+      t.string :entity_type
+      t.string :access_right_code
+      t.string :transition_date
+
+      t.timestamps null: false
+    end
+
+    add_index :sipity_access_rights, [:entity_id, :entity_type], unique: true
+    change_column_null :sipity_access_rights, :entity_id, false
+    change_column_null :sipity_access_rights, :entity_type, false
+    change_column_null :sipity_access_rights, :access_right_code, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 20150303172902) do
     t.integer  "entity_id",         null: false
     t.string   "entity_type",       null: false
     t.string   "access_right_code", null: false
-    t.string   "transition_date"
+    t.date     "transition_date"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150226160732) do
+ActiveRecord::Schema.define(version: 20150303152259) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",              null: false
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20150226160732) do
 
   add_index "sipity_access_rights", ["entity_id", "entity_type", "enforcement_end_date"], name: "sipity_access_rights_end_for_entity", unique: true
   add_index "sipity_access_rights", ["entity_id", "entity_type", "enforcement_start_date"], name: "sipity_access_rights_start_for_entity", unique: true
-  add_index "sipity_access_rights", ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type", unique: true
+  add_index "sipity_access_rights", ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type"
 
   create_table "sipity_account_placeholders", force: :cascade do |t|
     t.string   "identifier",                                     null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,21 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150303152259) do
+ActiveRecord::Schema.define(version: 20150303172902) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
-    t.integer  "entity_id",              null: false
-    t.string   "entity_type",            null: false
-    t.string   "access_right_code",      null: false
-    t.date     "enforcement_start_date", null: false
-    t.date     "enforcement_end_date"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.integer  "entity_id",         null: false
+    t.string   "entity_type",       null: false
+    t.string   "access_right_code", null: false
+    t.string   "transition_date"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
   end
 
-  add_index "sipity_access_rights", ["entity_id", "entity_type", "enforcement_end_date"], name: "sipity_access_rights_end_for_entity", unique: true
-  add_index "sipity_access_rights", ["entity_id", "entity_type", "enforcement_start_date"], name: "sipity_access_rights_start_for_entity", unique: true
-  add_index "sipity_access_rights", ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type"
+  add_index "sipity_access_rights", ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type", unique: true
 
   create_table "sipity_account_placeholders", force: :cascade do |t|
     t.string   "identifier",                                     null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,6 +68,7 @@ ActiveRecord::Base.transaction do
         ['attach', nil],
         ['collaborators', nil],
         ['defense_date', nil],
+        ['access_policy', nil],
         ['assign_a_doi', nil],
         ['assign_a_citation', nil],
         ['submit_for_review', 'under_advisor_review'],
@@ -85,7 +86,7 @@ ActiveRecord::Base.transaction do
       end
 
       pre_requisite_states =       {
-        'submit_for_review' => ['describe', 'attach', 'collaborators']
+        'submit_for_review' => ['describe', 'attach', 'collaborators', 'access_policy']
       }
 
       if work_type_name == 'doctoral_dissertation'
@@ -110,6 +111,7 @@ ActiveRecord::Base.transaction do
         ['new', 'collaborators', ['creating_user', 'etd_reviewer']],
         ['new', 'destroy', ['creating_user', 'etd_reviewer']],
         ['new', 'defense_date', ['creating_user']],
+        ['new', 'access_policy', ['creating_user']],
         ['new', 'assign_a_doi', ['creating_user', 'etd_reviewer']],
         ['new', 'assign_a_citation', ['creating_user', 'etd_reviewer']],
         ['under_advisor_review', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
@@ -124,6 +126,7 @@ ActiveRecord::Base.transaction do
         ['advisor_changes_requested', 'show', ['creating_user', 'advisor', 'etd_reviewer']],
         ['advisor_changes_requested', 'edit', ['creating_user', 'etd_reviewer']],
         ['advisor_changes_requested', 'destroy', ['creating_user', 'etd_reviewer']],
+        ['advisor_changes_requested', 'access_policy', ['creating_user']],
         ['under_grad_school_review', 'assign_a_doi', ['etd_reviewer']],
         ['under_grad_school_review', 'assign_a_citation', ['etd_reviewer']],
         ['under_grad_school_review', 'grad_school_requests_change', ['etd_reviewer']],

--- a/spec/conversions/sipity/conversions/convert_to_date_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_date_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToDate do
+      include ::Sipity::Conversions::ConvertToDate
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          expect(described_class.call(Date.new(2014, 12, 1))).to eq(Date.new(2014, 12, 1))
+        end
+      end
+
+      context '.convert_to_date' do
+        it 'will be private' do
+          expect { described_class.convert_to_date(Date.new(2014, 12, 1)) }.
+            to raise_error(NoMethodError, /private method `convert_to_date'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_date' do
+
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_date)
+        end
+
+        [
+          ['2014-12-01', Date.new(2014, 12, 1)],
+          ['12/10/2013', Date.new(2013, 10, 12)],
+          [Date.new(2014, 12, 1), Date.new(2014, 12, 1)],
+        ].each_with_index do |(to_convert, expected), index|
+          it "will convert #{to_convert.inspect} to #{expected} (Scenario ##{index}" do
+            expect(convert_to_date(to_convert)).to eq(expected)
+          end
+        end
+
+        it 'will raise an exception if unparsable' do
+          expect { convert_to_date(1) }.to raise_error(Exceptions::DateConversionError)
+        end
+
+        it 'will yield and not raise if unparsable but block is given' do
+          today = Date.today
+          expect(convert_to_date(1) { today }).to eq(today)
+        end
+      end
+    end
+  end
+end

--- a/spec/conversions/sipity/conversions/convert_to_date_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_date_spec.rb
@@ -33,7 +33,7 @@ module Sipity
         [
           ['2014-12-01', Date.new(2014, 12, 1)],
           ['12/10/2013', Date.new(2013, 10, 12)],
-          [Date.new(2014, 12, 1), Date.new(2014, 12, 1)],
+          [Date.new(2014, 12, 1), Date.new(2014, 12, 1)]
         ].each_with_index do |(to_convert, expected), index|
           it "will convert #{to_convert.inspect} to #{expected} (Scenario ##{index}" do
             expect(convert_to_date(to_convert)).to eq(expected)

--- a/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
+++ b/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
@@ -2,7 +2,7 @@ User.create!([
   {email: "test@example.com", remember_created_at: nil, sign_in_count: 2, current_sign_in_at: "2015-02-24 18:32:52", last_sign_in_at: "2015-02-24 18:32:52", current_sign_in_ip: "127.0.0.1", last_sign_in_ip: "127.0.0.1", name: "Test User", role: nil, username: "test@example.com"}
 ])
 Sipity::Models::AccessRight.create!([
-  {entity_id: 1, entity_type: "Sipity::Models::Work", access_right_code: "private_access", enforcement_start_date: "2015-02-24", enforcement_end_date: nil}
+  {entity_id: 1, entity_type: "Sipity::Models::Work", access_right_code: "private_access"}
 ])
 Sipity::Models::AdditionalAttribute.create!([
   {work_id: 1, key: "abstract", value: "Lorem ipsum"}

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -45,12 +45,12 @@ module Sipity
                   entity_id: work.to_param,
                   entity_type: Sipity::Models::Work,
                   access_right_code: 'open_access',
-                  release_date: nil,
+                  release_date: nil
                 }, {
                   entity_id: attachment.to_param,
                   entity_type: Sipity::Models::Attachment,
                   access_right_code: 'embargo_then_open_access',
-                  release_date: Date.new(2032,12,01)
+                  release_date: Date.new(2032, 12, 01)
                 }
               ]
             )

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -2,16 +2,49 @@ module Sipity
   module Forms
     module WorkEnrichments
       RSpec.describe AccessPolicyForm do
+        let(:user) { double('User') }
         let(:work) { Models::Work.new(id: 1) }
         let(:attachment) { Models::Attachment.new(id: 2) }
         let(:repository) { CommandRepositoryInterface.new }
         subject { described_class.new(work: work, repository: repository) }
 
+        before do
+          allow(repository).to receive(:accessible_objects).with(work: work).and_return([work, attachment])
+        end
+
         it { should respond_to :accessible_objects_attributes= }
 
         it 'will expose accessible_objects' do
-          expect(repository).to receive(:accessible_objects).with(work: work).and_return([work, attachment])
-          subject.accessible_objects
+          expect(subject.accessible_objects.size).to eq(2)
+        end
+
+        it 'will validate the accessible_objects_attributes'
+
+        context '#submit' do
+          it 'will capture accessible_objects_attributes' do
+            attributes = {
+              "0" => { "id" => work.to_param, "access_right_code" => 'open_access', "release_date" => "" },
+              "1" => { "id" => attachment.to_param, "access_right_code" => 'embargo_then_open_access', "release_date" => "2032-12-01" }
+            }
+            subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: attributes)
+            expect(repository).to receive(:apply_access_policies_to).with(
+              work: work, access_policies:
+              [
+                {
+                  entity_id: work.to_param,
+                  entity_type: Sipity::Models::Work,
+                  access_right_code: 'open_access',
+                  release_date: ''
+                }, {
+                  entity_id: attachment.to_param,
+                  entity_type: Sipity::Models::Attachment,
+                  access_right_code: 'embargo_then_open_access',
+                  release_date: '2032-12-01'
+                }
+              ]
+            )
+            subject.submit(requested_by: user)
+          end
         end
       end
 

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -1,0 +1,19 @@
+module Sipity
+  module Forms
+    module WorkEnrichments
+      RSpec.describe AccessPolicyForm do
+        let(:work) { Models::Work.new(id: 1) }
+        let(:attachment) { Models::Attachment.new(id: 2) }
+        let(:repository) { CommandRepositoryInterface.new }
+        subject { described_class.new(work: work, repository: repository) }
+
+        it { should respond_to :accessible_objects_attributes= }
+
+        it 'will expose accessible_objects' do
+          expect(repository).to receive(:work_attachments).with(work: work).and_return([attachment])
+          expect(subject.accessible_objects.size).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -14,6 +14,35 @@ module Sipity
           subject.accessible_objects
         end
       end
+
+      RSpec.describe AccessPolicyForm::AccessibleObjectFromInput do
+        let(:attributes) { {} }
+        let(:persisted_object) { double('Persisted Object') }
+        subject { described_class.new(persisted_object, attributes) }
+
+        its(:persisted?) { should be_truthy }
+
+        it 'will parse the input date' do
+
+        end
+
+        it 'will be invalid if no access_right_code is given' do
+          subject.valid?
+          expect(subject.errors[:access_right_code]).to be_present
+        end
+
+        it 'will be invalid if no release_date is given for "embargo_then_open_access"' do
+          subject = described_class.new(persisted_object, access_right_code: 'embargo_then_open_access')
+          subject.valid?
+          expect(subject.errors[:release_date]).to be_present
+        end
+
+        it 'will be invalid if an incorrect access code is given' do
+          subject = described_class.new(persisted_object, access_right_code: 'chocolate bunny')
+          subject.valid?
+          expect(subject.errors[:access_right_code]).to be_present
+        end
+      end
     end
   end
 end

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -25,7 +25,7 @@ module Sipity
         end
 
         it 'will validate each of the given attributes' do
-          invalid_attributes = { "0" => {id: work.to_param, access_right_code: 'chici chici parm parm' } }
+          invalid_attributes = { "0" => { id: work.to_param, access_right_code: 'chici chici parm parm' } }
           subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: invalid_attributes)
           subject.valid?
           expect(subject.errors[:accessible_objects_attributes]).to be_present

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -18,7 +18,18 @@ module Sipity
           expect(subject.accessible_objects.size).to eq(2)
         end
 
-        it 'will validate the accessible_objects_attributes'
+        it 'will validate the presence of accessible_objects_attributes' do
+          subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: {})
+          subject.valid?
+          expect(subject.errors[:base]).to be_present
+        end
+
+        it 'will validate each of the given attributes' do
+          invalid_attributes = { "0" => {id: work.to_param, access_right_code: 'chici chici parm parm' } }
+          subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: invalid_attributes)
+          subject.valid?
+          expect(subject.errors[:accessible_objects_attributes]).to be_present
+        end
 
         context '#submit' do
           it 'will capture accessible_objects_attributes' do

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -9,7 +9,7 @@ module Sipity
         subject { described_class.new(work: work, repository: repository) }
 
         before do
-          allow(repository).to receive(:accessible_objects).with(work: work).and_return([work, attachment])
+          allow(repository).to receive(:access_rights_for_accessible_objects_of).with(work: work).and_return([work, attachment])
         end
 
         it { should respond_to :accessible_objects_attributes= }
@@ -61,13 +61,20 @@ module Sipity
 
       RSpec.describe AccessPolicyForm::AccessibleObjectFromInput do
         let(:attributes) { {} }
-        let(:persisted_object) { double('Persisted Object') }
+        let(:persisted_object) { double('Persisted Object', entity_type: 'Hello') }
         subject { described_class.new(persisted_object, attributes) }
 
         its(:persisted?) { should be_truthy }
 
         it 'will parse the input date' do
+          subject = described_class.new(persisted_object, release_date: '2014-12-1')
+          expect(subject.release_date).to eq(Date.new(2014, 12, 1))
+        end
 
+        it 'will use the persisted object entity_type if one is defined' do
+          persisted_object = double(entity_type: 'Ent')
+          subject = described_class.new(persisted_object)
+          expect(subject.entity_type).to eq(persisted_object.entity_type)
         end
 
         it 'will be invalid if no access_right_code is given' do

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -39,7 +39,7 @@ module Sipity
             }
             subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: attributes)
             expect(repository).to receive(:apply_access_policies_to).with(
-              work: work, access_policies:
+              work: work, user: user, access_policies:
               [
                 {
                   entity_id: work.to_param,

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -45,12 +45,12 @@ module Sipity
                   entity_id: work.to_param,
                   entity_type: Sipity::Models::Work,
                   access_right_code: 'open_access',
-                  release_date: ''
+                  release_date: nil,
                 }, {
                   entity_id: attachment.to_param,
                   entity_type: Sipity::Models::Attachment,
                   access_right_code: 'embargo_then_open_access',
-                  release_date: '2032-12-01'
+                  release_date: Date.new(2032,12,01)
                 }
               ]
             )

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -10,8 +10,8 @@ module Sipity
         it { should respond_to :accessible_objects_attributes= }
 
         it 'will expose accessible_objects' do
-          expect(repository).to receive(:work_attachments).with(work: work).and_return([attachment])
-          expect(subject.accessible_objects.size).to eq(2)
+          expect(repository).to receive(:accessible_objects).with(work: work).and_return([work, attachment])
+          subject.accessible_objects
         end
       end
     end

--- a/spec/models/sipity/models/access_right_facade_spec.rb
+++ b/spec/models/sipity/models/access_right_facade_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module Sipity
+  module Models
+    RSpec.describe AccessRightFacade do
+      let(:object) { Models::Work.new(id: 123) }
+      let(:access_right) { Models::AccessRight.new(access_right_code: 'embargo_then_open_access', release_date: Date.today) }
+      subject { described_class.new(object) }
+
+      before { allow(Models::AccessRight).to receive(:find_or_initialize_by).and_return(access_right) }
+
+      its(:id) { should eq(object.id) }
+      its(:persisted?) { should eq(object.persisted?) }
+      its(:to_s) { should eq(object.to_s) }
+      its(:entity_id) { should eq(subject.id) }
+      its(:to_param) { should eq(object.to_param) }
+      its(:entity_type) { should eq(Sipity::Models::Work) }
+      its(:access_right_code) { should eq(access_right.access_right_code) }
+      its(:release_date) { should eq(access_right.release_date) }
+    end
+  end
+end

--- a/spec/models/sipity/models/access_right_spec.rb
+++ b/spec/models/sipity/models/access_right_spec.rb
@@ -9,6 +9,7 @@ module Sipity
       its(:column_names) { should include('access_right_code') }
       its(:column_names) { should include('enforcement_start_date') }
       its(:column_names) { should include('enforcement_end_date') }
+      its(:primative_acccess_right_codes) { should be_a(Array) }
     end
   end
 end

--- a/spec/models/sipity/models/access_right_spec.rb
+++ b/spec/models/sipity/models/access_right_spec.rb
@@ -7,8 +7,7 @@ module Sipity
       its(:column_names) { should include('entity_id') }
       its(:column_names) { should include('entity_type') }
       its(:column_names) { should include('access_right_code') }
-      its(:column_names) { should include('enforcement_start_date') }
-      its(:column_names) { should include('enforcement_end_date') }
+      its(:column_names) { should include('transition_date') }
       its(:primative_acccess_right_codes) { should be_a(Array) }
     end
   end

--- a/spec/models/sipity/models/attachment_spec.rb
+++ b/spec/models/sipity/models/attachment_spec.rb
@@ -16,7 +16,10 @@ module Sipity
 
       context 'instance methods' do
         subject { described_class.new }
-
+        it 'will have a #to_s equal to the file name' do
+          subject.file_name = 'Hello World'
+          expect(subject.to_s).to eq('Hello World')
+        end
         it 'has an file via the dragonfly gem' do
           subject.file = File.new(__FILE__)
           expect(subject.file.data).to eq(File.read(__FILE__))

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -142,6 +142,16 @@ module Sipity
             not_to change { Models::Attachment.where(is_representative_file: true).count }
         end
       end
+
+      context '#apply_access_policies_to' do
+        let(:work) { double('Work') }
+        let(:user) { double('User') }
+        let(:access_policies) { double('AccessPolicies') }
+        it 'will mark the given attachments as representative in the system' do
+          expect(Services::ApplyAccessPoliciesTo).to receive(:call).with(work: work, user: user, access_policies: access_policies)
+          test_repository.apply_access_policies_to(work: work, user: user, access_policies: access_policies)
+        end
+      end
     end
   end
 end

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -22,6 +22,13 @@ module Sipity
         end
       end
 
+      context '#accessible_objects' do
+        it 'returns the attachments for the given work and role' do
+          attachment = Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment', file: file)
+          expect(subject.accessible_objects(work: work)).to eq([work, attachment])
+        end
+      end
+
       context '#representative_attachment_for' do
         it 'returns attachment marked as representative for work' do
           Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment',

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -43,8 +43,8 @@ module Sipity
           allow(test_repository).to receive(:accessible_objects).and_return([work, attachment])
           access_rights = test_repository.access_rights_for_accessible_objects_of(work: work)
           expect(access_rights.size).to eq(2)
-          expect(access_rights[0]).to be_a(Models::AccessRight)
-          expect(access_rights[1]).to be_a(Models::AccessRight)
+          expect(access_rights[0]).to be_a(Models::AccessRightFacade)
+          expect(access_rights[1]).to be_a(Models::AccessRightFacade)
         end
       end
     end

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -36,6 +36,17 @@ module Sipity
           expect(subject.representative_attachment_for(work: work).count).to eq(1)
         end
       end
+
+      context '#access_rights_for_accessible_objects' do
+        let(:attachment) { Models::Attachment.new(id: 'abc') }
+        it 'returns an enumerable of AccessRight objects' do
+          allow(test_repository).to receive(:accessible_objects).and_return([work, attachment])
+          access_rights = test_repository.access_rights_for_accessible_objects_of(work: work)
+          expect(access_rights.size).to eq(2)
+          expect(access_rights[0]).to be_a(Models::AccessRight)
+          expect(access_rights[1]).to be_a(Models::AccessRight)
+        end
+      end
     end
   end
 end

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -15,14 +15,14 @@ module Sipity
         end
       end
 
-      context '.work_attachments' do
+      context '#work_attachments' do
         it 'returns the attachments for the given work and role' do
           Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment', file: file)
           expect(subject.work_attachments(work: work).count).to eq(1)
         end
       end
 
-      context '.representative_attachment_for' do
+      context '#representative_attachment_for' do
         it 'returns attachment marked as representative for work' do
           Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment',
                                      file: file, is_representative_file: true)

--- a/spec/services/sipity/services/apply_access_policies_to_spec.rb
+++ b/spec/services/sipity/services/apply_access_policies_to_spec.rb
@@ -11,7 +11,9 @@ module Sipity
       it 'will not allow specifying policies for objects not part of the existing work'
 
       context 'for open access' do
-        let(:access_policies) { { entity_id: 1, entity_type: Sipity::Models::Work, access_right_code: 'open_access', release_date: '' } }
+        let(:access_policies) do
+          { entity_id: 1, entity_type: Sipity::Models::Work, access_right_code: Models::AccessRight::OPEN_ACCESS, release_date: '' }
+        end
         it 'create a new AccessRight' do
           expect { subject.call }.to change { Models::AccessRight.count }.by(1)
         end
@@ -26,7 +28,7 @@ module Sipity
           {
             entity_id: 1,
             entity_type: Sipity::Models::Work,
-            access_right_code: 'embargo_then_open_access', release_date: '2032-12-01'
+            access_right_code: Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS, release_date: '2032-12-01'
           }
         end
         it 'create a two AccessRight entries' do

--- a/spec/services/sipity/services/apply_access_policies_to_spec.rb
+++ b/spec/services/sipity/services/apply_access_policies_to_spec.rb
@@ -16,35 +16,15 @@ module Sipity
 
       it 'will not allow specifying policies for objects not part of the existing work'
 
-      context 'for open access' do
-        let(:access_policies) do
-          { entity_id: 1, entity_type: Sipity::Models::Work, access_right_code: Models::AccessRight::OPEN_ACCESS, release_date: '' }
-        end
-        it 'create a new AccessRight' do
-          expect { subject.call }.to change { Models::AccessRight.count }.by(1)
-        end
-        it 'will obliterate the previous AccessRights' do
-          subject.call
-          expect { subject.call }.to_not change { Models::AccessRight.count }
-        end
+      let(:access_policies) do
+        { entity_id: 1, entity_type: Sipity::Models::Work, access_right_code: Models::AccessRight::OPEN_ACCESS, release_date: '' }
       end
-
-      context 'for embargo_then_open_access' do
-        let(:access_policies) do
-          {
-            entity_id: 1,
-            entity_type: Sipity::Models::Work,
-            access_right_code: Models::AccessRight::EMBARGO_THEN_OPEN_ACCESS, release_date: '2032-12-01'
-          }
-        end
-        it 'create a two AccessRight entries' do
-          expect { subject.call }.to change { Models::AccessRight.count }.by(2)
-        end
-
-        it 'will obliterate the previous AccessRights' do
-          subject.call
-          expect { subject.call }.to_not change { Models::AccessRight.count }
-        end
+      it 'create a new AccessRight' do
+        expect { subject.call }.to change { Models::AccessRight.count }.by(1)
+      end
+      it 'will obliterate the previous AccessRights' do
+        subject.call
+        expect { subject.call }.to_not change { Models::AccessRight.count }
       end
     end
   end

--- a/spec/services/sipity/services/apply_access_policies_to_spec.rb
+++ b/spec/services/sipity/services/apply_access_policies_to_spec.rb
@@ -5,7 +5,7 @@ module Sipity
       let(:user) { User.new }
       let(:work) { Models::Work.new(id: 1) }
       let(:attachment) { Models::Attachment.new(id: 2) }
-      let(:access_policies) { { } }
+      let(:access_policies) { {} }
 
       subject { described_class.new(work: work, user: user, access_policies: access_policies) }
 

--- a/spec/services/sipity/services/apply_access_policies_to_spec.rb
+++ b/spec/services/sipity/services/apply_access_policies_to_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+module Sipity
+  module Services
+    RSpec.describe ApplyAccessPoliciesTo do
+      let(:user) { User.new }
+      let(:work) { Models::Work.new(id: 1) }
+      let(:attachment) { Models::Attachment.new(id: 2) }
+
+      subject { described_class.new(work: work, user: user, access_policies: access_policies) }
+
+      it 'will not allow specifying policies for objects not part of the existing work'
+
+      context 'for open access' do
+        let(:access_policies) { { entity_id: 1, entity_type: Sipity::Models::Work, access_right_code: 'open_access', release_date: '' } }
+        it 'create a new AccessRight' do
+          expect { subject.call }.to change { Models::AccessRight.count }.by(1)
+        end
+        it 'will obliterate the previous AccessRights' do
+          subject.call
+          expect { subject.call }.to_not change { Models::AccessRight.count }
+        end
+      end
+
+      context 'for embargo_then_open_access' do
+        let(:access_policies) do
+          {
+            entity_id: 1,
+            entity_type: Sipity::Models::Work,
+            access_right_code: 'embargo_then_open_access', release_date: '2032-12-01'
+          }
+        end
+        it 'create a two AccessRight entries' do
+          expect { subject.call }.to change { Models::AccessRight.count }.by(2)
+        end
+
+        it 'will obliterate the previous AccessRights' do
+          subject.call
+          expect { subject.call }.to_not change { Models::AccessRight.count }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/sipity/services/apply_access_policies_to_spec.rb
+++ b/spec/services/sipity/services/apply_access_policies_to_spec.rb
@@ -5,8 +5,14 @@ module Sipity
       let(:user) { User.new }
       let(:work) { Models::Work.new(id: 1) }
       let(:attachment) { Models::Attachment.new(id: 2) }
+      let(:access_policies) { { } }
 
       subject { described_class.new(work: work, user: user, access_policies: access_policies) }
+
+      it 'exposes .call as a convenience method' do
+        expect_any_instance_of(described_class).to receive(:call)
+        described_class.call(work: work, user: user, access_policies: access_policies)
+      end
 
       it 'will not allow specifying policies for objects not part of the existing work'
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -6,6 +6,10 @@
 module Sipity
   class CommandRepositoryInterface
     # @see ./app/repositories/sipity/queries/attachment_queries.rb
+    def access_rights_for_accessible_objects_of(work:)
+    end
+
+    # @see ./app/repositories/sipity/queries/attachment_queries.rb
     def accessible_objects(work:)
     end
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -14,7 +14,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def apply_access_policies_to(*)
+    def apply_access_policies_to(work:, user:, access_policies:)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -14,6 +14,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
+    def apply_access_policies_to(*)
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
     def assign_collaborators_to(work:, collaborators:)
     end
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -5,6 +5,10 @@
 ################################################################################
 module Sipity
   class CommandRepositoryInterface
+    # @see ./app/repositories/sipity/queries/attachment_queries.rb
+    def accessible_objects(work:)
+    end
+
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def amend_files_metadata(work:, user:, metadata: {})
     end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -298,7 +298,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/attachment_queries.rb
-    def work_attachments(options = {})
+    def work_attachments(work:)
     end
 
     # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb


### PR DESCRIPTION
## Adjusting method signature

@9a2bfa9f8d79399281efa2b9da4475b29f8f8c00


## Including AttachmentQueries into query repository

@f925c9f2985c2a95086e7af6ee36afec7374003a

This was an apparent oversight

## Fixing a typo

@595b3d08f59b1f77c9feaf32e65fb22e3bef916d

[skip ci]

## Adding AccessPolicyForm

@af4fa27242aa8fb139899b7a603231818193375a

Responsible for exposing a means for defining what are the access
types.

## Adding Attachment#to_s method

@fec4efd085ac4cc5bc195466cac6a8e78695f366

To help with consistent rendering. I could be using an attachment
decorator.

## Reworking spec definition

@1c20df5becb14af2ae2aea3403b5a233d5a4b97e


## Adding AttachmentQueries#accessible_objects

@561da0f8c029fdce8d1009a8f9dc05bfbb90e30b

It removes some of the crazier conditionals that were in play.

## Renaming object for clarity

@1fc02063bd081aec28749eef23065ede4c476aee


## Leveraging more consise method

@a63fb9ed4aa374382a4756bdeb561f7d141b6a22

Instead of relying on merging an array, push that idea down to the
repository.

## Adding AccessibleObjectFromInput

@f1b77294bb4aab0d282736baee4eae750aca1e52


## Leveraging ExtractInputDateFromInput

@6ccd9c394b442f9db1bdafc1b7fd21c32b1c8953

Because the method exists to handle either the complicated user input
or the simple user input.

## Exposing apply_access_policies_for command

@88bf8ee057fff87937c8536d7cf837acdd0fa6a9


## Exposing means of updating accessible objects

@fef87fbdc3816eb5ac8383de3736196fd50f3af9

This is incomplete, in that we are capturing the form information and
not yet mapping it to the underlying layer. It also does not assume
an unhappy path.

## Tidying up method interface

@51984e16866c1e34ebe36042d3b41bee5991b30b


## Adding validation for AccessPolicyForm

@4f0aab3b91363daa15be1e3046665a8217be4a11


## Adjusting indices

@d39839647229d311ab9560fa3ee46cb03840ecf3

It was a mistake that the access rights had a unique constraint on
entity_id and entity_type; With that constraint, it was impossible to
have access policies change over time.

## Adding Services::ApplyAccessPoliciesTo

@b8f853cd8cb21721d53b10126b0cd6070502e8f5

> Responsible for rebuilding access policies for accessible objects
> associated with the given work.

## Wiring in Services::ApplyAccessPoliciesTo

@ca9c80101a3ed5626c6d81edd4eb234730f66f36


## Extracting AccessRight::EMBARGO_THEN_OPEN_ACCESS

@f41b8b32886644f68dafaf5cac973ab08c33bb8f

> This is not a valid persisted access_right_code, but is something
> that a user can specify via the UI.

By moving this to a constant, and in the same namespace, I keep a
symmetry in the method definition.

## Removing repetition of knowledge

@7c6b63a9be4c930447d2a403976b799004c464b8

Concerning the access_right_codes, I'm opting to instead expose only
methods that are valid access_codes and how they are handled.

## Appeasing the Rubocop

@edc5ef0bb29119ac471134aac21c0fd9bff71d68


## Adding Conversions::ConvertToDate

@1db587386f0f04dfa07eb9f5dd725f76b9a9ee65


## Splicing in usage of ConvertToDate

@8f08cec42b2d4b135dbe57c8793f76a29c876b43

Instead of duplicating this behavior, consolidating the conversion and
reusing it.

## Appeasing the hound

@06f3616f071d54cadded3fe414250c8f649bd71f


## Tidying up collaboration interaction

@0e5e473d41cf430fe96d59a7b7e3d3c75ba8e7c0


## Appeasing the hound

@781c1dfe86ef5a213e55352da48eb36ca676506b


## Reworking data model for AccessRights

@50cc4062726a0025b1e9c50385857a718a3d81dc

Given that we are not yet coping with Access Rights, I'm reworking the
data model. I'm not concerned with when it starts; Only concerned with
transitions.

Also, treating the embargo then open access as a first class citizen
in the database. This will ease future development as I look to
refactor the underlying form for access controls.

## Exposing access rights for accessible objects

@38c462cf88d2215a02a5c7e8945c984cbedc53bc

This helps ease some of the transformations happening in the poor
overworked AccessPolicyForm.

## Aliasing release_date from transition_date

@fc61ef530d89c4a7735bd24e12b951174aab9041

At a later point I want to replace usage of release_date with
transition_date.

## Adding the AccessRightFacade

@d4d914e2c22f5bb1e912f6e8123db26226d6241e

This object represents the join between the AccessRight and the
associated Entity

## Setting the transition date correctly

@84387ba33830260c3e99f51c4507017eed300e3d


## Using use access_rights_for_accessible_objects_of

@15d35cb5fb6c549336ff08955b6c37c917d6612a

Pushing the transformation to output onto a separate method. This also
draws attention to how a potential refactor could be brought about.

## Restoring test coverage

@e443b41df5972f73f942165898c803bca7066dfd

