### PR TITLE
Issue 257 correct confusing primary keys for entities

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_permanent_uri.rb
+++ b/app/conversions/sipity/conversions/convert_to_permanent_uri.rb
@@ -20,11 +20,9 @@ module Sipity
       #
       # @return Integer
       def convert_to_permanent_uri(input)
-        return convert_to_permanent_uri(input.id) if input.is_a?(Models::Work)
-        return convert_to_permanent_uri(input.work_id) if input.respond_to?(:work_id)
+        return PERMANENT_URI_FORMAT % input.id if input.is_a?(Models::Work)
+        return PERMANENT_URI_FORMAT % input.work_id if input.respond_to?(:work_id)
         return convert_to_permanent_uri(input.work) if input.respond_to?(:work)
-        # TODO: The Work key may not be a Fixed num
-        return PERMANENT_URI_FORMAT % input if input.is_a?(Fixnum)
         fail Exceptions::PermanentUriConversionError, input
       end
 

--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -4,6 +4,7 @@ module Sipity
     # The most basic of information required for generating a valid work.
     class Work < ActiveRecord::Base
       self.table_name = 'sipity_works'
+      self.primary_key = :id
 
       has_many :collaborators, foreign_key: :work_id, dependent: :destroy
       has_many :additional_attributes, foreign_key: :work_id, dependent: :destroy

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -42,10 +42,12 @@ module Sipity
         from_proxy.processing_actor.update(proxy_for: to_proxy)
       end
 
-      def create_work!(attributes = {})
+      def create_work!(attributes = {}, collaborators = {})
         # TODO: Encapsulate this into a Service Object as there is logic spilling
         #   around.
-        Models::Work.create!(attributes.slice(:title, :work_publication_strategy, :work_type)) do |work|
+        work_attributes = attributes.slice(:title, :work_publication_strategy, :work_type)
+        work_attributes[:id] = collaborators.fetch(:pid_minter) { default_pid_minter }.call
+        Models::Work.create!(work_attributes) do |work|
           named_work_type = attributes.fetch(:work_type)
           work_type = Models::WorkType.find_or_create_by!(name: named_work_type)
           # A bit of a weirdness as I splice in the new behavior

--- a/db/migrate/20141120155922_create_sipity_works.rb
+++ b/db/migrate/20141120155922_create_sipity_works.rb
@@ -1,10 +1,15 @@
 class CreateSipityWorks < ActiveRecord::Migration
   def change
-    create_table :sipity_works do |t|
+    create_table :sipity_works, id: false do |t|
+      t.string :id, limit: 32
       t.string :work_publication_strategy
       t.string :title
 
       t.timestamps
     end
+    add_index :sipity_works, :id, unique: true
+    add_index :sipity_works, :title
+    add_index :sipity_works, :work_publication_strategy
+    change_column_null :sipity_works, :id, false
   end
 end

--- a/db/migrate/20141120203834_create_sipity_collaborators.rb
+++ b/db/migrate/20141120203834_create_sipity_collaborators.rb
@@ -1,7 +1,7 @@
 class CreateSipityCollaborators < ActiveRecord::Migration
   def change
     create_table :sipity_collaborators do |t|
-      t.integer :work_id
+      t.string :work_id, limit: 32
       t.integer :sequence
       t.string :name
       t.string :role

--- a/db/migrate/20141124162510_create_sipity_additional_attributes.rb
+++ b/db/migrate/20141124162510_create_sipity_additional_attributes.rb
@@ -1,7 +1,7 @@
 class CreateSipityAdditionalAttributes < ActiveRecord::Migration
   def change
     create_table :sipity_additional_attributes do |t|
-      t.integer :work_id, null: false
+      t.string :work_id, limit: 32, null: false
       t.string :key, null: false
       t.string :value
 

--- a/db/migrate/20141125133337_create_sipity_doi_creation_requests.rb
+++ b/db/migrate/20141125133337_create_sipity_doi_creation_requests.rb
@@ -1,7 +1,7 @@
 class CreateSipityDoiCreationRequests < ActiveRecord::Migration
   def change
     create_table :sipity_doi_creation_requests do |t|
