### PR TITLE
Treating blank User#emails as nil

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,17 @@ class User < ActiveRecord::Base
   # record.
   before_save :set_notre_dame_specific_email, if: :new_record?
 
+  # Because of the unique constraint on User#email, when we receive an empty
+  # email for user (e.g. the user form that was filled out had blank spaces for
+  # the given email), blank that out.
+  def email=(value)
+    if value.present?
+      super(value)
+    else
+      super(nil)
+    end
+  end
+
   private
 
   def set_notre_dame_specific_email

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,4 +10,9 @@ describe User do
     expect(@user.email).to match 'user@example.com'
   end
 
+  it 'will allow multiple users to have a "" email' do
+    User.create!(username: 'one', email: '')
+    expect { User.create!(username: 'two', email: '') }.to_not raise_error
+  end
+
 end


### PR DESCRIPTION
Because of the unique constraint on User#email, when we receive an
empty email for user (e.g. the user form that was filled out had blank
spaces for the given email), blank that out.