### PR TITLE
Working on email notification behavior

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_work.rb
+++ b/app/conversions/sipity/conversions/convert_to_work.rb
@@ -1,0 +1,44 @@
+module Sipity
+  module Conversions
+    # Exposes a conversion method to take an input and transform it into a
+    # Sipity::Models::Work object.
+    #
+    # @see Sipity::Conversions for conventions regarding a conversion method
+    module ConvertToWork
+      # A convenience method so that you don't need to include the conversion
+      # module in your base class.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Sipity::Models::Work (or something that followsto the Liskov
+      #   Substitution Principle
+      #   http://en.wikipedia.org/wiki/Liskov_substitution_principle)
+      #
+      # @see #convert_to_work
+      def self.call(input)
+        convert_to_work(input)
+      end
+
+      # Does its best to convert the input into a Sipity::Models::Work object.
+      #
+      # @param input [Object] something coercable
+      #
+      # @return Sipity::Models::Work (or something that followsto the Liskov
+      #   Substitution Principle
+      #   http://en.wikipedia.org/wiki/Liskov_substitution_principle)
+      #
+      # @raise Exceptions::WorkConversionError
+      def convert_to_work(input)
+        return input.to_work if input.respond_to?(:to_work)
+        return input.work if input.respond_to?(:work)
+        return input if input.is_a?(Models::Work)
+        return convert_to_work(input.proxy_for) if input.respond_to?(:proxy_for)
+        fail Exceptions::WorkConversionError, input
+      end
+
+      module_function :convert_to_work
+      private_class_method :convert_to_work
+      private :convert_to_work
+    end
+  end
+end

--- a/app/decorators/sipity/decorators/email_notification_decorator.rb
+++ b/app/decorators/sipity/decorators/email_notification_decorator.rb
@@ -4,16 +4,25 @@ module Sipity
     class EmailNotificationDecorator < ApplicationDecorator
       # TODO
       # Add implementations to the methods
+      #
+      # TODO: The differences between work and processing entity are getting
+      #   confusing. Need to address that behavior to help provide clarity.
       def self.object_class
         Models::Work
       end
 
-      alias_method :entity, :object
+      def initialize(object, *args)
+        work = convert_decorated_object_to_work(object)
+        super(work, *args)
+      end
 
+      alias_method :entity, :object
+      deprecate :entity
+      alias_method :work, :object
       delegate_all
 
       def document_type
-        entity.work_type.humanize
+        work.work_type.humanize
       end
 
       def director
@@ -33,7 +42,7 @@ module Sipity
       end
 
       def work_show_path
-        view_context.work_url(entity)
+        view_context.work_url(work)
       end
 
       alias_method :review_link, :work_show_path
@@ -42,7 +51,7 @@ module Sipity
       end
 
       def creators
-        @creators ||= repository.scope_users_for_entity_and_roles(entity: entity, roles: Models::Role::CREATING_USER)
+        @creators ||= repository.scope_users_for_entity_and_roles(entity: work, roles: Models::Role::CREATING_USER)
       end
 
       def creator_names
@@ -66,7 +75,7 @@ module Sipity
       end
 
       def access_rights
-        Array.wrap(repository.work_access_right_codes(work: entity)).map(&:titleize).to_sentence
+        Array.wrap(repository.work_access_right_codes(work: work)).map(&:titleize).to_sentence
       end
 
       def will_be_released_to_the_public?
@@ -76,6 +85,10 @@ module Sipity
 
       def view_context
         Draper::ViewContext.current
+      end
+
+      def convert_decorated_object_to_work(object)
+        object.respond_to?(:work) && object.work.present? ? object.work : work
       end
     end
   end

--- a/app/decorators/sipity/decorators/email_notification_decorator.rb
+++ b/app/decorators/sipity/decorators/email_notification_decorator.rb
@@ -11,8 +11,9 @@ module Sipity
         Models::Work
       end
 
+      include Conversions::ConvertToWork
       def initialize(object, *args)
-        work = convert_decorated_object_to_work(object)
+        work = convert_to_work(object)
         super(work, *args)
       end
 
@@ -85,10 +86,6 @@ module Sipity
 
       def view_context
         Draper::ViewContext.current
-      end
-
-      def convert_decorated_object_to_work(object)
-        object.respond_to?(:work) && object.work.present? ? object.work : work
       end
     end
   end

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -97,6 +97,11 @@ module Sipity
       self.conversion_target = 'Models::Processing::StrategyAction#name'
     end
 
