### PR TITLE
Restoring test coverage at the unit level

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -80,7 +80,7 @@ Metrics/AbcSize:
      - app/conversions/**/*.rb
      - app/state_machines/**/*.rb
      - app/repositories/sipity/queries/*.rb
-     - 'app/state_machines/sipity/state_machines/state_diagram.rb'
+     - app/controllers/application_controller.rb
 
 Delegate:
   Description: 'Prefer delegate method for delegations.'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,10 +29,9 @@ class ApplicationController < ActionController::Base
   # Remove error inserted since we are not showing a page before going to web access, this error message always shows up a page too late.
   # for the moment just remove it always.  If we show a transition page in the future we may want to  display it then.
   def filter_notify
-    return unless flash[:alert].present?
-    flash[:alert] = [flash[:alert]].flatten.reject do |item|
-      item == "You need to sign in or sign up before continuing."
-    end
-    flash[:alert] = nil if flash[:alert].blank?
+    return true unless flash[:alert].present?
+    flash[:alert] = Array.wrap(flash[:alert]).select { |alert| alert != t('devise.failure.unauthenticated') }
+    flash[:alert] = nil unless flash[:alert].present?
+    true
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -34,4 +34,11 @@ RSpec.describe ApplicationController do
       expect(subject.to_s).to eq("Unable to find MyName in MyContainer")
     end
   end
+
+  context '#filter_notify' do
+    it 'will remove the devise messaging for failure.unauthenticated' do
+      subject.flash[:alert] = subject.t('devise.failure.unauthenticated')
+      expect { subject.send(:filter_notify) }.to change { subject.flash[:alert] }.to(nil)
+    end
+  end
 end


### PR DESCRIPTION
Also, switching to use translations instead of hard-coded strings.