### PR TITLE
Working on exception handling

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -9,11 +9,6 @@ module Sipity
     class RuntimeError < ::RuntimeError
     end
 
-    # When something about the entity for a given policy is just not quite
-    # right.
-    class PolicyEntityExpectationError < RuntimeError
-    end
-
     # When passing parameters through the job layer, passing complex objects
     # can cause problems; In that we don't want to pass state across the async
     # boundary.
@@ -24,13 +19,6 @@ module Sipity
     class UnprocessableResourcefulActionNameError < RuntimeError
       def initialize(container:, object:)
         super("Expected #{object} to have a #name that is within #{container}")
-      end
-    end
-
-    # There was a problem referencing the state for a policy lookup.
-    class StatePolicyQuestionRoleMapError < RuntimeError
-      def initialize(state:, context:)
-        super("Could not find #{state} in the corresponding map for #{context}")
       end
     end
 
@@ -136,10 +124,6 @@ module Sipity
     class WorkTypeNotFoundError < ConceptNotFoundError
     end
 
-    # A StateMachine was not found.
-    class StateMachineNotFoundError < ConceptNotFoundError
-    end
-
     # A EventTriggerForm was not found.
     class EventTriggerFormNotFoundError < ConceptNotFoundError
     end
@@ -169,15 +153,6 @@ module Sipity
       def initialize(user:, action_to_authorize:, entity:)
         @user, @action_to_authorize, @entity = user, action_to_authorize, entity
         super("#{user} not allowed to #{action_to_authorize} this #{entity}")
-      end
-    end
-
-    # The proposed state diagram was malformed.
-    class InvalidStateDiagramRawStructure < RuntimeError
-      attr_reader :structure
-      def initialize(structure:)
-        @structure = structure
-        super("#{structure} is not well formed for StateDiagram")
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module Sipity
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.action_dispatch.rescue_responses['Sipity::Exceptions::AuthorizationFailureError'] = :unauthorized
   end
 end

--- a/public/401.html
+++ b/public/401.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>You are not authorized to access the page (401)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/401.html -->
+  <div class="dialog">
+    <div>
+      <h1>You are not authorized to access the given page.</h1>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -3,11 +3,6 @@ require 'sipity/exceptions'
 
 module Sipity
   module Exceptions
-    RSpec.describe StatePolicyQuestionRoleMapError do
-      subject { described_class.new(state: 'hello', context: 'world') }
-      its(:message) { should be_a(String) }
-    end
-
     RSpec.describe ExistingMethodsAlreadyDefined do
       subject { described_class.new('hello', [:ab, :cd]) }
       its(:message) { should be_a(String) }
@@ -22,12 +17,6 @@ module Sipity
     RSpec.describe UnprocessableResourcefulActionNameError do
       subject { described_class.new(container: 'Container', object: 'hello') }
       its(:message) { should be_a(String) }
-    end
-
-    RSpec.describe InvalidStateDiagramRawStructure do
-      subject { described_class.new(structure: 'hello') }
-      its(:message) { should be_a(String) }
-      its(:structure) { should eq('hello') }
     end
 
     RSpec.describe AuthenticationFailureError do


### PR DESCRIPTION
## Removing unused exceptions

@9f6af8ae0e165dcc39adf73da9046e07a6c36941

These are exceptions that were used in previous iterations but are no
longer relevant.

## Configuration :unauthorized exceptions

@a4e0e0c8b6e0b34e11412d395066753d2a866b10

> * config.action_dispatch.rescue_responses configures what exceptions
>   are assigned to an HTTP status. It accepts a hash and you can
>   specify pairs of exception/status.
>
> From http://guides.rubyonrails.org/configuring.html#configuring-action-dispatch

## Adding public/401.html page

@6dcf0bd342cb9c7ac5ef8934e3a329bb43e7bca8

Instead of a crazy 500 exception error, I'm opting to provide an
unauthorized page 401 page. This is inadequate, but something we can
proceed with in a meaningful way.
