### PR TITLE
Exposing the access_url for accessible object

### DIFF
--- a/app/models/sipity/models/access_right_facade.rb
+++ b/app/models/sipity/models/access_right_facade.rb
@@ -25,6 +25,14 @@ module Sipity
         accessible_object.class.human_attribute_name(name)
       end
 
+      def access_url
+        if accessible_object.respond_to?(:file_url)
+          accessible_object.file_url
+        else
+          view_context.polymorphic_url(accessible_object)
+        end
+      end
+
       private
 
       include Conversions::ConvertToPolymorphicType
@@ -35,6 +43,10 @@ module Sipity
 
       def access_right_object
         @access_right_object ||= Models::AccessRight.find_or_initialize_by(entity_id: entity_id, entity_type: entity_type)
+      end
+
+      def view_context
+        Draper::ViewContext.current
       end
     end
   end

--- a/app/views/sipity/controllers/works/show.html.erb
+++ b/app/views/sipity/controllers/works/show.html.erb
@@ -176,7 +176,7 @@
                     <li class="nested-attribute-list">
                       <dl class="nested-attribute-definition">
                         <dt class="predicate title"><%= accessible_object.human_attribute_name(:title) %></dt>
-                        <dd class="value title"><%= accessible_object %></dd>
+                        <dd class="value title"><%= link_to accessible_object, accessible_object.access_url %></dd>
                         <dt class="predicate access-right"><%= accessible_object.human_attribute_name(:access_right_code) %></dt>
                         <dd class="value access-right"><%= accessible_object.access_right_code.to_s.titleize %></dd>
                         <% if accessible_object.release_date.present? %>

--- a/spec/models/sipity/models/access_right_facade_spec.rb
+++ b/spec/models/sipity/models/access_right_facade_spec.rb
@@ -17,9 +17,24 @@ module Sipity
       its(:entity_type) { should eq(Sipity::Models::Work) }
       its(:access_right_code) { should eq(access_right.access_right_code) }
       its(:release_date) { should eq(access_right.release_date) }
+      it { should respond_to :access_url }
 
       it 'will leverage the access right to translate human_attribute_name' do
         expect(subject.human_attribute_name(:title)).to eq('Title')
+      end
+
+      context '#access_url' do
+        it 'will be a file url if one is given' do
+          object = Models::Attachment.new(file: __FILE__)
+          subject = described_class.new(object)
+          expect(subject.access_url).to eq(object.file_url)
+        end
+
+        it 'will be a resolve polymorphic path for a Models::Work' do
+          allow(object).to receive(:persisted?).and_return(true)
+          subject = described_class.new(object)
+          expect(subject.access_url).to match(%r{^https?://[^/]*/works/#{object.id}$})
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, I was only rendering an accessible object
without a link/reference to its location.

Closes #350