-      t.integer :work_id, null: false, unique: true
+      t.string :work_id, limit: 32, null: false, unique: true
       t.string :state, null: false, length: 16
       t.string :response_message, :text
       t.timestamps

--- a/db/migrate/20141204154424_create_sipity_permissions.rb
+++ b/db/migrate/20141204154424_create_sipity_permissions.rb
@@ -4,7 +4,7 @@ class CreateSipityPermissions < ActiveRecord::Migration
       t.integer :actor_id, index: true
       t.string :actor_type, index: true, limit: 64
       t.string :acting_as, index: true, limit: 32
-      t.integer :entity_id, index: true
+      t.string :entity_id, limit: 32, index: true
       t.string :entity_type, index: true, limit: 64
 
       t.timestamps

--- a/db/migrate/20141204165259_create_sipity_event_logs.rb
+++ b/db/migrate/20141204165259_create_sipity_event_logs.rb
@@ -2,7 +2,7 @@ class CreateSipityEventLogs < ActiveRecord::Migration
   def change
     create_table :sipity_event_logs do |t|
       t.integer :user_id, index: true
-      t.integer :entity_id
+      t.string :entity_id, limit: 32
       t.string :entity_type, limit: 64
       t.string :event_name, index: true
 

--- a/db/migrate/20150112142919_create_sipity_models_attachments.rb
+++ b/db/migrate/20150112142919_create_sipity_models_attachments.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsAttachments < ActiveRecord::Migration
   def change
     create_table :sipity_attachments, id: false do |t|
-      t.integer :work_id
+      t.string :work_id, limit: 32
       t.string :pid
       t.string :predicate_name
       t.string :file_uid

--- a/db/migrate/20150113145636_create_sipity_models_access_rights.rb
+++ b/db/migrate/20150113145636_create_sipity_models_access_rights.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsAccessRights < ActiveRecord::Migration
   def change
     create_table :sipity_access_rights do |t|
-      t.integer :entity_id
+      t.string :entity_id, limit: 32
       t.string :entity_type
       t.string :access_right_code
       t.date :enforcement_start_date

--- a/db/migrate/20150113155503_create_sipity_models_transient_answers.rb
+++ b/db/migrate/20150113155503_create_sipity_models_transient_answers.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsTransientAnswers < ActiveRecord::Migration
   def change
     create_table :sipity_transient_answers do |t|
-      t.integer :entity_id
+      t.string :entity_id, limit: 32
       t.string :entity_type
       t.string :question_code
       t.string :answer_code

--- a/db/migrate/20150122181425_create_sipity_models_todo_item_states.rb
+++ b/db/migrate/20150122181425_create_sipity_models_todo_item_states.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsTodoItemStates < ActiveRecord::Migration
   def change
     create_table :sipity_todo_item_states do |t|
-      t.integer :entity_id
+      t.string :entity_id, limit: 32
       t.string :entity_type
       t.string :entity_processing_state
       t.string :enrichment_type

--- a/db/migrate/20150201002854_create_sipity_models_processing_entities.rb
+++ b/db/migrate/20150201002854_create_sipity_models_processing_entities.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsProcessingEntities < ActiveRecord::Migration
   def change
     create_table :sipity_processing_entities do |t|
-      t.integer :proxy_for_id, null: false
+      t.string :proxy_for_id, limit: 32, null: false
       t.string :proxy_for_type, null: false
       t.integer :strategy_id, null: false
       t.integer :strategy_state_id, null: false

--- a/db/migrate/20150201002855_create_sipity_models_processing_actors.rb
+++ b/db/migrate/20150201002855_create_sipity_models_processing_actors.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsProcessingActors < ActiveRecord::Migration
   def change
     create_table :sipity_processing_actors do |t|
-      t.integer :proxy_for_id, null: false
+      t.string :proxy_for_id, limit: 32, null: false
       t.string :proxy_for_type, null: false
       t.string :name_of_proxy
 

