### PR TITLE
Adding PresentationSequence to strategy_actions

### DIFF
--- a/app/models/sipity/models/processing/strategy_action.rb
+++ b/app/models/sipity/models/processing/strategy_action.rb
@@ -4,6 +4,7 @@ module Sipity
       # A named thing that "happens" to a processing entity.
       class StrategyAction < ActiveRecord::Base
         self.table_name = 'sipity_processing_strategy_actions'
+        default_scope { order(:presentation_sequence) }
         belongs_to :strategy
         belongs_to :resulting_strategy_state, class_name: 'StrategyState'
 

--- a/db/migrate/20150311145535_adding_presentation_sequence_to_strategy_action.rb
+++ b/db/migrate/20150311145535_adding_presentation_sequence_to_strategy_action.rb
@@ -1,0 +1,6 @@
+class AddingPresentationSequenceToStrategyAction < ActiveRecord::Migration
+  def change
+    add_column "sipity_processing_strategy_actions", "presentation_sequence", :integer
+    add_index "sipity_processing_strategy_actions", ["strategy_id", "presentation_sequence"], name: "sipity_processing_strategy_actions_sequence"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150305170338) do
+ActiveRecord::Schema.define(version: 20150311145535) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.string   "entity_id",         limit: 32, null: false
@@ -223,11 +223,13 @@ ActiveRecord::Schema.define(version: 20150305170338) do
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false
     t.string   "action_type",                                 null: false
+    t.integer  "presentation_sequence"
   end
 
   add_index "sipity_processing_strategy_actions", ["action_type"], name: "index_sipity_processing_strategy_actions_on_action_type"
   add_index "sipity_processing_strategy_actions", ["resulting_strategy_state_id"], name: "sipity_processing_strategy_actions_resulting_strategy_state"
   add_index "sipity_processing_strategy_actions", ["strategy_id", "name"], name: "sipity_processing_strategy_actions_aggregate", unique: true
+  add_index "sipity_processing_strategy_actions", ["strategy_id", "presentation_sequence"], name: "sipity_processing_strategy_actions_sequence"
 
   create_table "sipity_processing_strategy_responsibilities", force: :cascade do |t|
     t.integer  "actor_id",         null: false


### PR DESCRIPTION
> Given that certain required tasks make "more sense" to be done
> first, we need to specify a presentation sequence order. This will
> ensure that rendered todo list actions come back in the same order.
> It will also ensure that we have control over the sequence of state
> advancing buttons, etc.

Closes #294