### PR TITLE
Adding Collaborator#email validation

### DIFF
--- a/app/models/sipity/models/collaborator.rb
+++ b/app/models/sipity/models/collaborator.rb
@@ -45,6 +45,7 @@ module Sipity
       validates :name, presence: true
       validate :validate_required_information_if_responsible_for_review
       validates :netid, net_id: true
+      validates :email, format: { without: /@nd\.edu\Z/, message: :disallow_nd_dot_edu_emails }
 
       def validate_required_information_if_responsible_for_review
         return true unless responsible_for_review?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,4 +232,5 @@ en:
         files: 'Select files to upload'
   errors:
     messages:
+      disallow_nd_dot_edu_emails: 'You may not use an @nd.edu email'
       at_least_one_collaborator_must_be_responsible_for_review: 'At least one collaborator must be responsible for review'

--- a/spec/models/sipity/models/collaborator_spec.rb
+++ b/spec/models/sipity/models/collaborator_spec.rb
@@ -58,6 +58,12 @@ module Sipity
           expect(subject.errors[:name]).to be_present
         end
 
+        it 'will not allow an @nd.edu email address' do
+          subject.email = 'hello@nd.edu'
+          subject.valid?
+          expect(subject.errors[:email]).to be_present
+        end
+
         context 'when responsible for review' do
           it 'will have errors on netid and email if none are given' do
             subject.responsible_for_review = true


### PR DESCRIPTION
Disallowing @nd.edu email addresses so as to push people towards
providing a valid NetID.