--- a/db/migrate/20150201002859_create_sipity_models_processing_entity_specific_responsibility.rb
+++ b/db/migrate/20150201002859_create_sipity_models_processing_entity_specific_responsibility.rb
@@ -2,7 +2,7 @@ class CreateSipityModelsProcessingEntitySpecificResponsibility < ActiveRecord::M
   def change
     create_table :sipity_processing_entity_specific_responsibilities do |t|
       t.integer :strategy_role_id, null: false
-      t.integer :entity_id, null: false
+      t.string :entity_id, limit: 32, null: false
       t.integer :actor_id, null: false
 
       t.timestamps null: false

--- a/db/migrate/20150201002904_create_sipity_models_processing_entity_action_register.rb
+++ b/db/migrate/20150201002904_create_sipity_models_processing_entity_action_register.rb
@@ -2,7 +2,7 @@ class CreateSipityModelsProcessingEntityActionRegister < ActiveRecord::Migration
   def change
     create_table :sipity_processing_entity_action_registers do |t|
       t.integer :strategy_action_id, null: false
-      t.integer :entity_id, null: false
+      t.string :entity_id, limit: 32, null: false
 
       t.timestamps null: false
     end

--- a/db/migrate/20150225173436_create_sipity_models_processing_comments.rb
+++ b/db/migrate/20150225173436_create_sipity_models_processing_comments.rb
@@ -1,7 +1,7 @@
 class CreateSipityModelsProcessingComments < ActiveRecord::Migration
   def change
     create_table :sipity_processing_comments do |t|
-      t.integer :entity_id
+      t.string :entity_id, limit: 32
       t.integer :actor_id
       t.text :comment
       t.integer :originating_strategy_action_id

--- a/db/migrate/20150303172902_modify_access_right.rb
+++ b/db/migrate/20150303172902_modify_access_right.rb
@@ -3,7 +3,7 @@ class ModifyAccessRight < ActiveRecord::Migration
     drop_table :sipity_access_rights
 
     create_table :sipity_access_rights do |t|
-      t.integer :entity_id
+      t.string :entity_id, limit: 32
       t.string :entity_type
       t.string :access_right_code
       t.date :transition_date

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,12 +14,12 @@
 ActiveRecord::Schema.define(version: 20150305170338) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
-    t.integer  "entity_id",         null: false
-    t.string   "entity_type",       null: false
-    t.string   "access_right_code", null: false
+    t.string   "entity_id",         limit: 32, null: false
+    t.string   "entity_type",                  null: false
+    t.string   "access_right_code",            null: false
     t.date     "transition_date"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
   end
 
   add_index "sipity_access_rights", ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type", unique: true
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_account_placeholders", ["state"], name: "index_sipity_account_placeholders_on_state"
 
   create_table "sipity_additional_attributes", force: :cascade do |t|
-    t.integer  "work_id",    null: false
-    t.string   "key",        null: false
+    t.string   "work_id",    limit: 32, null: false
+    t.string   "key",                   null: false
     t.text     "value"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -50,29 +50,29 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_additional_attributes", ["work_id"], name: "index_sipity_additional_attributes_on_work_id"
 
   create_table "sipity_attachments", id: false, force: :cascade do |t|
-    t.integer  "work_id",                                null: false
-    t.string   "pid",                                    null: false
-    t.string   "predicate_name",                         null: false
-    t.string   "file_uid",                               null: false
-    t.string   "file_name",                              null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.boolean  "is_representative_file", default: false
+    t.string   "work_id",                limit: 32,                 null: false
+    t.string   "pid",                                               null: false
+    t.string   "predicate_name",                                    null: false
+    t.string   "file_uid",                                          null: false
+    t.string   "file_name",                                         null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.boolean  "is_representative_file",            default: false
   end
 
   add_index "sipity_attachments", ["pid"], name: "index_sipity_attachments_on_pid", unique: true
   add_index "sipity_attachments", ["work_id"], name: "index_sipity_attachments_on_work_id"
 
   create_table "sipity_collaborators", force: :cascade do |t|
-    t.integer  "work_id",                                null: false
+    t.string   "work_id",                limit: 32,                 null: false
     t.integer  "sequence"
     t.string   "name"
-    t.string   "role",                                   null: false
+    t.string   "role",                                              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "netid"
     t.string   "email"
