### PR TITLE
Signoff on behalf of fails to advance if it is the last person

### DIFF
--- a/app/conversions/sipity/conversions/convert_to_processing_action.rb
+++ b/app/conversions/sipity/conversions/convert_to_processing_action.rb
@@ -7,11 +7,13 @@ module Sipity
       end
 
       def convert_to_processing_action(object, scope:)
+        strategy_id = ConvertToProcessingStrategyId.call(scope)
         if object.is_a?(Models::Processing::StrategyAction)
-          strategy_id = ConvertToProcessingStrategyId.call(scope)
           return object if object.strategy_id == strategy_id
+        elsif object.respond_to?(:to_processing_action)
+          strategy_action = object.to_processing_action
+          return strategy_action if strategy_action.present?
         elsif object.is_a?(String) || object.is_a?(Symbol)
-          strategy_id = ConvertToProcessingStrategyId.call(scope)
           strategy_action = Models::Processing::StrategyAction.find_by(strategy_id: strategy_id, name: object.to_s)
           return strategy_action if strategy_action.present?
         end

--- a/app/forms/sipity/forms/etd/signoff_on_behalf_of_form.rb
+++ b/app/forms/sipity/forms/etd/signoff_on_behalf_of_form.rb
@@ -34,12 +34,20 @@ module Sipity
         end
 
         def save(requested_by:)
-          repository.register_action_taken_on_entity(
-            work: work, enrichment_type: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of_collaborator
-          )
+          register_the_actions(requested_by: requested_by)
           repository.log_event!(entity: work, user: requested_by, event_name: event_name)
           signoff_service.call(form: self, requested_by: requested_by, repository: repository)
           work
+        end
+
+        RELATED_ACTION_FOR_SIGNOFF = 'advisor_signoff'
+        def register_the_actions(requested_by:)
+          repository.register_action_taken_on_entity(
+            work: work, enrichment_type: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of_collaborator
+          )
+          @registered_action = repository.register_action_taken_on_entity(
+            work: work, enrichment_type: RELATED_ACTION_FOR_SIGNOFF, requested_by: requested_by, on_behalf_of: on_behalf_of_collaborator
+          )
         end
 
         def default_signoff_service

--- a/app/models/sipity/models/processing/entity_action_register.rb
+++ b/app/models/sipity/models/processing/entity_action_register.rb
@@ -13,6 +13,9 @@ module Sipity
         belongs_to :strategy_action
         belongs_to :requested_by_actor, class_name: 'Sipity::Models::Processing::Actor'
         belongs_to :on_behalf_of_actor, class_name: 'Sipity::Models::Processing::Actor'
+
+        alias_method :to_processing_action, :strategy_action
+        alias_method :to_processing_entity, :entity
       end
     end
   end

--- a/app/services/sipity/services/advisor_signs_off.rb
+++ b/app/services/sipity/services/advisor_signs_off.rb
@@ -50,7 +50,7 @@ module Sipity
       end
 
       def collaborators_that_have_taken_the_action_on_the_entity
-        repository.collaborators_that_have_taken_the_action_on_the_entity(entity: form.work, action: form.action)
+        repository.collaborators_that_have_taken_the_action_on_the_entity(entity: form.work, action: form.registered_action)
       end
     end
   end

--- a/spec/conversions/sipity/conversions/convert_to_processing_action_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_action_spec.rb
@@ -38,6 +38,11 @@ module Sipity
             expect(convert_to_processing_action(action, scope: strategy_id)).to eq(action)
           end
 
+          it 'will return the object if it responds to #to_processing_action' do
+            object = double(to_processing_action: action)
+            expect(convert_to_processing_action(object, scope: strategy_id)).to eq(action)
+          end
+
           it 'will raise an error if it cannot convert the object' do
             object = double
             expect { convert_to_processing_action(object, scope: strategy_id) }.

--- a/spec/forms/sipity/forms/etd/signoff_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/etd/signoff_on_behalf_of_form_spec.rb
@@ -65,10 +65,16 @@ module Sipity
             allow(subject).to receive(:valid?).and_return(true)
           end
 
-          it 'will register_action_taken_on_entity' do
+          it 'will registered the action and related action' do
             expect(repository).to receive(:register_action_taken_on_entity).
               with(work: work, enrichment_type: 'signoff_on_behalf_of', requested_by: user, on_behalf_of: on_behalf_of_collaborator).
               and_call_original
+            expect(repository).to receive(:register_action_taken_on_entity).with(
+              work: work,
+              enrichment_type: described_class::RELATED_ACTION_FOR_SIGNOFF,
+              requested_by: user,
+              on_behalf_of: on_behalf_of_collaborator
+            ).and_call_original
             subject.submit(requested_by: user)
           end
 

--- a/spec/models/sipity/models/processing/entity_action_register_spec.rb
+++ b/spec/models/sipity/models/processing/entity_action_register_spec.rb
@@ -4,11 +4,19 @@ module Sipity
   module Models
     module Processing
       RSpec.describe EntityActionRegister, type: :model do
