### PR TITLE
Adding requirement for Figaro keys

### DIFF
--- a/app/services/sipity/services/ldap_client.rb
+++ b/app/services/sipity/services/ldap_client.rb
@@ -5,9 +5,9 @@ module Sipity
     class LdapClient
       def self.valid_netid?(netid)
         configuration = {
-          host: Figaro.env.ldap_host,
-          port: Figaro.env.ldap_port,
-          encryption: Figaro.env.ldap_encryption.to_sym
+          host: Figaro.env.ldap_host!,
+          port: Figaro.env.ldap_port!,
+          encryption: Figaro.env.ldap_encryption!.to_sym
         }
         new(configuration).valid_netid?(netid)
       end

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,1 +1,6 @@
-Figaro.require_keys("domain_name")
+Figaro.require_keys(
+  "domain_name",
+  "ldap_host",
+  "ldap_port",
+  "ldap_encryption"
+)


### PR DESCRIPTION
> If a particular configuration value is required but not set, it's
> appropriate to raise an error. With Figaro, you can either raise
> these errors proactively or lazily.
>
> To proactively require configuration keys:
>
> ```ruby
> # config/initializers/figaro.rb
> Figaro.require_keys("pusher_app_id", "pusher_key", "pusher_secret")
> ```
> If any of the configuration keys above are not set, your application
> will raise an error during initialization. This method is preferred
> because it prevents runtime errors in a production application due
> to improper configuration.
>
> From https://github.com/laserlemon/figaro#required-keys