+    # Unable to convert the given object into a work.
+    class WorkConversionError < ProcessingConversionError
+      self.conversion_target = 'Models::Work'
+    end
+
     # As you are looking up something by name, within a given container.
     class ConceptNotFoundError < RuntimeError
       def initialize(name:, container:)

--- a/app/mailers/sipity/mailers/email_notifier.rb
+++ b/app/mailers/sipity/mailers/email_notifier.rb
@@ -29,6 +29,12 @@ module Sipity
         mail(options.slice(:to, :cc, :bcc))
       end
 
+      def ready_for_grad_school_review(options = {})
+        entity = options.fetch(:entity)
+        @entity = options.fetch(:decorator) { Decorators::EmailNotificationDecorator }.new(entity)
+        mail(options.slice(:to, :cc, :bcc))
+      end
+
       def entity_ready_for_cataloging(entity:, to:, cc: [], bcc: [])
         @entity = convert_entity_into_decorator(entity)
         mail(to: to, cc: cc, bcc: bcc)

--- a/app/services/sipity/services/advisor_signs_off.rb
+++ b/app/services/sipity/services/advisor_signs_off.rb
@@ -31,7 +31,7 @@ module Sipity
       def handle_last_advisor_signoff
         repository.update_processing_state!(entity: form, to: form.resulting_strategy_state)
         repository.send_notification_for_entity_trigger(
-          notification: 'entity_ready_for_review', entity: form, acting_as: 'etd_reviewer'
+          notification: 'ready_for_grad_school_review', entity: form, acting_as: 'etd_reviewer'
         )
         repository.send_notification_for_entity_trigger(
           notification: 'all_advisors_have_signed_off', entity: form, acting_as: 'creating_user'

--- a/app/views/sipity/mailers/email_notifier/ready_for_grad_school_review.html.erb
+++ b/app/views/sipity/mailers/email_notifier/ready_for_grad_school_review.html.erb
@@ -1,0 +1,20 @@
+<p><%= @entity.title %> (<%= @entity.document_type %>) by <%= @entity.creator_names %> is ready for Grad School Review at <%= link_to @entity.review_link, @entity.review_link %></p>
+<p>
+  All advisors have signed off (see the list below).
+  <ul>
+    <% @entity.collaborators.each do |advisor| %>
+      <li>
+        <dl>
+          <dt>Name:</dt>
+          <dd><%= advisor.name %></dd>
+          <dt>NetID:</dt>
+          <dd><%= advisor.netid %></dd>
+          <dt>Email:</dt>
+          <dd><%= advisor.email %></dd>
+          <dt>Role:</dt>
+          <dd><%= advisor.role %></dd>
+        </dl>
+      </li>
+    <% end %>
+  </ul>
+</p>

--- a/spec/conversions/sipity/conversions/convert_to_work_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_work_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+module Sipity
+  module Conversions
+    describe ConvertToWork do
+      include ::Sipity::Conversions::ConvertToWork
+
+      context '.call' do
+        it 'will call the underlying conversion method' do
+          object = Models::Work.new
+          expect(described_class.call(object)).to eq(object)
+        end
+      end
+
+      context '.convert_to_work' do
+        it 'will be private' do
+          object = double(to_processing_entity: 1234)
+          expect { described_class.convert_to_work(object) }.
+            to raise_error(NoMethodError, /private method `convert_to_work'/)
+        end
+      end
+
+      context '#call' do
+        it 'will not be implemented' do
+          expect(self).to_not respond_to(:call)
+        end
+      end
+
+      context '#convert_to_work' do
+        it 'will be a private instance method' do
+          expect(self.class.private_instance_methods).to include(:convert_to_work)
+        end
+
+        it 'will return the object if it is a Models::Work' do
+          object = Models::Work.new
+          expect(convert_to_work(object)).to eq(object)
+        end
+
+        it 'will attempt to convert the proxied object' do
+          work = Models::Work.new
+          proxy = double(proxy_for: work)
+          expect(convert_to_work(proxy)).to eq(work)
+        end
+
+        it 'will return the object there is a #to_work method' do
+          work = Models::Work.new
+          proxy = double(to_work: work)
+          expect(convert_to_work(proxy)).to eq(work)
+        end
+
+        it 'will return the object there is a #work method' do
+          work = Models::Work.new
+          proxy = double(work: work)
+          expect(convert_to_work(proxy)).to eq(work)
+        end
+
+        it 'will raise an error if it cannot convert' do
+          object = double
+          expect { convert_to_work(object) }.to raise_error(Exceptions::WorkConversionError)
+        end
+      end
+    end
+  end
+end

--- a/spec/decorators/sipity/decorators/email_notification_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/email_notification_decorator_spec.rb
@@ -4,7 +4,8 @@ module Sipity
   module Decorators
     RSpec.describe EmailNotificationDecorator do
       let(:repository) { QueryRepositoryInterface.new }
-      let(:entity) { Models::Work.new(id: '123', work_type: 'doctoral_dissertation', title: 'A title') }
+      let(:work) { Models::Work.new(id: '123', work_type: 'doctoral_dissertation', title: 'A title') }
+      let(:entity) { double(work: work) }
 
       subject { described_class.new(entity, repository: repository) }
 
@@ -30,9 +31,14 @@ module Sipity
         expect(EmailNotificationDecorator.object_class).to eq(Models::Work)
       end
 
-      its(:document_type) { should eq(entity.work_type.humanize) }
+      its(:document_type) { should eq(work.work_type.humanize) }
 
-      its(:title) { should eq entity.title }
+      its(:title) { should eq work.title }
+
+      it 'will coerce the input into a work' do
+        decorator = described_class.new(entity, repository: repository)
+        expect(decorator.object).to eq(work)
+      end
 
       it 'will have a #work_show_path' do
         expect(subject.work_show_path).to be_a(String)

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -33,7 +33,7 @@ module Sipity
         end
       end
       context '#request_revision_from_creator' do
-        let(:entity) { Models::Work.new }
+        let(:entity) { Models::Work.new(id: '123') }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
           described_class.request_revision_from_creator(entity: entity, to: to).deliver_now
@@ -42,7 +42,7 @@ module Sipity
         end
       end
       context '#entity_ready_for_cataloging' do
-        let(:entity) { Models::Work.new }
+        let(:entity) { Models::Work.new(id: '123') }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
           described_class.entity_ready_for_cataloging(entity: entity, to: to).deliver_now
@@ -51,7 +51,7 @@ module Sipity
         end
       end
       context '#request_revision_from_creator' do
-        let(:entity) { Models::Work.new }
+        let(:entity) { Models::Work.new(id: '123') }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
           described_class.request_revision_from_creator(entity: entity, to: to).deliver_now
@@ -73,8 +73,18 @@ module Sipity
           expect(ActionMailer::Base.deliveries.count).to eq(1)
         end
       end
+
+      context '#ready_for_grad_school_review' do
+        let(:entity) { Models::Work.create!(id: '123') }
+        let(:to) { 'test@example.com' }
+        it 'should send an email' do
+          entity.create_processing_entity!(strategy_id: '1', strategy_state_id: '1')
+          described_class.ready_for_grad_school_review(entity: entity, to: to).deliver_now
+          expect(ActionMailer::Base.deliveries.count).to eq(1)
+        end
+      end
       context '#entity_ready_for_cataloging' do
-        let(:entity) { Models::Work.new }
+        let(:entity) { Models::Work.new(id: '123') }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
           described_class.entity_ready_for_cataloging(entity: entity, to: to).deliver_now
@@ -114,7 +124,7 @@ module Sipity
         end
       end
       context '#grad_school_requests_change' do
-        let(:entity) { Models::Work.new }
+        let(:entity) { Models::Work.new(id: '123') }
         let(:to) { 'test@example.com' }
         it 'should send an email' do
           described_class.grad_school_requests_change(entity: entity, to: to).deliver_now

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -35,7 +35,7 @@ module Sipity
         end
         it 'will send emails to the etd_reviewers and creating user' do
           expect(repository).to receive(:send_notification_for_entity_trigger).
-            with(notification: 'entity_ready_for_review', entity: form, acting_as: 'etd_reviewer')
+            with(notification: 'ready_for_grad_school_review', entity: form, acting_as: 'etd_reviewer')
           expect(repository).to receive(:send_notification_for_entity_trigger).
             with(notification: 'all_advisors_have_signed_off', entity: form, acting_as: 'creating_user')
           subject.call


### PR DESCRIPTION
## Factoring towards more sane email decoration

@b71deed80cada0aed5f217e3646eaa513e056b18

The current solution is a bit confusing. This is a first step to
clarify that most emails are related to the given work.

## Adding Conversion::ConvertToWork

@982458da33740e4346266d004be9064b7269525a

Given that I am always working with polymrophic things and composed
objects, I want a means of getting an object's work.

## Leveraging Conversions::ConvertToWork

@c02e07f13a8a4a370988d7641b0a4727da2a5e4c

Instead of the localized method, rely on a more centralized converter.

## Adding email for ready_for_grad_school_review

@2cbb06270e3cd4ef1e6165ea8fe20f3c0e394205

The email that was previously being sent was confusing as it was
related to an incorrect state.

Closes #273
