### PR TITLE
Working on ability to delete collaborators

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
@@ -51,7 +51,9 @@ module Sipity
 
         def collaborators_from_work
           return [] unless work
-          work.collaborators.present? ? work.collaborators : [Models::Collaborator.build_default]
+          # Manually building an empty collaborator to allow adding more once
+          # one is already created:
+          work.collaborators + [Models::Collaborator.build_default]
         end
 
         def each_collaborator_must_be_valid

--- a/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
@@ -7,15 +7,16 @@ module Sipity
           super
           self.collaborators_attributes = attributes[:collaborators_attributes]
         end
-        attr_reader :collaborators_attributes
+        attr_reader :collaborators_attributes, :collaborators_from_input
+        private :collaborators_from_input
 
         # When the form is being rendered, the fields_for :collaborators drive
         # on this method, as such this is a read only method.
         def collaborators
-          @collaborators || collaborators_from_work
+          collaborators_from_input || collaborators_from_work
         end
 
-        validate :each_collaborator_must_be_valid
+        validate :each_collaborator_from_input_must_be_valid
         validate :at_least_one_collaborator_must_be_responsible_for_review
 
         # Mirroring the expected behavior/implementation of the
@@ -27,11 +28,17 @@ module Sipity
         # #collaborators method. So if that has 2 collaborators, the form will
         # render with those two collaborators and be submitted with that
         # information.
+        #
+        # @note Don't privatize me bro! I'm a good public servant. If
+        #   #collaborators_attributes= is not a public method then the expected
+        #   interface for :accepts_nested_attributes_for and :fields_for breaks
+        #   down.
         def collaborators_attributes=(inputs)
+          # ::Kernel.require 'byebug'; ::Kernel.byebug; true;
           return inputs unless inputs.present?
-          @collaborators = []
+          @collaborators_from_input = []
           inputs.each do |_, attributes|
-            build_collaborator_from_input(@collaborators, attributes)
+            build_collaborator_from_input(@collaborators_from_input, attributes)
           end
           @collaborators_attributes = inputs
         end
@@ -39,7 +46,7 @@ module Sipity
         private
 
         def save(requested_by:)
-          super { repository.assign_collaborators_to(work: work, collaborators: collaborators) }
+          super { repository.manage_collaborators_for(work: work, collaborators: collaborators) }
         end
 
         def collaborators_from_work

--- a/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/collaborator_form.rb
@@ -56,11 +56,6 @@ module Sipity
           work.collaborators + [Models::Collaborator.build_default]
         end
 
-        def each_collaborator_must_be_valid
-          return true if collaborators.all?(&:valid?)
-          errors.add(:collaborators_attributes, :are_incomplete)
-        end
-
         def build_collaborator_from_input(collection, attributes)
           return if !attributes[:name].present? && !attributes[:id].present?
           collaborator = repository.find_or_initialize_collaborators_by(work: work, id: attributes[:id])
@@ -75,8 +70,14 @@ module Sipity
           permitted_attributes
         end
 
+        def each_collaborator_from_input_must_be_valid
+          return true if Array.wrap(collaborators_from_input).all?(&:valid?)
+          errors.add(:collaborators_attributes, :are_incomplete)
+        end
+
         def at_least_one_collaborator_must_be_responsible_for_review
-          errors.add(:base, :at_least_one_collaborator_must_be_responsible_for_review) if collaborators.none?(&:responsible_for_review?)
+          return true unless Array.wrap(collaborators_from_input).none?(&:responsible_for_review?)
+          errors.add(:base, :at_least_one_collaborator_must_be_responsible_for_review)
         end
       end
     end

--- a/app/models/sipity/models/collaborator.rb
+++ b/app/models/sipity/models/collaborator.rb
@@ -20,7 +20,7 @@ module Sipity
 
       belongs_to :work, foreign_key: 'work_id'
       belongs_to :user, primary_key: 'username', foreign_key: 'netid'
-      has_one :processing_actor, as: :proxy_for, class_name: 'Sipity::Models::Processing::Actor'
+      has_one :processing_actor, dependent: :destroy, as: :proxy_for, class_name: 'Sipity::Models::Processing::Actor'
 
       include Conversions::ConvertToProcessingActor
       def to_processing_actor

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -3,6 +3,19 @@ module Sipity
   module Commands
     # Commands
     module WorkCommands
+      # Responsible for adding collaborators to the work and removing anyone
+      # else.
+      def manage_collaborators_for(work:, collaborators:)
+        collaborators_table = Models::Collaborator.arel_table
+        Models::Collaborator.where(
+          collaborators_table[:work_id].eq(work.id).and(
+            collaborators_table[:id].not_in(collaborators.flat_map(&:id))
+          )
+        ).destroy_all
+
+        assign_collaborators_to(work: work, collaborators: collaborators)
+      end
+
       # Responsible for assigning collaborators to a work.
       def assign_collaborators_to(work:, collaborators:)
         # TODO: Encapsulate this is a Service Object as there is enough logic

