### PR TITLE
Removing with action pane

### DIFF
--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -15,10 +15,6 @@ module Sipity
         h.render(layout: 'sipity/form_panel', locals: { name: name, theme: theme, object: self }, &block)
       end
 
-      def with_action_pane(name, css_class = '', &block)
-        h.render(layout: 'sipity/form_action_pane', locals: { name: name, css_class: css_class, object: self }, &block)
-      end
-
       def to_s
         title
       end

--- a/app/runners/sipity/runners/citation_runners.rb
+++ b/app/runners/sipity/runners/citation_runners.rb
@@ -27,8 +27,7 @@ module Sipity
 
         def run(work_id:)
           work = repository.find_work(work_id)
-          decorated_work = Decorators::WorkDecorator.decorate(work)
-          form = repository.build_assign_a_citation_form(work: decorated_work)
+          form = repository.build_assign_a_citation_form(work: work)
           authorization_layer.enforce!(action_name => form) do
             if repository.citation_already_assigned?(work)
               callback(:citation_assigned, work)
@@ -47,8 +46,7 @@ module Sipity
 
         def run(work_id:, attributes: {})
           work = repository.find_work(work_id)
-          decorated_work = Decorators::WorkDecorator.decorate(work)
-          form = repository.build_assign_a_citation_form(attributes.merge(work: decorated_work))
+          form = repository.build_assign_a_citation_form(attributes.merge(work: work))
           authorization_layer.enforce!(action_name => form) do
             if form.submit(requested_by: current_user)
               callback(:success, work)

--- a/app/runners/sipity/runners/work_enrichment_runners.rb
+++ b/app/runners/sipity/runners/work_enrichment_runners.rb
@@ -8,10 +8,7 @@ module Sipity
 
         def run(work_id:, enrichment_type:)
           work = repository.find_work(work_id)
-          # TODO: Remove this behavior; It does not belong here. However it is
-          #   necessary for the rendered views. So be mindful of that.
-          decorated_work = Decorators::WorkDecorator.decorate(work)
-          form = repository.build_enrichment_form(work: decorated_work, enrichment_type: enrichment_type)
+          form = repository.build_enrichment_form(work: work, enrichment_type: enrichment_type)
           authorization_layer.enforce!(enrichment_type => form) do
             callback(:success, form)
           end
@@ -25,10 +22,7 @@ module Sipity
 
         def run(work_id:, enrichment_type:, attributes:)
           work = repository.find_work(work_id)
-          # TODO: Remove this behavior; It does not belong here. However it is
-          #   necessary for the rendered views. So be mindful of that.
-          decorated_work = Decorators::WorkDecorator.decorate(work)
-          form = repository.build_enrichment_form(attributes.merge(work: decorated_work, enrichment_type: enrichment_type))
+          form = repository.build_enrichment_form(attributes.merge(work: work, enrichment_type: enrichment_type))
           authorization_layer.enforce!(enrichment_type => form) do
             if form.submit(requested_by: current_user)
               callback(:success, work)

--- a/app/views/sipity/controllers/citations/new.html.erb
+++ b/app/views/sipity/controllers/citations/new.html.erb
@@ -26,13 +26,13 @@
 
     </fieldset>
 
-    <%= model.work.with_action_pane('new_citation', 'panel-footer') do %>
+    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
       <%= f.submit %>
-    <% end %>
+    </div>
   <% end %>
 
 </div>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t('sipity/citations.action/show.cancel'), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/citations/new.html.erb
+++ b/app/views/sipity/controllers/citations/new.html.erb
@@ -26,13 +26,13 @@
 
     </fieldset>
 
-    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
+    <div class="panel-footer action-pane">
       <%= f.submit %>
     </div>
   <% end %>
 
 </div>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t('sipity/citations.action/show.cancel'), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/dois/assign_a_doi.html.erb
+++ b/app/views/sipity/controllers/dois/assign_a_doi.html.erb
@@ -13,7 +13,7 @@
     <%= f.error_notification %>
     <%= f.input :identifier, input_html: { class: 'form-control' } %>
   </fieldset>
-  <%= model.work.with_action_pane('existing_doi', 'panel-footer') do %>
+  <div class="<%= dom_class(model, 'existing_doi') %> panel-footer action-pane">
     <%= f.submit %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/sipity/controllers/dois/assign_a_doi.html.erb
+++ b/app/views/sipity/controllers/dois/assign_a_doi.html.erb
@@ -13,7 +13,7 @@
     <%= f.error_notification %>
     <%= f.input :identifier, input_html: { class: 'form-control' } %>
   </fieldset>
