### PR TITLE
Capistrano should take BRANCH_NAME for deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,7 +10,7 @@ set :bundle_without, %w{development test doc}.join(' ')
 set :application, 'sipity'
 set :scm, :git
 set :repo_url, "https://github.com/ndlib/sipity.git"
-set :branch, ENV['BRANCH'] || 'master'
+set :branch, ENV['BRANCH_NAME'] || 'master'
 set :keep_releases, 5
 set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 set :secret_repo_name, Proc.new{

--- a/config/deploy/pre_production.rb
+++ b/config/deploy/pre_production.rb
@@ -13,7 +13,7 @@
 
 SSHKit.config.command_map[:bundle] = '/opt/ruby/current/bin/bundle'
 SSHKit.config.command_map[:rake] = "#{fetch(:bundle)} exec rake"
-set :branch,    'master'
+set :branch,    ENV["BRANCH_NAME"] || 'master'
 set :rails_env, 'pre_production'
 set :deploy_to, '/home/app/sipity'
 set :user,      'app'


### PR DESCRIPTION
BRANCH_NAME env is required to deploy a branch