### PR TITLE
Adding #to_array_without_empty_values

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/degree_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/degree_form.rb
@@ -5,12 +5,11 @@ module Sipity
       class DegreeForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
           super
-          @degree = attributes.fetch(:degree) { degree_from_work }
-          @program_name = attributes.fetch(:program_name) { program_name_from_work }
+          self.degree = attributes.fetch(:degree) { degree_from_work }
+          self.program_name = attributes.fetch(:program_name) { program_name_from_work }
         end
 
-        attr_accessor :degree
-        attr_accessor :program_name
+        attr_reader :degree, :program_name
 
         validates :degree, presence: true
         validates :program_name, presence: true
@@ -25,6 +24,14 @@ module Sipity
 
         private
 
+        def degree=(values)
+          @degree = to_array_without_empty_values(values)
+        end
+
+        def program_name=(values)
+          @program_name = to_array_without_empty_values(values)
+        end
+
         def save(requested_by:)
           super do
             repository.update_work_attribute_values!(work: work, key: 'degree', values: degree)
@@ -38,6 +45,10 @@ module Sipity
 
         def program_name_from_work
           repository.work_attribute_values_for(work: work, key: 'program_name')
+        end
+
+        def to_array_without_empty_values(value)
+          Array.wrap(value).select(&:present?)
         end
       end
     end

--- a/spec/forms/sipity/forms/work_enrichments/degree_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/degree_form_spec.rb
@@ -28,6 +28,16 @@ module Sipity
           expect(subject.errors[:program_name]).to be_present
         end
 
+        it 'will only keep degree entries that are "present?"' do
+          subject = described_class.new(work: work, repository: repository, degree: ['hello', '', nil, 'world'])
+          expect(subject.degree).to eq(['hello', 'world'])
+        end
+
+        it 'will only keep program_names entries that are "present?"' do
+          subject = described_class.new(work: work, repository: repository, program_name: ['hello', '', nil, 'world'])
+          expect(subject.program_name).to eq(['hello', 'world'])
+        end
+
         context '#degree' do
           it 'will have #degree_names' do
             expect(repository).to receive(:get_values_by_predicate_name).with(name: 'degree').and_return(['degree_name', 'bogus'])


### PR DESCRIPTION
When a user enters data via the form, if they are using the multi-
select options, it is possible that we will receive blank entries.

So as part of setting the values, I'm only keeping those values that
are present.