### PR TITLE
Working on ensuring that attachments have policy enforcement applied

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -75,7 +75,7 @@ module Sipity
           def initialize(attachment)
             @attachment = attachment
           end
-          delegate :id, :name, :thumbnail_url, :persisted?, to: :attachment
+          delegate :id, :name, :thumbnail_url, :persisted?, :file_url, to: :attachment
           attr_accessor :delete
           attr_reader :attachment
           private :attachment

--- a/app/models/sipity/models/attachment.rb
+++ b/app/models/sipity/models/attachment.rb
@@ -21,6 +21,8 @@ module Sipity
       def thumbnail_url(size = THUMBNAIL_SIZE)
         file.thumb(size).url
       end
+
+      delegate :url, to: :file, prefix: :file, allow_nil: true
     end
   end
 end

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -193,6 +193,8 @@ module Sipity
       # @param user [User]
       # @return ActiveRecord::Relation<Models::Processing::Actor>
       def scope_processing_actors_for(user:)
+        return Models::Processing::Actor.where('1 = 0') unless user.present?
+
         memb_table = Models::GroupMembership.arel_table
         actor_table = Models::Processing::Actor.arel_table
 

--- a/app/views/sipity/controllers/work_enrichments/attach.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/attach.html.erb
@@ -24,7 +24,12 @@
       <%= f.fields_for :attachments do |attachment_form| %>
         <li class="attachement form-inline">
           <figure class="thumbnail-wrapper">
-            <%= image_tag attachment_form.object.thumbnail_url, class: 'img-thumbnail' %>
+            <%= link_to(
+                  image_tag(attachment_form.object.thumbnail_url, alt: attachment_form.object.name, class: 'img-thumbnail'),
+                  attachment_form.object.file_url,
+                  target: '_blank'
+                )
+             %>
           </figure>
           <%= attachment_form.input :name, input_html: { class: 'form-control' } %>
           <%= attachment_form.input :delete, as: :boolean, wrapper_html: { class: 'checkbox' } %>

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -22,6 +22,8 @@ Dragonfly.app.configure do
       throw :halt, [401, { 'Content-Type' => 'text/plain' }, ["Unauthorized"]]
     end
   end
+
+  response_header 'Cache-Control', 'private, max-age=10800'
 end
 
 # Logger

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -8,9 +8,13 @@ Dragonfly.app.configure do
 
   url_format "/attachments/:job/:name"
 
-  datastore :file,
-    root_path: Rails.root.join('dragonfly', Rails.env),
-    server_root: Rails.root.join('public')
+  if Rails.env.test?
+    datastore :memory
+  else
+    datastore :file,
+      root_path: Rails.root.join('dragonfly', Rails.env),
+      server_root: Rails.root.join('public')
+  end
 
   before_serve do |job, env|
     user = env.fetch('warden').user

--- a/spec/models/sipity/models/attachment_spec.rb
+++ b/spec/models/sipity/models/attachment_spec.rb
@@ -30,6 +30,11 @@ module Sipity
           expect(subject.thumbnail_url).to match(/\/#{File.basename(__FILE__)}/)
         end
 
+        it 'has a file_url' do
+          subject.file = File.new(__FILE__)
+          expect(subject.file_url).to eq(subject.file.url)
+        end
+
         it 'has an file_name via the dragonfly gem' do
           subject.file = File.new(__FILE__)
           expect(subject.file_name).to eq(File.basename(__FILE__))

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -74,7 +74,15 @@ module Sipity
 
       context '#scope_processing_actors_for' do
         subject { test_repository.scope_processing_actors_for(user: user) }
-        it 'will return an array of both user and group' do
+        it 'will return an empty enumerable if the user is nil' do
+          user_processing_actor
+          group_processing_actor
+          Models::GroupMembership.create(user_id: user.id, group_id: group.id)
+          subject = test_repository.scope_processing_actors_for(user: nil)
+          expect(subject).to eq([])
+          expect(subject).to be_a(ActiveRecord::Relation)
+        end
+        it 'will return an enumerable of both user and group' do
           user_processing_actor
           group_processing_actor
           Models::GroupMembership.create(user_id: user.id, group_id: group.id)


### PR DESCRIPTION
## Ensuring that a nil user won't choke a query

@d7b09a2bc13aec22165c3a9c2c8bf669e3f3e933


## Exposing a file_url for an attachment

@bb8f42a233b480ca2d5efda93afdce17c922d922

So that a user can download the attachment, I want to expose a means
of accessing that.

## Enforcing authorization for reading attachments

@d9c00251e40fe912eabddd56689e8d9a72b7fab7

Prior to this commit, the URL for any attachment was publicly
accessible. And while it may have been hard to determine what the URL
should have been, it is something that could easily be disclosed (on
accident).

With this change, authorization is enforced on an attachment. It is a
quick fix and may not reflect the ideal situtation, but it is a better
approximation of what we need.

NOTE: Due to Dragonfly's caching if the policy enforcement changes it
is possible a user that once had access (but should no longer) will
still have access.

## Switching dragonfly to memory for tests

@e94e2e549ae1325c4d8612f72bfa7923f0900fdc

Because I'm tired of having my ./dragonfly directory grow larger and
larger.

## Privatizing cache-control

@5f2e42ac6926f558da6a39bac084ef1814654c4c

Instead of relying on public caching, I want private cache control for
the files. This should be verified against the staging server to make
sure that Rack::Cache is properly configured.