-        subject { described_class }
-        its(:column_names) { should include("strategy_action_id") }
-        its(:column_names) { should include("entity_id") }
-        its(:column_names) { should include("on_behalf_of_actor_id") }
-        its(:column_names) { should include("requested_by_actor_id") }
+        context 'class configuration' do
+          subject { described_class }
+          its(:column_names) { should include("strategy_action_id") }
+          its(:column_names) { should include("entity_id") }
+          its(:column_names) { should include("on_behalf_of_actor_id") }
+          its(:column_names) { should include("requested_by_actor_id") }
+        end
+
+        context 'conversions methods' do
+          subject { described_class.new }
+          it { should respond_to :to_processing_action }
+          it { should respond_to :to_processing_entity }
+        end
       end
     end
   end

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -411,27 +411,33 @@ module Sipity
             name: 'groupy', netid: groupy.username, responsible_for_review: true, role: 'Committee Member', work_id: entity.proxy_for_id
           )
 
+          not_yet_acted_collaborator = Models::Collaborator.create!(
+            name: 'not_yet_acted_collaborator',
+            email: 'not_yet_acted_collaborator@gmail.com',
+            responsible_for_review: true,
+            role: 'Committee Member',
+            work_id: entity.proxy_for_id
+          )
           Models::GroupMembership.create(user_id: groupy.id, group_id: group.id)
 
           [
-            user, non_acting_user, other_user, groupy, user_acting_collaborator, acting_via_email_collaborator
+            user, non_acting_user, other_user, groupy, user_acting_collaborator, acting_via_email_collaborator, not_yet_acted_collaborator
           ].each do |proxy_for_actor|
             Conversions::ConvertToProcessingActor.call(proxy_for_actor)
           end
 
           Models::Collaborator.create!(
-            name: 'non_acting',
-            email: 'non_acting@gmail.com',
-            responsible_for_review: true,
-            role: 'Committee Member',
-            work_id: entity.proxy_for_id
+            name: 'non_reviewing', role: 'Committee Member', responsible_for_review: false, work_id: entity.proxy_for_id
           )
-          Models::Collaborator.create!(name: 'non_reviewing', role: 'Committee Member', work_id: entity.proxy_for_id)
           Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
           Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
           Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: acting_via_email_collaborator)
           expect(subject.pluck(:name)).to eq(
-            [user_acting_collaborator.name, acting_via_email_collaborator.name, group_collaborator.name]
+            [
+              user_acting_collaborator.name,
+              acting_via_email_collaborator.name,
+              group_collaborator.name
+            ]
           )
         end
         it "will be a chainable scope" do

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -67,7 +67,7 @@ module Sipity
       end
 
       context 'default repository' do
-        let(:form) { double('Form', resulting_strategy_state: 'chubacabra', action: 'submit_for_review', work: double) }
+        let(:form) { double('Form', resulting_strategy_state: 'chubacabra', registered_action: 'submit_for_review', work: double) }
         subject { described_class.new(form: form, requested_by: requested_by) }
         it 'exposes #collaborators_that_have_taken_the_action_on_the_entity' do
           expect(subject.send(:repository)).to receive(:collaborators_that_have_taken_the_action_on_the_entity)

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -13,6 +13,10 @@ module Sipity
     def accessible_objects(work:)
     end
 
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def action_registers_subquery_builder(poly_type:, entity:, action:)
+    end
+
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def amend_files_metadata(work:, user:, metadata: {})
     end
@@ -195,6 +199,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def mark_as_representative(work:, pid:, user: user)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def non_user_collaborators_that_have_taken_the_action_on_the_entity(entity:, action:)
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -14,6 +14,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def action_registers_subquery_builder(poly_type:, entity:, action:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
     def authorized_for_processing?(user:, entity:, action:)
     end
 
@@ -119,6 +123,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
     def get_controlled_vocabulary_values_for_predicate_name(name:)
+    end
+
+    # @see ./app/repositories/sipity/queries/processing_queries.rb
+    def non_user_collaborators_that_have_taken_the_action_on_the_entity(entity:, action:)
     end
 
     # @see ./app/repositories/sipity/queries/attachment_queries.rb


### PR DESCRIPTION
## Ensuring that Signoff on Behalf advances state

@35a64eb748b6221d022136e8f20803b4d62a5bd1

Given that two separate actions are being called, I need to ensure
that both the actual action (Signoff on Behalf) is registered and
the related action (Advisor Signoff) is registered. Without both of
those, the state advancement query won't work without other crazy
data modifications.

## Normalizing Group, User, Collaborator queries

@08d342d7a4c808bb8a7892ce67b4f3af3697d6ea

Prior to this commit, any collaborator that was identified by email
was always considered to have taken the given action.

This commit makes sure the same logic for determining if a user has
taken an action is applied to the has a non-user collaborator taken
the action.

Closes #252

## Exposing to_processing_action conversion

@0da6ca5223c14e85020cdfd9836a938f1c6b35ee

A registered action is something that can easily be converted to
a processing action. So I need to do that, given that I'm saying the
registered action is what is used for state advancement.
