### PR TITLE
Removing deprecated method usage

### DIFF
--- a/app/decorators/sipity/decorators/emails/work_email_decorator.rb
+++ b/app/decorators/sipity/decorators/emails/work_email_decorator.rb
@@ -34,9 +34,6 @@ module Sipity
           @accessible_objects ||= repository.access_rights_for_accessible_objects_of(work: work)
         end
 
-        alias_method :document_type, :work_type
-        deprecate :document_type
-
         # TODO: The methods with `email_message_` prefix are ripe for extraction
         #   into a composed object. After all they are shared with the
         #   ProcessingCommentDecorator.

--- a/app/views/sipity/mailers/email_notifier/confirmation_of_entity_created.html.erb
+++ b/app/views/sipity/mailers/email_notifier/confirmation_of_entity_created.html.erb
@@ -2,7 +2,7 @@
 
 <dl>
   <dd>Title: </dd> <dt><%= @entity.title %></dt>
-  <dd>Submission Type: </dd> <dt><%= @entity.document_type %></dt>
+  <dd>Submission Type: </dd> <dt><%= @entity.work_type %></dt>
 </dl>
 
 <p>To access your ETD record, please use the following URL: <%= link_to @entity.email_message_action_url, @entity.email_message_action_url %></p>

--- a/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
@@ -24,7 +24,6 @@ module Sipity
             with(work: work).and_return(reviewers)
         end
 
-        its(:document_type) { should eq('Doctoral Dissertation') }
         its(:work_type) { should eq('Doctoral Dissertation') }
         its(:title) { should eq(work.title) }
         its(:email_message_action_description) { should eq("Review Doctoral Dissertation “#{work.title}”") }


### PR DESCRIPTION
Normalizing on work_type instead of document_type; I suppose document
type might be more applicable, but this feels better.