-    t.boolean  "responsible_for_review", default: false
+    t.boolean  "responsible_for_review",            default: false
   end
 
   add_index "sipity_collaborators", ["email"], name: "index_sipity_collaborators_on_email"
@@ -80,8 +80,8 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_collaborators", ["work_id", "sequence"], name: "index_sipity_collaborators_on_work_id_and_sequence"
 
   create_table "sipity_doi_creation_requests", force: :cascade do |t|
-    t.integer  "work_id",                                                null: false
-    t.string   "state",            default: "request_not_yet_submitted", null: false
+    t.string   "work_id",          limit: 32,                                       null: false
+    t.string   "state",                       default: "request_not_yet_submitted", null: false
     t.string   "response_message"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 20150305170338) do
 
   create_table "sipity_event_logs", force: :cascade do |t|
     t.integer  "user_id",                null: false
-    t.integer  "entity_id",              null: false
+    t.string   "entity_id",   limit: 32, null: false
     t.string   "entity_type", limit: 64, null: false
     t.string   "event_name",             null: false
     t.datetime "created_at"
@@ -130,23 +130,23 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_groups", ["name"], name: "index_sipity_groups_on_name", unique: true
 
   create_table "sipity_processing_actors", force: :cascade do |t|
-    t.integer  "proxy_for_id",   null: false
-    t.string   "proxy_for_type", null: false
+    t.string   "proxy_for_id",   limit: 32, null: false
+    t.string   "proxy_for_type",            null: false
     t.string   "name_of_proxy"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
   end
 
   add_index "sipity_processing_actors", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_actors_proxy_for", unique: true
 
   create_table "sipity_processing_comments", force: :cascade do |t|
-    t.integer  "entity_id",                      null: false
-    t.integer  "actor_id",                       null: false
+    t.string   "entity_id",                      limit: 32, null: false
+    t.integer  "actor_id",                                  null: false
     t.text     "comment"
-    t.integer  "originating_strategy_action_id", null: false
-    t.integer  "originating_strategy_state_id",  null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.integer  "originating_strategy_action_id",            null: false
+    t.integer  "originating_strategy_state_id",             null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
   end
 
   add_index "sipity_processing_comments", ["actor_id"], name: "index_sipity_processing_comments_on_actor_id"
@@ -155,12 +155,12 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_processing_comments", ["originating_strategy_state_id"], name: "sipity_processing_comments_state_index"
 
   create_table "sipity_processing_entities", force: :cascade do |t|
-    t.integer  "proxy_for_id",      null: false
-    t.string   "proxy_for_type",    null: false
-    t.integer  "strategy_id",       null: false
-    t.integer  "strategy_state_id", null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.string   "proxy_for_id",      limit: 32, null: false
+    t.string   "proxy_for_type",               null: false
+    t.integer  "strategy_id",                  null: false
+    t.integer  "strategy_state_id",            null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
   end
 
   add_index "sipity_processing_entities", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_entities_proxy_for", unique: true
@@ -168,12 +168,12 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_processing_entities", ["strategy_state_id"], name: "index_sipity_processing_entities_on_strategy_state_id"
 
   create_table "sipity_processing_entity_action_registers", force: :cascade do |t|
-    t.integer  "strategy_action_id",    null: false
-    t.integer  "entity_id",             null: false
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
-    t.integer  "requested_by_actor_id", null: false
-    t.integer  "on_behalf_of_actor_id", null: false
+    t.integer  "strategy_action_id",               null: false
+    t.string   "entity_id",             limit: 32, null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.integer  "requested_by_actor_id",            null: false
+    t.integer  "on_behalf_of_actor_id",            null: false
   end
 
   add_index "sipity_processing_entity_action_registers", ["strategy_action_id", "entity_id", "on_behalf_of_actor_id"], name: "sipity_processing_entity_action_registers_on_behalf"
@@ -181,11 +181,11 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_processing_entity_action_registers", ["strategy_action_id", "entity_id"], name: "sipity_processing_entity_action_registers_aggregate"
 
   create_table "sipity_processing_entity_specific_responsibilities", force: :cascade do |t|
