### PR TITLE
354 when appending attachments reset the must do state for access rights

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -82,7 +82,7 @@ Metrics/AbcSize:
      - app/state_machines/**/*.rb
      - app/repositories/sipity/queries/*.rb
      - app/controllers/application_controller.rb
-
+     - app/forms/sipity/forms/work_enrichments/attach_form.rb
 Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -31,12 +31,16 @@ module Sipity
 
         def save(requested_by:)
           super do
-            # TODO: Validate that the attachment you are deleting is not also
-            # the representative image.
             repository.attach_files_to(work: work, files: files, user: requested_by)
             repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
             repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
             repository.amend_files_metadata(work: work, user: requested_by, metadata: attachments_metadata)
+            # HACK: This is expanding the knowledge of what action is being
+            #   taken. Instead it is something that should be modeled in the
+            #   underlying database. That is to say: When an action fires what
+            #   actions should be registered and what actions should be
+            #   unregistered.
+            repository.unregister_action_taken_on_entity(work: work, enrichment_type: 'access_policy', requested_by: requested_by)
           end
         end
 

--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -5,7 +5,7 @@ module Sipity
     # TODO: Rename to ProcessingCommands
     module TodoListCommands
       def register_action_taken_on_entity(work:, enrichment_type:, requested_by:, on_behalf_of: requested_by)
-        Services::RegisterActionTakenOnEntity.call(
+        Services::ActionTakenOnEntity.call(
           entity: work, action: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of
         )
       end

--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -5,7 +5,7 @@ module Sipity
     # TODO: Rename to ProcessingCommands
     module TodoListCommands
       def register_action_taken_on_entity(work:, enrichment_type:, requested_by:, on_behalf_of: requested_by)
-        Services::ActionTakenOnEntity.call(
+        Services::ActionTakenOnEntity.register(
           entity: work, action: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of
         )
       end

--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -10,6 +10,12 @@ module Sipity
         )
       end
 
+      def unregister_action_taken_on_entity(work:, enrichment_type:, requested_by:, on_behalf_of: requested_by)
+        Services::ActionTakenOnEntity.unregister(
+          entity: work, action: enrichment_type, requested_by: requested_by, on_behalf_of: on_behalf_of
+        )
+      end
+
       # @api public
       #
       # Responsible for capturing a :comment made by a given :commenter on a

--- a/app/services/sipity/services/action_taken_on_entity.rb
+++ b/app/services/sipity/services/action_taken_on_entity.rb
@@ -4,8 +4,8 @@ module Sipity
     class ActionTakenOnEntity
       include Conversions::ConvertToProcessingEntity
       include Conversions::ConvertToProcessingActor
-      def self.call(entity:, action:, requested_by:, on_behalf_of: requested_by)
-        new(entity: entity, action: action, requested_by: requested_by, on_behalf_of: on_behalf_of).call
+      def self.register(entity:, action:, requested_by:, on_behalf_of: requested_by)
+        new(entity: entity, action: action, requested_by: requested_by, on_behalf_of: on_behalf_of).register
       end
 
       def initialize(entity:, action:, requested_by:, on_behalf_of: requested_by)
@@ -16,7 +16,7 @@ module Sipity
       end
       attr_reader :entity, :action, :requesting_actor, :on_behalf_of_actor
 
-      def call
+      def register
         # TODO: Tease apart the requested_by and on_behalf_of
         Models::Processing::EntityActionRegister.create!(
           strategy_action_id: action.id,

--- a/app/services/sipity/services/action_taken_on_entity.rb
+++ b/app/services/sipity/services/action_taken_on_entity.rb
@@ -1,7 +1,7 @@
 module Sipity
   module Services
     # Service object that handles the business logic of granting permission.
-    class RegisterActionTakenOnEntity
+    class ActionTakenOnEntity
       include Conversions::ConvertToProcessingEntity
       include Conversions::ConvertToProcessingActor
       def self.call(entity:, action:, requested_by:, on_behalf_of: requested_by)

--- a/app/services/sipity/services/action_taken_on_entity.rb
+++ b/app/services/sipity/services/action_taken_on_entity.rb
@@ -8,6 +8,10 @@ module Sipity
         new(entity: entity, action: action, requested_by: requested_by, on_behalf_of: on_behalf_of).register
       end
 
+      def self.unregister(entity:, action:, requested_by:, on_behalf_of: requested_by)
+        new(entity: entity, action: action, requested_by: requested_by, on_behalf_of: on_behalf_of).unregister
+      end
+
       def initialize(entity:, action:, requested_by:, on_behalf_of: requested_by)
         self.entity = entity
         self.action = action
@@ -24,6 +28,16 @@ module Sipity
           requested_by_actor_id: requesting_actor.id,
           on_behalf_of_actor_id: on_behalf_of_actor.id
         )
+      end
+
+      def unregister
+        # TODO: Tease apart the requested_by and on_behalf_of
+        Models::Processing::EntityActionRegister.where(
+          strategy_action_id: action.id,
+          entity_id: entity.id,
+          requested_by_actor_id: requesting_actor.id,
+          on_behalf_of_actor_id: on_behalf_of_actor.id
+        ).destroy_all
       end
 
       private

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -100,8 +100,13 @@ module Sipity
               subject.submit(requested_by: user)
             end
 
-            it "will transition the work's corresponding enrichment todo item to :done" do
+            it "will register that the action was taken" do
               expect(repository).to receive(:register_action_taken_on_entity).and_call_original
+              subject.submit(requested_by: user)
+            end
+
+            it "will unregister that the 'access_policy' action was taken" do
+              expect(repository).to receive(:unregister_action_taken_on_entity).and_call_original
               subject.submit(requested_by: user)
             end
 

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -9,7 +9,7 @@ module Sipity
       context '#register_action_taken_on_entity' do
         let(:existing_enrichment_type) { 'describe' }
         it "will call the underlying service object" do
-          expect(Services::ActionTakenOnEntity).to receive(:call)
+          expect(Services::ActionTakenOnEntity).to receive(:register)
           test_repository.register_action_taken_on_entity(work: work, enrichment_type: existing_enrichment_type, requested_by: user)
         end
       end

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -9,7 +9,7 @@ module Sipity
       context '#register_action_taken_on_entity' do
         let(:existing_enrichment_type) { 'describe' }
         it "will call the underlying service object" do
-          expect(Services::RegisterActionTakenOnEntity).to receive(:call)
+          expect(Services::ActionTakenOnEntity).to receive(:call)
           test_repository.register_action_taken_on_entity(work: work, enrichment_type: existing_enrichment_type, requested_by: user)
         end
       end

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -14,6 +14,14 @@ module Sipity
         end
       end
 
+      context '#unregister_action_taken_on_entity' do
+        let(:existing_enrichment_type) { 'describe' }
+        it "will call the underlying service object" do
+          expect(Services::ActionTakenOnEntity).to receive(:unregister)
+          test_repository.unregister_action_taken_on_entity(work: work, enrichment_type: existing_enrichment_type, requested_by: user)
+        end
+      end
+
       context '#record_processing_comment' do
         let(:entity) { Models::Processing::Entity.new(id: 1, strategy_id: strategy.id, strategy_state_id: state.id, strategy_state: state) }
         let(:actor) { Models::Processing::Actor.new(id: 2) }

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -282,7 +282,7 @@ module Sipity
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: guarded_action.id, prerequisite_strategy_action_id: action.id
           )
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: other_guarded_action.id, prerequisite_strategy_action_id: guarded_action.id
           )
@@ -332,7 +332,7 @@ module Sipity
       context '#scope_statetegy_actions_that_have_occurred' do
         subject { test_repository.scope_statetegy_actions_that_have_occurred(entity: entity) }
         it "will include actions that do not have prerequisites" do
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
           expect(subject).to eq([action])
         end
         it "will be a chainable scope" do
@@ -359,7 +359,7 @@ module Sipity
             guarded_strategy_action_id: guarded_action.id, prerequisite_strategy_action_id: action.id
           )
 
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
 
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: other_guarded_action.id, prerequisite_strategy_action_id: guarded_action.id
@@ -381,8 +381,8 @@ module Sipity
           Conversions::ConvertToProcessingActor.call(user)
           Conversions::ConvertToProcessingActor.call(other_user)
           Conversions::ConvertToProcessingActor.call(group)
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
           expect(subject).to eq([user, groupy])
         end
         it "will be a chainable scope" do
@@ -429,9 +429,9 @@ module Sipity
           Models::Collaborator.create!(
             name: 'non_reviewing', role: 'Committee Member', responsible_for_review: false, work_id: entity.proxy_for_id
           )
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action, requested_by: acting_via_email_collaborator)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: acting_via_email_collaborator)
           expect(subject.pluck(:name)).to eq(
             [
               user_acting_collaborator.name,
@@ -466,7 +466,7 @@ module Sipity
           ) do |current_action|
             current_action.requiring_strategy_action_prerequisites.build(prerequisite_strategy_action: action)
           end
-          Services::RegisterActionTakenOnEntity.call(entity: entity, action: action_with_completed_prerequisites, requested_by: user)
+          Services::ActionTakenOnEntity.call(entity: entity, action: action_with_completed_prerequisites, requested_by: user)
 
           Models::Processing::StrategyAction.find_or_create_by!(strategy: strategy, name: 'with_incomplete_prereqs') do |current_action|
             current_action.requiring_strategy_action_prerequisites.build(

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -282,7 +282,7 @@ module Sipity
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: guarded_action.id, prerequisite_strategy_action_id: action.id
           )
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: user)
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: other_guarded_action.id, prerequisite_strategy_action_id: guarded_action.id
           )
@@ -332,7 +332,7 @@ module Sipity
       context '#scope_statetegy_actions_that_have_occurred' do
         subject { test_repository.scope_statetegy_actions_that_have_occurred(entity: entity) }
         it "will include actions that do not have prerequisites" do
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: user)
           expect(subject).to eq([action])
         end
         it "will be a chainable scope" do
@@ -359,7 +359,7 @@ module Sipity
             guarded_strategy_action_id: guarded_action.id, prerequisite_strategy_action_id: action.id
           )
 
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: user)
 
           Models::Processing::StrategyActionPrerequisite.find_or_create_by!(
             guarded_strategy_action_id: other_guarded_action.id, prerequisite_strategy_action_id: guarded_action.id
@@ -381,8 +381,8 @@ module Sipity
           Conversions::ConvertToProcessingActor.call(user)
           Conversions::ConvertToProcessingActor.call(other_user)
           Conversions::ConvertToProcessingActor.call(group)
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: group)
           expect(subject).to eq([user, groupy])
         end
         it "will be a chainable scope" do
@@ -429,9 +429,9 @@ module Sipity
           Models::Collaborator.create!(
             name: 'non_reviewing', role: 'Committee Member', responsible_for_review: false, work_id: entity.proxy_for_id
           )
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: user)
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: group)
-          Services::ActionTakenOnEntity.call(entity: entity, action: action, requested_by: acting_via_email_collaborator)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: user)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: group)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: acting_via_email_collaborator)
           expect(subject.pluck(:name)).to eq(
             [
               user_acting_collaborator.name,
@@ -466,7 +466,7 @@ module Sipity
           ) do |current_action|
             current_action.requiring_strategy_action_prerequisites.build(prerequisite_strategy_action: action)
           end
-          Services::ActionTakenOnEntity.call(entity: entity, action: action_with_completed_prerequisites, requested_by: user)
+          Services::ActionTakenOnEntity.register(entity: entity, action: action_with_completed_prerequisites, requested_by: user)
 
           Models::Processing::StrategyAction.find_or_create_by!(strategy: strategy, name: 'with_incomplete_prereqs') do |current_action|
             current_action.requiring_strategy_action_prerequisites.build(

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -21,17 +21,17 @@ module Sipity
         end
       end
 
-      context '.call' do
-        it 'will delegate do the unerlying #initialize then #call' do
+      context '.register' do
+        it 'will delegate do the unerlying #initialize then #register' do
           allow(described_class).to receive(:new).and_call_original
-          described_class.call(entity: entity, requested_by: requested_by, action: action)
+          described_class.register(entity: entity, requested_by: requested_by, action: action)
         end
       end
 
-      context '#call' do
+      context '#register' do
         context 'with a valid action object for the given entity' do
           it 'will increment the registry' do
-            expect { subject.call }.to change { Models::Processing::EntityActionRegister.count }.by(1)
+            expect { subject.register }.to change { Models::Processing::EntityActionRegister.count }.by(1)
           end
         end
       end

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Sipity
   module Services
-    RSpec.describe RegisterActionTakenOnEntity do
+    RSpec.describe ActionTakenOnEntity do
       let(:entity) { Models::Processing::Entity.new(id: 1, strategy_id: strategy.id, strategy: strategy) }
       let(:strategy) { Models::Processing::Strategy.new(id: 2) }
       let(:requested_by) { Models::Processing::Actor.new(id: 4) }

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -21,10 +21,16 @@ module Sipity
         end
       end
 
-      context '.register' do
-        it 'will delegate do the unerlying #initialize then #register' do
-          allow(described_class).to receive(:new).and_call_original
-          described_class.register(entity: entity, requested_by: requested_by, action: action)
+      [
+        :register,
+        :unregister
+      ].each do |method_name|
+        context ".#{method_name}" do
+          it "will delegate do the unerlying #initialize then ##{method_name}" do
+            allow(described_class).to receive(:new).and_call_original
+            expect_any_instance_of(described_class).to receive(method_name)
+            described_class.send(method_name, entity: entity, requested_by: requested_by, action: action)
+          end
         end
       end
 
@@ -32,6 +38,23 @@ module Sipity
         context 'with a valid action object for the given entity' do
           it 'will increment the registry' do
             expect { subject.register }.to change { Models::Processing::EntityActionRegister.count }.by(1)
+          end
+        end
+      end
+
+      context '#register' do
+        context 'with a valid action object for the given entity' do
+          it 'will attempt to destroy the entry' do
+            expect { subject.unregister }.to_not change { Models::Processing::EntityActionRegister.count }
+          end
+        end
+      end
+
+      context '#register then #unregister' do
+        context 'with a valid action object for the given entity' do
+          it 'will increment then decrement' do
+            expect { subject.register }.to change { Models::Processing::EntityActionRegister.count }.by(1)
+            expect { subject.unregister }.to change { Models::Processing::EntityActionRegister.count }.by(-1)
           end
         end
       end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -313,6 +313,10 @@ module Sipity
     def submit_request_a_doi_form(form, requested_by:)
     end
 
+    # @see ./app/repositories/sipity/commands/todo_list_commands.rb
+    def unregister_action_taken_on_entity(work:, enrichment_type:, requested_by:, on_behalf_of: requested_by)
+    end
+
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def update_processing_state!(entity:, to:)
     end


### PR DESCRIPTION
## Renaming class to ActionTakenOnEntity

@6b140203b28169b97267548b2d1911014d9a4b3d

I want a .register and .unregister command, so I'm refactoring the
class name to account for this.

## Replacing .call/#call with register

@96faf08b64c0fedd5942f129b4dd92761a73cdb0

Since I want to both register and unregister an action, I want to
reflect that capability via the method name.

## Adding .unregister method for ActionTakenOnEntity

@7c653c3b575933f4970a447d059da27b706ebdfc

There is a case in which I need to reset that an action was taken; I
upload files, then assign access rights, then upload new files. I need
to make sure the access rights are properly assigned again.

## Adding a repository method to expose the service

@d360107b330059b64183cd7cfd0d6e5927b8e79a


## Attaching files resets access_policy action

@c13a560e6d6eecf960c656eb070c6e8c00f4ebae

```gherkin
Given that I have three attachments
And I have assigned access rights to each attachment
When I add a new attachment
Then the todo item for the access rights is no longer done
```

Of note, see the acknowledgement that this is a hack, but also there
is a path forward.

> This is expanding the knowledge of what action is being taken.
> Instead it is something that should be modeled in the underlying
> database. That is to say: When an action fires what actions should
> be registered and what actions should be unregistered.

Closes #354
