### PR TITLE
Adding meta_request gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ group :development do
   gem 'pry-byebug'
   gem 'letter_opener'
   gem 'seed_dump'
+  # Paired with Chrome the RailsPanel plugin, you can see request information
+  # https://github.com/dejan/rails_panel
+  gem 'meta_request'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
+    callsite (0.0.11)
     capistrano (3.3.5)
       capistrano-stats (~> 1.1.0)
       i18n
@@ -213,6 +214,10 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    meta_request (0.3.4)
+      callsite (~> 0.0, >= 0.0.11)
+      rack-contrib (~> 1.1)
+      railties (>= 3.0.0, < 5.0.0)
     method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.2)
@@ -259,6 +264,8 @@ GEM
     rack (1.6.0)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-contrib (1.2.0)
+      rack (>= 0.9.1)
     rack-test (0.6.2)
       rack (>= 1.0)
     railroady (1.3.0)
@@ -454,6 +461,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   letter_opener
+  meta_request
   micromachine!
   mysql2
   net-ldap


### PR DESCRIPTION
Paired with the [RailsPanel](https://github.com/dejan/rails_panel)
Chrome Extension, I can get lots of information related to rendering
and queries.

> The first columns gives you the HTTP Response Status, the Controller
> and Action that your route hit, the HTTP Verb (PUT/POST/GET),
> request format (HTML, JSON, XML) and the response time. These
> metrics by itself would have been quite valuable, but there is more.
> You can click on any request that you made and see more information
> about it.
>
> ...
>
> The next tab is the Rendering which gives a breakdown of all the
> views being rendered. This is useful for finding which partials are
> taking the longest to render. Click on the view name automatically
> opens it in your editor.

Discovered from the following blog post:
http://www.rubyonrails365.com/7-must-have-gems-to-install-on-any-project/

Consider adding the newrelic_rpm gem for local reporting.