--- a/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
@@ -16,6 +16,7 @@
     <fieldset class="panel-body">
       <%= content_tag :p, t("sipity/decorators/entitiy_enrichments.panels.collaborators.hint"), class: 'panel-hint' %>
       <%= f.error_notification %>
+      <%= f.error :base, error_method: :to_sentence %>
 
       <table class="table expandible collaborators">
         <thead>

--- a/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
@@ -2,16 +2,6 @@
 <% description = t("sipity/decorators/entitiy_enrichments.description.#{model.enrichment_type}") %>
 <%= content_tag( :p, description) if description.present? %>
 
-<%
-  # Manually building an empty collaborator to allow adding more once one is already created:
-  # TODO: Move this somewhere else (obviously)
-  # TODO: Strip out 'empty' collaborators on submit
-
-  if model.work.collaborators.present?
-    model.work.collaborators << Sipity::Models::Collaborator.new(work_id: model.work.id)
-  end
-%>
-
 <%= simple_form_for(
     model,
     url: enrich_work_path(model.work, model.enrichment_type),

--- a/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
@@ -35,6 +35,15 @@ module Sipity
           end
         end
 
+        context 'when no collaborator attributes are passed and the form is submitted' do
+          let(:collaborator) { double('Collaborator', valid?: true) }
+          subject { described_class.new(work: work, repository: repository) }
+          it 'will not fall back to the persisted collaborators for validation' do
+            expect(work).to_not receive(:collaborators)
+            expect(subject.valid?).to be_falsey
+          end
+        end
+
         context '#submit' do
           let(:user) { User.new(id: '1') }
           context 'with invalid data' do
@@ -63,7 +72,7 @@ module Sipity
             end
 
             it 'will create a collaborator' do
-              expect(repository).to receive(:assign_collaborators_to).and_call_original
+              expect(repository).to receive(:manage_collaborators_for).and_call_original
               subject.submit(requested_by: user)
             end
           end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -28,6 +28,19 @@ module Sipity
         end
       end
 
+      context '#manage_collaborators_for' do
+        let(:work) { Models::Work.new(id: 123) }
+        let(:collaborator) do
+          Models::Collaborator.new(work_id: work.id, responsible_for_review: true, name: 'Jeremy', role: 'advisor', netid: 'somebody')
+        end
+        it 'will destroy collaborators not passed in' do
+          collaborator.save!
+          expect(test_repository).to receive(:assign_collaborators_to).with(work: work, collaborators: [])
+          expect { test_repository.manage_collaborators_for(work: work, collaborators: []) }.
+            to change { Models::Collaborator.count }.by(-1)
+        end
+      end
+
       context '#assign_collaborators_to' do
         let(:work) { Models::Work.new(id: 123) }
         let(:collaborator) do

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -182,6 +182,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
+    def manage_collaborators_for(work:, collaborators:)
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
     def mark_as_representative(work:, pid:, user: user)
     end
 


### PR DESCRIPTION
## Adding method for managing collaborators

@ded05e7d54ec0c975e873be997635cc09ff93ec2

> Responsible for adding collaborators to the work and removing anyone
> else.

## Adding ability to remove collaborators

@fef6d891a8f8cdd551bebca2328c01e69a0b6b6a

Since we have the repeater field, I'm making an assumption. If the
user removes the collaborator via the remove button in the UI, then
I will delete that collaborator.

## Destroying collaborator destroys its actor

@1745a1df4782c8d1658805a0eeb154a5c05585d3

Unlike a user and a group, a collaborator-based actor is much more
transient; That is to say Sipity is exposing a user based means of
getting rid of collaborators.

## Pushing collaborator build logic into form

@99bdd817b4fbbea803a36ebf8cc738dc5c635048

As per @danhorst's TODO items, I'm moving the building an extra
collaborator logic down into the form.

Also, don't worry about stripping away extract empty rows from the UI.
It is being [handled here](https://github.com/ndlib/sipity/blob/e75508b1566624133f72f021bde439dba3f5ddc7/app/forms/sipity/forms/work_enrichments/collaborator_form.rb#L56).
See the guard condition of the below method.

```ruby
def build_collaborator_from_input(collection, attributes)
  return if !attributes[:name].present? && !attributes[:id].present?
  collaborator = repository.find_or_initialize_collaborators_by(work: work, id: attributes[:id])
  collaborator.attributes = extract_collaborator_attributes(attributes)
  collection << collaborator
end
```

## Restoring collaborator errors on base

@f007d8fea94a73bd0b4e2586c5ee252ea946cb45

This is an ugly solution, but one to revisit. The validations of the
form throw an error on base if NO collaborators are given that require
review. That error message does belong with any of the collaborators.

It would be possible to push that error onto each of the items. But
we'd need to revisit how we'd do that.

## Gathering validation methods to common location

@23c226c20fe8085bad51774cfc89786cb563bc5e

Not only am I moving the methods, but I'm also wrapping the possible
input because it could be nil.

That is one concession concerning the contributors, I won't set a user
input if I receive an empty hash. But validation should be against
the collaborator attributes that were provided.