-  <div class="<%= dom_class(model, 'existing_doi') %> panel-footer action-pane">
+  <div class="panel-footer action-pane">
     <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/sipity/controllers/dois/doi_not_assigned.html.erb
+++ b/app/views/sipity/controllers/dois/doi_not_assigned.html.erb
@@ -6,6 +6,6 @@
   <%= render template: 'sipity/controllers/dois/request_a_doi' %>
 </div>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t('sipity/dois.action/show.cancel'), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/dois/doi_not_assigned.html.erb
+++ b/app/views/sipity/controllers/dois/doi_not_assigned.html.erb
@@ -6,6 +6,6 @@
   <%= render template: 'sipity/controllers/dois/request_a_doi' %>
 </div>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t('sipity/dois.action/show.cancel'), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/dois/request_a_doi.html.erb
+++ b/app/views/sipity/controllers/dois/request_a_doi.html.erb
@@ -37,7 +37,7 @@
 
   </fieldset>
 
-  <div class="<%= dom_class(model, 'new_doi') %> panel-footer action-pane">
+  <div class="panel-footer action-pane">
     <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/sipity/controllers/dois/request_a_doi.html.erb
+++ b/app/views/sipity/controllers/dois/request_a_doi.html.erb
@@ -37,7 +37,7 @@
 
   </fieldset>
 
-  <%= model.work.with_action_pane('new_doi', 'panel-footer') do %>
+  <div class="<%= dom_class(model, 'new_doi') %> panel-footer action-pane">
     <%= f.submit %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
@@ -80,11 +80,11 @@
     </table>
   </fieldset>
 
-  <div class="<%= dom_class(model, 'new_defense_date') %> panel-footer action-pane">
+  <div class="panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
   </div>
 <% end %>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
@@ -80,11 +80,11 @@
     </table>
   </fieldset>
 
-  <%= model.work.with_action_pane('new_defense_date', 'panel-footer') do %>
+  <div class="<%= dom_class(model, 'new_defense_date') %> panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-  <% end %>
+  </div>
 <% end %>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/work_enrichments/attach.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/attach.html.erb
@@ -43,11 +43,11 @@
 
   </fieldset>
 
-  <%= model.work.with_action_pane('new_citation', 'panel-footer') do %>
+  <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-  <% end %>
+  </div>
 <% end %>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/work_enrichments/attach.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/attach.html.erb
@@ -43,11 +43,11 @@
 
   </fieldset>
 
-  <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
+  <div class="panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
   </div>
 <% end %>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
@@ -109,12 +109,11 @@
       </table>
     </fieldset>
 
-    <%= model.work.with_action_pane('new_citation', 'panel-footer') do %>
+    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-    <% end %>
+    </div>
   <% end %>
 
-
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/collaborators.html.erb
@@ -109,11 +109,11 @@
       </table>
     </fieldset>
 
-    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
+    <div class="panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
     </div>
   <% end %>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/defense_date.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/defense_date.html.erb
@@ -22,13 +22,13 @@
     <%= f.input :defense_date, as: :date, input_html: { class: 'form-control' }, wrapper_html: { class: 'form-inline' } %>
   </fieldset>
 
-  <div class="<%= dom_class(model, 'new_defense_date') %> panel-footer action-pane">
+  <div class="panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
   </div>
 <% end %>
 
 </div>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/defense_date.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/defense_date.html.erb
@@ -22,13 +22,13 @@
     <%= f.input :defense_date, as: :date, input_html: { class: 'form-control' }, wrapper_html: { class: 'form-inline' } %>
   </fieldset>
 
-  <%= model.work.with_action_pane('new_defense_date', 'panel-footer') do %>
+  <div class="<%= dom_class(model, 'new_defense_date') %> panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-  <% end %>
+  </div>
 <% end %>
 
 </div>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/work_enrichments/degree.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/degree.html.erb
@@ -22,12 +22,12 @@
         <%= f.input :program_name, collection: model.available_program_names, input_html: { class: 'form-control', multiple: true, selected: model.program_name } %>
     </fieldset>
 
-    <div class="<%= dom_class(model, 'new_degree') %> panel-footer action-pane">
+    <div class="panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
     </div>
   <% end %>
 </div>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/degree.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/degree.html.erb
@@ -22,12 +22,12 @@
         <%= f.input :program_name, collection: model.available_program_names, input_html: { class: 'form-control', multiple: true, selected: model.program_name } %>
     </fieldset>
 
-    <%= model.work.with_action_pane('new_degree', 'panel-footer') do %>
+    <div class="<%= dom_class(model, 'new_degree') %> panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-    <% end %>
-        <% end %>
+    </div>
+  <% end %>
 </div>
 
