### PR TITLE
Adding model for SimpleControlledVocabulary

### DIFF
--- a/app/models/sipity/models/simple_controlled_vocabulary.rb
+++ b/app/models/sipity/models/simple_controlled_vocabulary.rb
@@ -1,0 +1,17 @@
+module Sipity
+  module Models
+    # Responsible for defining what values are allowed for a given predicate.
+    #
+    # @todo - Convert Sipity::ModelCollaborators#role to use controlled
+    #   vocabulary based on work type. That will be important once we have
+    #   collaborator's roles vary by work type (i.e. does a Doctoral
+    #   Dissertation have different roles from a Master's Thesis, or from a
+    #   Conference Presentation).
+    #
+    # @note - At present the controlled vocabularies do not vary based on
+    #   any work type; However that is one potentiaul future variance.
+    class SimpleControlledVocabulary < ActiveRecord::Base
+      self.table_name = 'sipity_simple_controlled_vocabularies'
+    end
+  end
+end

--- a/db/migrate/20150304150208_create_sipity_models_simple_controlled_vocabularies.rb
+++ b/db/migrate/20150304150208_create_sipity_models_simple_controlled_vocabularies.rb
@@ -1,0 +1,15 @@
+class CreateSipityModelsSimpleControlledVocabularies < ActiveRecord::Migration
+  def change
+    create_table :sipity_simple_controlled_vocabularies do |t|
+      t.string :predicate_name
+      t.string :predicate_value
+
+      t.timestamps null: false
+    end
+
+    add_index :sipity_simple_controlled_vocabularies, :predicate_name
+    add_index :sipity_simple_controlled_vocabularies, [:predicate_name, :predicate_value], unique: true, name: :index_sipity_simple_controlled_vocabularies_unique
+    change_column_null :sipity_simple_controlled_vocabularies, :predicate_name, false
+    change_column_null :sipity_simple_controlled_vocabularies, :predicate_value, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150303172902) do
+ActiveRecord::Schema.define(version: 20150304150208) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.integer  "entity_id",         null: false
@@ -283,6 +283,16 @@ ActiveRecord::Schema.define(version: 20150303172902) do
   end
 
   add_index "sipity_roles", ["name"], name: "index_sipity_roles_on_name", unique: true
+
+  create_table "sipity_simple_controlled_vocabularies", force: :cascade do |t|
+    t.string   "predicate_name",  null: false
+    t.string   "predicate_value", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "sipity_simple_controlled_vocabularies", ["predicate_name", "predicate_value"], name: "index_sipity_simple_controlled_vocabularies_unique", unique: true
+  add_index "sipity_simple_controlled_vocabularies", ["predicate_name"], name: "index_sipity_simple_controlled_vocabularies_on_predicate_name"
 
   create_table "sipity_transient_answers", force: :cascade do |t|
     t.integer  "entity_id",     null: false

--- a/spec/models/sipity/models/simple_controlled_vocabulary_spec.rb
+++ b/spec/models/sipity/models/simple_controlled_vocabulary_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+module Sipity
+  module Models
+    RSpec.describe SimpleControlledVocabulary, type: :model do
+      context 'data structure' do
+        subject { described_class }
+        its(:column_names) { should include('predicate_name') }
+        its(:column_names) { should include('predicate_value') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Responsible for defining what values are allowed for a given
> predicate.
>
> @todo - Convert Sipity::ModelCollaborators#role to use controlled
>   vocabulary based on work type. That will be important once we have
>   collaborator's roles vary by work type (i.e. does a Doctoral
>   Dissertation have different roles from a Master's Thesis, or from
>   a Conference Presentation).
>
> @note - At present the controlled vocabularies do not vary based on
>   any work type; However that is one potentiaul future variance.