### PR TITLE
Ensuring that User#email is set

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,14 @@ class User < ActiveRecord::Base
   has_many :group, through: :group_memberships, class_name: 'Sipity::Models::Group'
   has_one :processing_actor, as: :proxy_for, class_name: 'Sipity::Models::Processing::Actor'
   has_many :event_logs, class_name: 'Sipity::Models::EventLog'
+
+  # I'm using a callback because Devise CAS authentication is creating the
+  # record.
+  before_save :set_notre_dame_specific_email, if: :new_record?
+
+  private
+
+  def set_notre_dame_specific_email
+    self.email ||= "#{username}@nd.edu"
+  end
 end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -67,6 +67,7 @@ module Sipity
         it 'will create a user from the given netid if one does not exist' do
           expect { test_repository.create_sipity_user_from(netid: 'helloworld') }.
             to change { User.count }.by(1)
+          expect(User.last.email).to be_present
         end
         it 'will skip user creation of the netID exists' do
           test_repository.create_sipity_user_from(netid: 'helloworld')

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -78,7 +78,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def create_sipity_user_from(netid:)
+    def create_sipity_user_from(netid:, email: nil)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -87,6 +87,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def create_work_attribute_values!(work:, key:, values:)
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
+    def default_email_for_netid(netid)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb


### PR DESCRIPTION
Given that Devise is creating the user, and a Grad Student can create
a user, I'm wanting to make sure that we have emails.

Without emails, the system will start throwing errors when emails are
sent.