### PR TITLE
Nullifying input release_date when not an embargo

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -127,7 +127,17 @@ module Sipity
 
           include Conversions::ConvertToDate
           def release_date=(value)
-            @release_date = convert_to_date(value) { nil }
+            if keep_user_input_release_date?
+              @release_date = convert_to_date(value) { nil }
+            else
+              @release_date = nil
+            end
+          end
+
+          def keep_user_input_release_date?
+            # We don't want to obliterate their input just because they didn't
+            # give us an access_right_code.
+            access_right_code.blank? || will_be_under_embargo?
           end
 
           def will_be_under_embargo?

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -107,6 +107,21 @@ module Sipity
           expect(subject.errors[:release_date]).to be_present
         end
 
+        it 'will blank out the release date when a release date is given but the access_right_code is "open_access"' do
+          subject = described_class.new(persisted_object, release_date: Date.today, access_right_code: 'open_access')
+          expect(subject.release_date).to_not be_present
+        end
+
+        it 'will not blank out the release date when a release date is given but no access_right_code' do
+          subject = described_class.new(persisted_object, release_date: Date.today)
+          expect(subject.release_date).to be_present
+        end
+
+        it 'will not blank out the release date when a release date is given and access_right code is "embargo_then_open_access"' do
+          subject = described_class.new(persisted_object, release_date: Date.today, access_right_code: 'embargo_then_open_access')
+          expect(subject.release_date).to be_present
+        end
+
         it 'will be invalid if an incorrect access code is given' do
           subject = described_class.new(persisted_object, access_right_code: 'chocolate bunny')
           subject.valid?


### PR DESCRIPTION
> When a user fills out the access rights for the given work, the date
> is auto-populated. However, it should be discarded before
> preservation if a non-embargo access right is specified.

Why did I choose to put this in the form? Because the form
encapsulates the business logic.

Question: Does it make more sense in the model? Knowledge is bleeding
out of the data structure.

Closes #327