### PR TITLE
Ensuring we only attempt to persist user input

### DIFF
--- a/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/collaborator_form_spec.rb
@@ -92,7 +92,9 @@ module Sipity
             end
 
             it 'will create a collaborator' do
-              expect(repository).to receive(:manage_collaborators_for).and_call_original
+              expect(repository).to receive(:manage_collaborators_for).
+                with(work: work, collaborators: subject.send(:collaborators_from_input)).
+                and_call_original
               subject.submit(requested_by: user)
             end
           end


### PR DESCRIPTION
There were a few moving parts in this; First we want to make sure that
we are always rendering enough input fields for the user. Second, due
to changes in how we render collaborators on the form, there was an
unintended side-effect of attempting to persist those collaborators
via the repository.

The solution is to explicitly persist the collaborators_from_input
to the repository; Hence the name changes.

Also clarifying the intent of a guard method:

```ruby
reject_because_an_empty_row_was_submitted_via_user_input?
```

The above method I believe is more clear in its intent.

Closes #311