### PR TITLE
Adding build task to validate I18n files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ end
 if defined?(RSpec)
   namespace :spec do
     desc "Run all specs"
-    RSpec::Core::RakeTask.new(all: 'sipity:rebuild_interfaces') do
+    RSpec::Core::RakeTask.new(all: ['sipity:rebuild_interfaces', 'sipity:verify_i18n']) do
       ENV['COVERAGE'] = 'true'
     end
 
@@ -58,6 +58,7 @@ if defined?(RSpec)
 
   Rake::Task["default"].clear
   task default: ['db:schema:load', 'rubocop', 'spec:all']
+  task spec: ['sipity:rebuild_interfaces']
   task stats: ['sipity:stats_setup']
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,7 +18,6 @@
 #
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   activemodel:
     attributes:

--- a/lib/tasks/sipity.rake
+++ b/lib/tasks/sipity.rake
@@ -1,5 +1,13 @@
 namespace :sipity do
 
+  desc 'Verify i18n translation files are valid yaml'
+  task verify_i18n: :environment do
+    @load_errors = []
+    Dir.glob(Rails.root.join('config/locales/**/*.yml').to_s).each do |filename|
+      Psych.load_file(filename)
+    end
+  end
+
   desc 'Create a user based on $USER'
   task environment_bootstrapper: :environment do
     load(Rails.root.join('config/environment_bootstrapper.rb'))


### PR DESCRIPTION
> We bypass I18n in the test suite to speed things up but we depend
> on it a lot for the application. This is ordinarily fine but
> introduces some risk.
>
> For example @78cb09d introduced a syntax error into the YAML file
> but it did not cause any tests or validations to fail. This kept the
> build passing but the application could no longer render any pages.
>
> From #290

Closes #290