### PR TITLE
Ensure that only attributes that are present are persisted

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/describe_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/describe_form.rb
@@ -28,15 +28,15 @@ module Sipity
         end
 
         def abstract_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'abstract').first
+          repository.work_attribute_values_for(work: work, key: 'abstract').first
         end
 
         def discipline_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'discipline').first
+          repository.work_attribute_values_for(work: work, key: 'discipline').first
         end
 
         def alternate_title_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'alternate_title').first
+          repository.work_attribute_values_for(work: work, key: 'alternate_title').first
         end
       end
     end

--- a/app/forms/sipity/forms/work_enrichments/describe_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/describe_form.rb
@@ -10,9 +10,7 @@ module Sipity
           @alternate_title = attributes.fetch(:alternate_title) { alternate_title_from_work }
         end
 
-        attr_accessor :abstract
-        attr_accessor :discipline
-        attr_accessor :alternate_title
+        attr_reader :abstract, :discipline, :alternate_title
 
         validates :abstract, presence: true
         validates :discipline, presence: true

--- a/app/forms/sipity/forms/work_enrichments/describe_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/describe_form.rb
@@ -5,12 +5,13 @@ module Sipity
       class DescribeForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
           super
-          @abstract = attributes.fetch(:abstract) { abstract_from_work }
-          @discipline = attributes.fetch(:discipline) { discipline_from_work }
-          @alternate_title = attributes.fetch(:alternate_title) { alternate_title_from_work }
+          self.abstract = attributes.fetch(:abstract) { abstract_from_work }
+          self.discipline = attributes.fetch(:discipline) { discipline_from_work }
+          self.alternate_title = attributes.fetch(:alternate_title) { alternate_title_from_work }
         end
 
-        attr_reader :abstract, :discipline, :alternate_title
+        attr_accessor :discipline, :alternate_title, :abstract
+        private :discipline=, :alternate_title=, :abstract=
 
         validates :abstract, presence: true
         validates :discipline, presence: true

--- a/app/repositories/sipity/commands/additional_attribute_commands.rb
+++ b/app/repositories/sipity/commands/additional_attribute_commands.rb
@@ -23,7 +23,7 @@ module Sipity
 
       def create_work_attribute_values!(work:, key:, values:)
         Array.wrap(values).each do |value|
-          Models::AdditionalAttribute.create!(work: work, key: key, value: value)
+          Models::AdditionalAttribute.create!(work: work, key: key, value: value) if value.present?
         end
       end
       module_function :create_work_attribute_values!

--- a/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
@@ -17,11 +17,8 @@ module Sipity
 
         it { should respond_to :work }
         it { should respond_to :abstract }
-        it { should respond_to :abstract= }
         it { should respond_to :discipline }
-        it { should respond_to :discipline= }
         it { should respond_to :alternate_title }
-        it { should respond_to :alternate_title= }
 
         it 'will require a abstract' do
           subject.valid?

--- a/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/describe_form_spec.rb
@@ -8,6 +8,10 @@ module Sipity
         let(:repository) { CommandRepositoryInterface.new }
         subject { described_class.new(work: work, repository: repository) }
 
+        before do
+          allow(repository).to receive(:work_attribute_values_for).and_return([])
+        end
+
         its(:enrichment_type) { should eq('describe') }
         its(:policy_enforcer) { should eq Policies::Processing::WorkProcessingPolicy }
 
@@ -33,13 +37,13 @@ module Sipity
         context '#abstract' do
           let(:abstract) { ['Hello Dolly'] }
           let(:discipline) { ['Computer Science'] }
-          subject { described_class.new(work: work) }
+          subject { described_class.new(work: work, repository: repository) }
           it 'will return the abstract of the work' do
-            expect(Queries::AdditionalAttributeQueries).to receive(:work_attribute_values_for).
+            expect(repository).to receive(:work_attribute_values_for).
               with(work: work, key: 'alternate_title').and_return("")
-            expect(Queries::AdditionalAttributeQueries).to receive(:work_attribute_values_for).
+            expect(repository).to receive(:work_attribute_values_for).
               with(work: work, key: 'abstract').and_return(abstract)
-            expect(Queries::AdditionalAttributeQueries).to receive(:work_attribute_values_for).
+            expect(repository).to receive(:work_attribute_values_for).
               with(work: work, key: 'discipline').and_return(discipline)
             expect(subject.abstract).to eq 'Hello Dolly'
             expect(subject.discipline).to eq 'Computer Science'

--- a/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
+++ b/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
@@ -17,6 +17,11 @@ module Sipity
           to change { subject.work_attribute_values_for(work: work, key: key) }.from([]).to(['abc'])
       end
 
+      it 'will not create blank nodes' do
+        expect { subject.update_work_attribute_values!(work: work, key: key, values: '') }.
+          to_not change { subject.work_attribute_values_for(work: work, key: key) }
+      end
+
       it 'will destroy_work_attribute_values a key/value pair if the value exists but is not part of the update' do
         subject.create_work_attribute_values!(work: work, key: key, values: 'abc')
         subject.update_work_attribute_values!(work: work, key: key, values: 'new_value')


### PR DESCRIPTION
## Removing module_function call from form

@0f07878397aa3dd04cf00e224c4522bf240b37ae

Instead of using Queries::AdditionalAttributeQueries, prefer an
instance method.

## Removing attr_accessor usage from form object

@f741f2c4c30efdaccde68f442408a09c30220073

These methods are not necessary as a public method.

## Replacing instance setting with private setter

@f0d67b808cff9bd5cde56b8e15cd4af9329ab0de

## Avoding persistence of blank nodes

@8b97a65ee8871d6ff89be3fd1d177e7cb73ac329

Skolemize all the things!

Closes #250
