### PR TITLE
Adding secret seeds to mix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,5 +63,5 @@ end
 
 if Rails.env.development? || Rails.env.test?
   desc 'Drop and create a new database with proper seed data'
-  task bootstrap: ['db:drop', 'db:create', 'db:schema:load', 'db:seed', 'sipity:create_user']
+  task bootstrap: ['db:drop', 'db:create', 'db:schema:load', 'db:seed', 'sipity:environment_bootstrapper']
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,7 +67,7 @@ namespace :deploy do
     on roles(:app) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, "db:seed"
+          execute :rake, "db:seed sipity:environment_bootstrapper"
         end
       end
     end

--- a/config/environment_bootstrapper.rb
+++ b/config/environment_bootstrapper.rb
@@ -1,0 +1,4 @@
+# Don't worry, this will be obliterated by super secret environment bootstrap
+# type things.
+$stdout.puts "Creating User '#{ENV['USER']}' (from ENV['USER'])..."
+User.find_or_create_by!(username: ENV['USER'])

--- a/lib/tasks/sipity.rake
+++ b/lib/tasks/sipity.rake
@@ -1,9 +1,8 @@
 namespace :sipity do
 
   desc 'Create a user based on $USER'
-  task :create_user do
-    $stdout.puts "Creating User '#{ENV['USER']}' (from ENV['USER'])..."
-    User.find_or_create_by!(username: ENV['USER'])
+  task environment_bootstrapper: :environment do
+    load(Rails.root.join('config/environment_bootstrapper.rb'))
   end
 
   desc 'Build the various repository interfaces for testing purposes; These are descriptive interfaces'

--- a/scripts/update_secrets.sh
+++ b/scripts/update_secrets.sh
@@ -19,6 +19,7 @@ git clone "git@git.library.nd.edu:$secret_repo"
 files_to_copy="
     application.yml
     database.yml
+    environment_bootstrapper.rb
     "
 
 for f in $files_to_copy; do


### PR DESCRIPTION
## Adding environemnt_bootstrapper.rb behavior

@756c7aaa9dd98b9b24136ee11c71c97e4c8ed1f6

Moving the existing rake task into an environment_bootstrapper.rb

Why config? Because secrets drops all of that information in config.

## Adding environment_bootstrapper.rb to secrets

@d7b842122b39529d4ea7c7882d2f3e55f4fd37ec

I need a way, at least for the short-term, to manage environment
specific data entries; Both create and update. This is that
communication change vector.

I would prefer to have a robust administrative interface.

## Adding sipity's environment bootstrapper

@4812dcd5cfcfd50829d566e1968e5997a9ee0a80

I don't want to auto-assume environment bootstrapping with db:seed; I
don't know the impact on Travis's builds. However, I do want to be
able to add environment specific data entries.

This is perhaps a stop gap as we don't have an administrative
interface concerning the application.
