### PR TITLE
Requiring user to aggree to Terms of Deposit (ToD)

### DIFF
--- a/app/forms/sipity/forms/etd/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/etd/submit_for_review_form.rb
@@ -6,9 +6,26 @@ module Sipity
       class SubmitForReviewForm < Forms::StateAdvancingAction
         def initialize(attributes = {})
           super
+          self.agree_to_terms_of_deposit = attributes[:agree_to_terms_of_deposit]
+        end
+
+        attr_reader :agree_to_terms_of_deposit
+        validates :agree_to_terms_of_deposit, acceptance: { accept: true }
+
+        def render(f:)
+          view_context.content_tag('div', submission_terms) +
+            f.input(:agree_to_terms_of_deposit, as: :boolean)
+        end
+
+        def submission_terms
+          view_context.t('submission_terms', scope: 'sipity/forms.etd/submit_for_review_form').html_safe
         end
 
         private
+
+        def view_context
+          Draper::ViewContext.current
+        end
 
         def save(requested_by:)
           super do
@@ -20,6 +37,11 @@ module Sipity
               notification: "entity_ready_for_review", entity: work, acting_as: ['etd_reviewer', 'advisor']
             )
           end
+        end
+
+        include Conversions::ConvertToBoolean
+        def agree_to_terms_of_deposit=(value)
+          @agree_to_terms_of_deposit = convert_to_boolean(value)
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,8 @@ en:
         title: 'You must provide a title'
         work_publication_strategy: 'Please tell us if you intend to publish this work'
         work_type: 'Please select a work type'
+    etd/submit_for_review_form:
+      terms_of_deposit: '<p>I can deposit these things.</p>'
   simple_form:
     labels:
       doi:

--- a/spec/features/sipity/trigger_work_state_change_spec.rb
+++ b/spec/features/sipity/trigger_work_state_change_spec.rb
@@ -52,6 +52,7 @@ feature "Trigger Work State Change", :devise, :feature do
       end
 
       on('event_trigger_page') do |the_page|
+        the_page.check('work[agree_to_terms_of_deposit]')
         the_page.take_named_action('confirm/event_trigger/submit_for_review')
       end
 

--- a/spec/forms/sipity/forms/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/submit_for_review_form_spec.rb
@@ -11,6 +11,12 @@ module Sipity
         let(:user) { User.new(id: 1) }
         subject { described_class.new(work: work, processing_action_name: action, repository: repository) }
 
+        it 'validates the aggreement to the submission terms' do
+          subject = described_class.new(work: work, processing_action_name: action, repository: repository)
+          subject.valid?
+          expect(subject.errors[:agree_to_terms_of_deposit]).to be_present
+        end
+
         context 'processing_action_name to action conversion' do
           it 'will use the given action if the strategy matches' do
             subject = described_class.new(work: work, processing_action_name: action, repository: repository)
@@ -18,29 +24,44 @@ module Sipity
           end
         end
 
-        it 'will log the event' do
-          expect(repository).to receive(:log_event!).and_call_original
-          subject.submit(requested_by: user)
+        context '#render' do
+          it 'will render HTML safe submission terms and confirmation' do
+            form_object = double('Form Object')
+            expect(form_object).to receive(:input).with(:agree_to_terms_of_deposit, as: :boolean).and_return("<input />")
+            expect(subject.render(f: form_object)).to be_html_safe
+          end
         end
 
-        it 'will register than the given action was taken on the entity' do
-          expect(repository).to receive(:register_action_taken_on_entity).and_call_original
-          subject.submit(requested_by: user)
-        end
+        its(:submission_terms) { should be_html_safe }
 
-        it 'will update the processing state' do
-          strategy_state = action.build_resulting_strategy_state
-          expect(repository).to receive(:update_processing_state!).
-            with(entity: work, to: strategy_state).and_call_original
-          subject.submit(requested_by: user)
-        end
+        context 'with valid data' do
+          subject do
+            described_class.new(work: work, processing_action_name: action, repository: repository, agree_to_terms_of_deposit: true)
+          end
+          it 'will log the event' do
+            expect(repository).to receive(:log_event!).and_call_original
+            subject.submit(requested_by: user)
+          end
 
-        it 'will send differing notifications to the creating user, etd reviewer, and advisor' do
-          expect(repository).to receive(:send_notification_for_entity_trigger).
-            with(notification: 'confirmation_of_entity_submitted_for_review', entity: work, acting_as: 'creating_user')
-          expect(repository).to receive(:send_notification_for_entity_trigger).
-            with(notification: 'entity_ready_for_review', entity: work, acting_as: ['etd_reviewer', 'advisor'])
-          subject.submit(requested_by: user)
+          it 'will register than the given action was taken on the entity' do
+            expect(repository).to receive(:register_action_taken_on_entity).and_call_original
+            subject.submit(requested_by: user)
+          end
+
+          it 'will update the processing state' do
+            strategy_state = action.build_resulting_strategy_state
+            expect(repository).to receive(:update_processing_state!).
+              with(entity: work, to: strategy_state).and_call_original
+            subject.submit(requested_by: user)
+          end
+
+          it 'will send differing notifications to the creating user, etd reviewer, and advisor' do
+            expect(repository).to receive(:send_notification_for_entity_trigger).
+              with(notification: 'confirmation_of_entity_submitted_for_review', entity: work, acting_as: 'creating_user')
+            expect(repository).to receive(:send_notification_for_entity_trigger).
+              with(notification: 'entity_ready_for_review', entity: work, acting_as: ['etd_reviewer', 'advisor'])
+            subject.submit(requested_by: user)
+          end
         end
       end
     end


### PR DESCRIPTION
Given that a grad student may be depositing all kinds of material, we
need to confirm with them that they are submitting documents to which
they have a right to submit.