-  <%= model.work.with_action_pane('actions') do %>
-    <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-  <% end %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
+  <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
+</div>

--- a/app/views/sipity/controllers/work_enrichments/describe.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/describe.html.erb
@@ -32,13 +32,13 @@
 
     </fieldset>
 
-    <%= model.work.with_action_pane('new_citation', 'panel-footer') do %>
+    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-    <% end %>
+    </div>
   <% end %>
 
 </div>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/work_enrichments/describe.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/describe.html.erb
@@ -32,13 +32,13 @@
 
     </fieldset>
 
-    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
+    <div class="panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
     </div>
   <% end %>
 
 </div>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/search_terms.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/search_terms.html.erb
@@ -32,13 +32,13 @@
     </fieldset>
 
 
-    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
+    <div class="panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
     </div>
   <% end %>
 
 </div>
 
-<div class="<%= dom_class(model, 'actions') %> action-pane">
+<div class="action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
 </div>

--- a/app/views/sipity/controllers/work_enrichments/search_terms.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/search_terms.html.erb
@@ -31,13 +31,14 @@
 
     </fieldset>
 
-    <%= model.work.with_action_pane('new_citation', 'panel-footer') do %>
+
+    <div class="<%= dom_class(model, 'new_citation') %> panel-footer action-pane">
       <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
-    <% end %>
+    </div>
   <% end %>
 
 </div>
 
-<%= model.work.with_action_pane('actions') do %>
+<div class="<%= dom_class(model, 'actions') %> action-pane">
   <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
-<% end %>
+</div>

--- a/app/views/sipity/controllers/works/edit.html.erb
+++ b/app/views/sipity/controllers/works/edit.html.erb
@@ -8,7 +8,7 @@
       <%= render 'form_for_work_publication_strategy', { f: f } %>
     <% end %>
   </div>
-  <%= model.with_action_pane('actions') do %>
+  <div class="<%= dom_class(model, 'actions') %> action-pane">
     <%= f.submit %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/sipity/controllers/works/edit.html.erb
+++ b/app/views/sipity/controllers/works/edit.html.erb
@@ -8,7 +8,7 @@
       <%= render 'form_for_work_publication_strategy', { f: f } %>
     <% end %>
   </div>
-  <div class="<%= dom_class(model, 'actions') %> action-pane">
+  <div class="action-pane">
     <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/sipity/controllers/works/new.html.erb
+++ b/app/views/sipity/controllers/works/new.html.erb
@@ -14,7 +14,7 @@
       <%= f.input :access_rights_answer, as: :radio_buttons, collection: model.access_rights_answer_for_select %>
     <% end %>
   </div>
-  <%= model.with_action_pane('actions') do %>
+  <div class="<%= dom_class(model, 'actions') %> action-pane">
     <%= f.submit %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/sipity/controllers/works/new.html.erb
+++ b/app/views/sipity/controllers/works/new.html.erb
@@ -14,7 +14,7 @@
       <%= f.input :access_rights_answer, as: :radio_buttons, collection: model.access_rights_answer_for_select %>
     <% end %>
   </div>
-  <div class="<%= dom_class(model, 'actions') %> action-pane">
+  <div class="action-pane">
     <%= f.submit %>
   </div>
 <% end %>

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -20,13 +20,6 @@ module Sipity
         end
       end
 
-      context '#with_action_pane' do
-        it 'wrap the results of the block inside an action pane' do
-          rendered = subject.with_action_pane('actions') { 'submit' }
-          expect(rendered).to have_tag('.action-pane', content: 'submit')
-        end
-      end
-
       context '#rich_text_value' do
         it 'returns the value rendered as HTML' do
           rendered = subject.rich_text_value("several\n\nparagraphs")

--- a/spec/views/sipity/controllers/works/new.html.erb_spec.rb
+++ b/spec/views/sipity/controllers/works/new.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'sipity/controllers/works/new.html.erb', type: :view do
           with_tag('input', with: { name: 'work[work_publication_strategy]', value: name })
         end
       end
-      with_tag('.actions_work') do
+      with_tag('.action-pane') do
         with_tag('input', with: { type: 'submit' })
       end
     end


### PR DESCRIPTION
## Removing #with_action_pane

@30b603d1b705b307a257e06c7eb6e6016f556468

This was a kludge and resulted in decorating an object within the
repository methods; Something that I want to avoid. So I'm attempting
to streamline the behavior.

## Removing unneeding dom classifications

@8656e5c58d40668b460c2a5b583ad8a78cbc163d

These extra DOM classes were chatty and by appearance nothing was
contingent on their presence.
