### PR TITLE
Issue #270 - Email should be sent to creating user when the work is first created

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -29,6 +29,7 @@ MethodLength:
   Exclude:
     - app/conversions/**/*.rb
     - 'app/controllers/sipity/controllers/dois_controller.rb'
+    - 'app/forms/sipity/forms/create_work_form.rb'
     - 'app/repositories/sipity/queries/permission_queries.rb'
     - 'app/repositories/sipity/queries/enrichment_queries.rb'
     - 'app/repositories/sipity/queries/processing_queries.rb'

--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -55,6 +55,9 @@ module Sipity
           repository.handle_transient_access_rights_answer(entity: work, answer: f.access_rights_answer)
           repository.update_work_publication_date!(work: work, publication_date: f.publication_date)
           repository.grant_creating_user_permission_for!(entity: work, user: requested_by)
+          repository.send_notification_for_entity_trigger(
+            notification: "confirmation_of_entity_created", entity: work, acting_as: 'creating_user'
+          )
           repository.log_event!(entity: work, user: requested_by, event_name: event_name)
           work
         end

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -12,6 +12,12 @@ module Sipity
         mail(options.slice(:to, :cc, :bcc))
       end
 
+      def confirmation_of_entity_created(options = {})
+        entity = options.fetch(:entity)
+        @entity = options.fetch(:decorator) { Decorators::EmailNotificationDecorator }.new(entity)
+        mail(options.slice(:to, :cc, :bcc))
+      end
+
       def request_revision_from_creator(entity:, to:, cc: [], bcc: [])
         @entity = convert_entity_into_decorator(entity)
         mail(to: to, cc: cc, bcc: bcc)

--- a/app/views/sipity/mailers/email_notifier/confirmation_of_entity_created.html.erb
+++ b/app/views/sipity/mailers/email_notifier/confirmation_of_entity_created.html.erb
@@ -1,0 +1,14 @@
+Dear author,
+<p>Welcome to the Electronic Thesis and Dissertation (ETD) submission site. You have begun a formal submission for the following document:</p>
+
+<dl>
+  <dd> Title: </dd> <dt>@entity.title</dt>
+  <dd> Submission Type: </dd> <dt>@entity.document_type</dt>
+</dl>
+
+<p>To access your ETD record, please use the following URL:  <%= @entity.review_link %></p>
+
+<p>After you’ve completed the descriptive information and uploaded your file(s), be sure to click the “Submit” button to begin the final review process. Please note: you will be unable to edit the record while it is under review. </p>
+<p>If you have questions about your ETD record or the other submission materials, please contact me or my assistant at <a href="mailto:dteditor@nd.edu">dteditor@nd.edu</a> or 574-631-7545 for assistance.</p>
+
+<%= render partial: 'grad_school_email_signature' %>

--- a/spec/forms/sipity/forms/create_work_form_spec.rb
+++ b/spec/forms/sipity/forms/create_work_form_spec.rb
@@ -95,12 +95,27 @@ module Sipity
         context 'with valid data' do
           let(:user) { User.new(id: '123') }
           let(:work) { double }
+          before do
+            expect(subject).to receive(:valid?).and_return(true)
+          end
           it 'will return the work having created the work, added the attributes,
               assigned collaborators, assigned permission, and loggged the event' do
-            allow(subject).to receive(:valid?).and_return(true)
             expect(repository).to receive(:create_work!).and_return(work)
             response = subject.submit(repository: repository, requested_by: user)
             expect(response).to eq(work)
+          end
+
+          it 'will log the event' do
+            expect(repository).to receive(:log_event!).and_call_original
+            subject.submit(repository: repository, requested_by: user)
+          end
+
+          it 'will send emails to the creating user' do
+            expect(repository).to receive(:create_work!).and_return(work)
+            expect(repository).to receive(:send_notification_for_entity_trigger).
+              with(notification: 'confirmation_of_entity_created', entity: work, acting_as: 'creating_user').
+              and_call_original
+            subject.submit(repository: repository, requested_by: user)
           end
         end
       end

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -19,6 +19,19 @@ module Sipity
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
+      context '#confirmation_of_entity_created' do
+        let(:entity) { double('Hello') }
+        let(:decorated) do
+          double(title: 'A title', review_link: "link to work show", document_type: "A document_type")
+        end
+        let(:decorator) { double(new: decorated) }
+        let(:to) { 'test@example.com' }
+        it 'should send an email' do
+          described_class.confirmation_of_entity_created(entity: entity, to: to, decorator: decorator).deliver_now
+
+          expect(ActionMailer::Base.deliveries.count).to eq(1)
+        end
+      end
       context '#request_revision_from_creator' do
         let(:entity) { Models::Work.new }
         let(:to) { 'test@example.com' }


### PR DESCRIPTION
Send notification to creating user when creating a work
Add email notifier method and script for confirmation_of_entity_created
Spec to verify nofication on create form and verify notifier sends email
Closes #270