### PR TITLE
Rearranging presentation order of fields

### DIFF
--- a/app/views/sipity/controllers/work_enrichments/describe.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/describe.html.erb
@@ -27,8 +27,8 @@
         #The discipline text field should be replaced by controlled vocabulary
       %>
 
-      <%= f.input :alternate_title, input_html: { class: 'form-control' }  %>
       <%= f.input :discipline, input_html: { class: 'form-control' } %>
+      <%= f.input :alternate_title, input_html: { class: 'form-control' }  %>
 
     </fieldset>
 


### PR DESCRIPTION
Given that the discipline is required but the alternate title is not,
present the discipline first then alternate title.

[skip ci]