-    t.integer  "strategy_role_id", null: false
-    t.integer  "entity_id",        null: false
-    t.integer  "actor_id",         null: false
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.integer  "strategy_role_id",            null: false
+    t.string   "entity_id",        limit: 32, null: false
+    t.integer  "actor_id",                    null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
   end
 
   add_index "sipity_processing_entity_specific_responsibilities", ["actor_id"], name: "sipity_processing_entity_specific_responsibilities_actor"
@@ -297,12 +297,12 @@ ActiveRecord::Schema.define(version: 20150305170338) do
   add_index "sipity_simple_controlled_vocabularies", ["predicate_value_code"], name: "sipity_simple_controlled_vocabularies_predicate_code"
 
   create_table "sipity_transient_answers", force: :cascade do |t|
-    t.integer  "entity_id",     null: false
-    t.string   "entity_type",   null: false
-    t.string   "question_code", null: false
-    t.string   "answer_code",   null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.string   "entity_id",     limit: 32, null: false
+    t.string   "entity_type",              null: false
+    t.string   "question_code",            null: false
+    t.string   "answer_code",              null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   add_index "sipity_transient_answers", ["entity_id", "entity_type", "question_code"], name: "sipity_transient_entity_answers", unique: true
@@ -317,14 +317,18 @@ ActiveRecord::Schema.define(version: 20150305170338) do
 
   add_index "sipity_work_types", ["name"], name: "index_sipity_work_types_on_name", unique: true
 
-  create_table "sipity_works", force: :cascade do |t|
+  create_table "sipity_works", id: false, force: :cascade do |t|
+    t.string   "id",                        limit: 32, null: false
     t.string   "work_publication_strategy"
     t.string   "title"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "work_type",                 null: false
+    t.string   "work_type",                            null: false
   end
 
+  add_index "sipity_works", ["id"], name: "index_sipity_works_on_id", unique: true
+  add_index "sipity_works", ["title"], name: "index_sipity_works_on_title"
+  add_index "sipity_works", ["work_publication_strategy"], name: "index_sipity_works_on_work_publication_strategy"
   add_index "sipity_works", ["work_type"], name: "index_sipity_works_on_work_type"
 
   create_table "users", force: :cascade do |t|

--- a/spec/conversions/sipity/conversions/convert_to_permanent_uri_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_permanent_uri_spec.rb
@@ -7,13 +7,14 @@ module Sipity
 
       context '.call' do
         it 'will call the underlying conversion method' do
-          expect(described_class.call(1234)).to be_a(String)
+          object = double(work_id: 1234)
+          expect(described_class.call(object)).to be_a(String)
         end
       end
 
       context '.convert_to_permanent_uri' do
         it 'will be private' do
