### PR TITLE
Signoff on behalf of fails to advance if it is the last person 252

### DIFF
--- a/app/forms/sipity/forms/etd/signoff_on_behalf_of_form.rb
+++ b/app/forms/sipity/forms/etd/signoff_on_behalf_of_form.rb
@@ -34,12 +34,20 @@ module Sipity
         end
 
         def save(requested_by:)
-          repository.register_action_taken_on_entity(
-            work: work, enrichment_type: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of_collaborator
-          )
+          register_the_actions(requested_by: requested_by)
           repository.log_event!(entity: work, user: requested_by, event_name: event_name)
           signoff_service.call(form: self, requested_by: requested_by, repository: repository)
           work
+        end
+
+        RELATED_ACTION_FOR_SIGNOFF = 'advisor_signoff'
+        def register_the_actions(requested_by:)
+          repository.register_action_taken_on_entity(
+            work: work, enrichment_type: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of_collaborator
+          )
+          @registered_action = repository.register_action_taken_on_entity(
+            work: work, enrichment_type: RELATED_ACTION_FOR_SIGNOFF, requested_by: requested_by, on_behalf_of: on_behalf_of_collaborator
+          )
         end
 
         def default_signoff_service

--- a/spec/forms/sipity/forms/etd/signoff_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/signoff_on_behalf_of_form_spec.rb
@@ -65,10 +65,16 @@ module Sipity
             allow(subject).to receive(:valid?).and_return(true)
           end
 
-          it 'will register_action_taken_on_entity' do
+          it 'will registered the action and related action' do
             expect(repository).to receive(:register_action_taken_on_entity).
               with(work: work, enrichment_type: 'signoff_on_behalf_of', requested_by: user, on_behalf_of: on_behalf_of_collaborator).
               and_call_original
+            expect(repository).to receive(:register_action_taken_on_entity).with(
+              work: work,
+              enrichment_type: described_class::RELATED_ACTION_FOR_SIGNOFF,
+              requested_by: user,
+              on_behalf_of: on_behalf_of_collaborator
+            ).and_call_original
             subject.submit(requested_by: user)
           end
 

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -411,27 +411,33 @@ module Sipity
             name: 'groupy', netid: groupy.username, responsible_for_review: true, role: 'Committee Member', work_id: entity.proxy_for_id
           )
 
+          not_yet_acted_collaborator = Models::Collaborator.create!(
+            name: 'not_yet_acted_collaborator',
+            email: 'not_yet_acted_collaborator@gmail.com',
+            responsible_for_review: true,
+            role: 'Committee Member',
+            work_id: entity.proxy_for_id
+          )
           Models::GroupMembership.create(user_id: groupy.id, group_id: group.id)
 
           [
-            user, non_acting_user, other_user, groupy, user_acting_collaborator, acting_via_email_collaborator
+            user, non_acting_user, other_user, groupy, user_acting_collaborator, acting_via_email_collaborator, not_yet_acted_collaborator
           ].each do |proxy_for_actor|
             Conversions::ConvertToProcessingActor.call(proxy_for_actor)
           end
 
           Models::Collaborator.create!(
-            name: 'non_acting',
-            email: 'non_acting@gmail.com',
-            responsible_for_review: true,
-            role: 'Committee Member',
-            work_id: entity.proxy_for_id
+            name: 'non_reviewing', role: 'Committee Member', responsible_for_review: false, work_id: entity.proxy_for_id
           )
-          Models::Collaborator.create!(name: 'non_reviewing', role: 'Committee Member', work_id: entity.proxy_for_id)
           Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
           Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
           Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: acting_via_email_collaborator)
           expect(subject.pluck(:name)).to eq(
-            [user_acting_collaborator.name, acting_via_email_collaborator.name, group_collaborator.name]
+            [
+              user_acting_collaborator.name,
+              acting_via_email_collaborator.name,
+              group_collaborator.name
+            ]
           )
         end
         it "will be a chainable scope" do

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -13,6 +13,10 @@ module Sipity
     def accessible_objects(work:)
     end
 
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def action_registers_subquery_builder(poly_type:, entity:, action:)
+    end
+
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def amend_files_metadata(work:, user:, metadata: {})
     end
@@ -195,6 +199,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def mark_as_representative(work:, pid:, user: user)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def non_user_collaborators_that_have_taken_the_action_on_the_entity(entity:, action:)
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -14,6 +14,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def action_registers_subquery_builder(poly_type:, entity:, action:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
     def authorized_for_processing?(user:, entity:, action:)
     end
 
@@ -119,6 +123,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
     def get_controlled_vocabulary_values_for_predicate_name(name:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def non_user_collaborators_that_have_taken_the_action_on_the_entity(entity:, action:)
     end
 
     # @see ./app/repositories/sipity/queries/attachment_queries.rb


### PR DESCRIPTION
## Ensuring that Signoff on Behalf advances state

@35a64eb748b6221d022136e8f20803b4d62a5bd1

Given that two separate actions are being called, I need to ensure
that both the actual action (Signoff on Behalf) is registered and
the related action (Advisor Signoff) is registered. Without both of
those, the state advancement query won't work without other crazy
data modifications.

## Normalizing Group, User, Collaborator queries

@a02ced7a5e6c0e79086679e1eb1238ee50a177b5

Prior to this commit, any collaborator that was identified by email
was always considered to have taken the given action.

This commit makes sure the same logic for determining if a user has
taken an action is applied to the has a non-user collaborator taken
the action.

Closes #252
