### PR TITLE
Show reviewers sufficient information that they can make decisions about a submission

### DIFF
--- a/app/assets/stylesheets/modules/_attributes.css.scss
+++ b/app/assets/stylesheets/modules/_attributes.css.scss
@@ -52,11 +52,11 @@
   }
 }
 
-.collaborator {
+.nested-attribute-definition {
   margin-bottom:0;
 }
 
-.collaborators-list {
+.nested-attributes-list,  {
   list-style-type:none;
   margin:0;
   padding:0;
@@ -64,7 +64,7 @@
   width:100%;
 }
 
-.collaborators-list-item {
+.nested-attribute-item {
   float:left;
   width:100%;
 }

--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -27,6 +27,10 @@ module Sipity
         object.class.human_attribute_name(name)
       end
 
+      def accessible_objects
+        @accessible_objects ||= repository.access_rights_for_accessible_objects_of(work: object)
+      end
+
       include Conversions::ConvertToRichText
       def rich_text_value(attribute)
         Conversions::ConvertToRichText.call(attribute).html_safe

--- a/app/models/sipity/models/access_right_facade.rb
+++ b/app/models/sipity/models/access_right_facade.rb
@@ -18,6 +18,12 @@ module Sipity
       delegate :access_right_code, :release_date, to: :access_right_object
       alias_method :entity_id, :id
       attr_reader :entity_type
+      attr_reader :accessible_object
+      private :accessible_object
+
+      def human_attribute_name(name)
+        accessible_object.class.human_attribute_name(name)
+      end
 
       private
 

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -144,10 +144,10 @@
             <% if model.collaborators.present? %>
               <dt class="predicate collaborators"><%= model.human_attribute_name(:collaborators) %></dt>
               <dd class="value collaborators">
-                <ul class="collaborators-list">
+                <ul class="nested-attributes-list">
                   <% model.collaborators.each do |collaborator| %>
-                    <li class="collaborators-list-item">
-                      <dl class="collaborator">
+                    <li class="nested-attribute-list">
+                      <dl class="nested-attribute-definition">
                         <dt class="predicate name"><%= collaborator.human_attribute_name(:name) %></dt>
                         <dd class="value name"><%= collaborator.name %></dd>
                         <dt class="predicate role"><%= collaborator.human_attribute_name(:role) %></dt>
@@ -167,6 +167,27 @@
                   </ul>
                 </dd>
               <% end %>
+            <% end %>
+            <% if model.accessible_objects.any? %>
+              <dt class="predicate accessible-objects"><%= model.human_attribute_name('access_rights') %></dt>
+              <dd class="value accessible-objects">
+                <ul class="nested-attributes-list">
+                  <% model.accessible_objects.each do |accessible_object| %>
+                    <li class="nested-attribute-list">
+                      <dl class="nested-attribute-definition">
+                        <dt class="predicate title"><%= accessible_object.human_attribute_name(:title) %></dt>
+                        <dd class="value title"><%= accessible_object %></dd>
+                        <dt class="predicate access-right"><%= accessible_object.human_attribute_name(:access_right_code) %></dt>
+                        <dd class="value access-right"><%= accessible_object.access_right_code.to_s.titleize %></dd>
+                        <% if accessible_object.release_date.present? %>
+                        <dt class="predicate release-date"><%= accessible_object.human_attribute_name(:release_date) %></dt>
+                        <dd class="value release-date"><%= accessible_object.release_date %></dd>
+                        <% end %>
+                      </dl>
+                    </li>
+                  <% end %>
+                </ul>
+              </dt>
             <% end %>
           </dl>
         </div>

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -51,6 +51,12 @@ module Sipity
         expect(subject.human_attribute_name(:title)).to eq('Title')
       end
 
+      it 'will have #accessible_objects' do
+        accessible_objects = [double, double]
+        expect(repository).to receive(:access_rights_for_accessible_objects_of).with(work: work).and_return(accessible_objects)
+        expect(subject.accessible_objects).to eq(accessible_objects)
+      end
+
       xit '#state_advancing_actions is missing'
       xit '#resourceful_actions is missing'
       xit '#enrichment_actions is missing'

--- a/spec/features/sipity/enriching_a_work_spec.rb
+++ b/spec/features/sipity/enriching_a_work_spec.rb
@@ -44,7 +44,9 @@ feature 'Enriching a Work', :devise, :feature do
     create_a_work(work_type: 'doctoral_dissertation', title: 'Hello World', work_publication_strategy: 'do_not_know')
 
     on('work_page') do |the_page|
-      expect(the_page.text_for('title')).to eq(['Hello World'])
+      # There are two because it is listed as a top-level attribute and as part
+      # of the access rights.
+      expect(the_page.text_for('title')).to eq(['Hello World', 'Hello World'])
       expect(the_page.text_for('work_publication_strategy')).to eq(['Do Not Know']) # NOTE: weak match on default I18n
     end
   end

--- a/spec/models/sipity/models/access_right_facade_spec.rb
+++ b/spec/models/sipity/models/access_right_facade_spec.rb
@@ -17,6 +17,10 @@ module Sipity
       its(:entity_type) { should eq(Sipity::Models::Work) }
       its(:access_right_code) { should eq(access_right.access_right_code) }
       its(:release_date) { should eq(access_right.release_date) }
+
+      it 'will leverage the access right to translate human_attribute_name' do
+        expect(subject.human_attribute_name(:title)).to eq('Title')
+      end
     end
   end
 end


### PR DESCRIPTION
## Exposing WorkDecorator#accessible_objects

@d34bb1fd13929c345ece721ecc4df35e4b9e177a

I want to be able to render the accessible objects on the view, so
this is the first step.

## Displaying access rights information on show page

@30f540b93e6d59175cc0b77eee308280850740f9

Given that we need a way for advisors to review the pertinent
information regarding an object, we need a way to display that
information.

Closes #317