-          object = 1234
+          object = double(work_id: 1234)
           expect { described_class.convert_to_permanent_uri(object) }.
             to raise_error(NoMethodError, /private method `convert_to_permanent_uri'/)
         end
@@ -51,9 +52,9 @@ module Sipity
           expect(convert_to_permanent_uri(object)).to match(/1234\Z/)
         end
 
-        it 'converts a Fixnum object (at least until we change that scheme)' do
+        it 'will not convert a Fixnum object (at least until we change that scheme)' do
           object = 1234
-          expect(convert_to_permanent_uri(object)).to match(/1234\Z/)
+          expect { convert_to_permanent_uri(object) }.to raise_error(Exceptions::PermanentUriConversionError)
         end
 
         it 'will raise an exception if the input is not convertable' do

--- a/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
+++ b/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
@@ -77,7 +77,7 @@ Sipity::Models::TransientAnswer.create!([
   {entity_id: 1, entity_type: "Sipity::Models::Work", question_code: "access_rights", answer_code: "private_access"}
 ])
 Sipity::Models::Work.create!([
-  {work_publication_strategy: "do_not_know", title: "Hello World", work_type: "doctoral_dissertation"}
+  {id: 1, work_publication_strategy: "do_not_know", title: "Hello World", work_type: "doctoral_dissertation"}
 ])
 Sipity::Models::WorkType.create!([
   {name: "doctoral_dissertation", description: nil},

--- a/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
+++ b/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
@@ -154,7 +154,7 @@ Sipity::Models::TransientAnswer.create!([
   {entity_id: 1, entity_type: "Sipity::Models::Work", question_code: "access_rights", answer_code: "private_access"}
 ])
 Sipity::Models::Work.create!([
-  {work_publication_strategy: "will_not_publish", title: "Hello", work_type: "doctoral_dissertation"}
+  {id: '1', work_publication_strategy: "will_not_publish", title: "Hello", work_type: "doctoral_dissertation"}
 ])
 Sipity::Models::WorkType.create!([
   {name: "doctoral_dissertation", description: nil}

--- a/spec/forms/sipity/forms/update_work_form_spec.rb
+++ b/spec/forms/sipity/forms/update_work_form_spec.rb
@@ -68,7 +68,7 @@ module Sipity
         # TODO: Make sure the repository is receiving the messages but don't worry about checking
         #   are changes being made.
         let(:user) { User.new(id: '123') }
-        let(:work) { Models::Work.create(title: 'My Title', work_publication_strategy: 'do_not_know') }
+        let(:work) { Models::Work.create!(id: '1', title: 'My Title', work_publication_strategy: 'do_not_know') }
         let(:repository) { CommandRepository.new }
         let(:form) { repository.build_update_work_form(work: work, attributes: { title: 'My New Title', publisher: 'new publisher' }) }
         context 'with invalid data' do

--- a/spec/repositories/sipity/commands/doi_commands_spec.rb
+++ b/spec/repositories/sipity/commands/doi_commands_spec.rb
@@ -64,7 +64,7 @@ module Sipity
         context 'on valid data' do
           let(:publisher) { 'Valid Publisher' }
           it 'will return true having created the DOI request, appended the captured attributes, and loggged the event' do
-            expect(Jobs).to receive(:submit).with('doi_creation_request_job', kind_of(Fixnum))
+            expect(Jobs).to receive(:submit).with('doi_creation_request_job', kind_of(String))
             response = test_repository.submit_request_a_doi_form(form, requested_by: user)
 
             expect(response).to be_truthy

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -9,7 +9,7 @@ module Sipity
       end
 
       context '#destroy_a_work' do
-        let(:work) { Models::Work.new }
+        let(:work) { Models::Work.new(id: '1') }
         it 'will destroy the work in question' do
           work.save! # so it is persisted
           expect { test_repository.destroy_a_work(work: work) }.
@@ -71,10 +71,11 @@ module Sipity
 
       context '#create_work!' do
         let(:attributes) { { title: 'Hello', work_publication_strategy: 'do_not_know', work_type: 'doctoral_dissertation' } }
+        let(:pid_minter) { double(call: '1') }
         it 'will create a work object' do
           expect do
             expect do
-              test_repository.create_work!(attributes)
+              test_repository.create_work!(attributes, pid_minter: pid_minter)
             end.to change { Models::Work.count }.by(1)
           end.to change { Models::Processing::Entity.count }.by(1)
         end
@@ -106,7 +107,7 @@ module Sipity
       end
 
       context '#update_processing_state!' do
-        let(:work) { Models::Work.create! }
+        let(:work) { Models::Work.create!(id: '1') }
         it 'will update update the entity processing state' do
           expect(Services::UpdateEntityProcessingState).to receive(:call)
           test_repository.update_processing_state!(entity: work, to: 'hello')
@@ -116,7 +117,7 @@ module Sipity
       context '#attach_files_to' do
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:user) { User.new(id: 1234) }
-        let(:work) { Models::Work.create! }
+        let(:work) { Models::Work.create!(id: '1') }
         let(:pid_minter) { -> { 'abc123' } }
         it 'will increment the number of attachments in the system' do
           expect { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }.
@@ -128,7 +129,7 @@ module Sipity
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:file_name) { "hello-world.txt" }
         let(:user) { User.new(id: 1234) }
-        let(:work) { Models::Work.create! }
+        let(:work) { Models::Work.create!(id: '1') }
         let(:pid_minter) { -> { 'abc123' } }
         before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will decrease the number of attachments in the system' do
@@ -141,7 +142,7 @@ module Sipity
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:file_name) { "hello-world.txt" }
         let(:user) { User.new(id: 1234) }
-        let(:work) { Models::Work.create! }
+        let(:work) { Models::Work.create!(id: 1) }
         let(:pid_minter) { -> { 'abc123' } }
         before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will change the file name' do
@@ -154,7 +155,7 @@ module Sipity
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:file_name) { "hello-world.txt" }
         let(:user) { User.new(id: 1234) }
-        let(:work) { Models::Work.create! }
+        let(:work) { Models::Work.create!(id: '1') }
         let(:pid_minter) { -> { 'abc123' } }
         before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will mark the given attachments as representative in the system' do

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -11,7 +11,7 @@ module Sipity
       context '#find_or_initialize_attachments' do
         subject { test_repository.find_or_initialize_attachments_by(work: work, pid: '12') }
         it 'will initialize a attachment based on the work id' do
-          expect(subject.work_id).to eq(work.id)
+          expect(subject.work_id).to eq(work.id.to_s)
         end
       end
 

--- a/spec/repositories/sipity/queries/collaborator_queries_spec.rb
+++ b/spec/repositories/sipity/queries/collaborator_queries_spec.rb
@@ -10,7 +10,7 @@ module Sipity
       context '#find_or_initialize_collaborators' do
         subject { test_repository.find_or_initialize_collaborators_by(work: work, id: '12') }
         it 'will initialize a collaborator based on the work id' do
-          expect(subject.work_id).to eq(work.id)
+          expect(subject.work_id).to eq(work.id.to_s)
         end
       end
 

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -120,11 +120,12 @@ module Sipity
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(user: user, proxy_for_type: Sipity::Models::Work)
           ).to eq([work_one, work_two])
 
+          sorter = ->(a, b) { a.id <=> b.id } # Because IDs may not be sorted
           expect(
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
               user: user, proxy_for_type: Sipity::Models::Work, filter: { processing_state: 'new' }
-            )
-          ).to eq([work_one, work_two])
+            ).sort(&sorter)
+          ).to eq([work_one, work_two].sort(&sorter))
 
           expect(
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
@@ -158,7 +159,7 @@ module Sipity
         end
 
         it "will resolve to an array of entities" do
-          work = Models::Work.create!
+          work = Models::Work.create!(id: 1)
           entity = Models::Processing::Entity.find_or_create_by!(proxy_for: work, strategy: strategy, strategy_state: originating_state)
           user_actor = Models::Processing::Actor.find_or_create_by!(proxy_for: user)
           Models::Processing::EntitySpecificResponsibility.find_or_create_by!(

--- a/spec/services/sipity/services/doi_creation_request_metadata_gatherer_spec.rb
+++ b/spec/services/sipity/services/doi_creation_request_metadata_gatherer_spec.rb
@@ -33,7 +33,7 @@ module Sipity
         end
         it 'will collect data from various sources and return a string keyed hash' do
           expect(subject.as_hash).to eq(
-            '_target' => Conversions::ConvertToPermanentUri.call(work.id),
+            '_target' => Conversions::ConvertToPermanentUri.call(work),
             'datacite.title' => work.title,
             'datacite.creator' => creator,
             'datacite.publisher' => publisher,

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -94,7 +94,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def create_work!(attributes = {})
+    def create_work!(attributes = {}, collaborators = {})
     end
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb


### PR DESCRIPTION
## Changing columns to be pids instead of integers

@64ddc3dcdd681e4fd8a7d922ac2eb0d6fb5580dc

Given that we are going to be ingesting both works and attachments
into CurateND, I want the identifiers to be something that can be
treated as a persistent ID.

Also, since I'm using strings and integers for polymorphic relations
I'm instead opting to use strings for those `belongs_to :polymorphic`
definitions.

## Adjusting application logic for PID based keys

@206ed300755ee76edcbed2bcc07c71b0b0b2a22a

This means that creating a work will require that you pass an :id.
The #create_work! can take a PID Minter that will generate the pid
on creation.

Closes #257
