### PR TITLE
Move mark as representative to the access policy form

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -8,7 +8,7 @@ module Sipity
           super
           self.accessible_objects_attributes = attributes.fetch(:accessible_objects_attributes) { {} }
           self.copyright = attributes.fetch(:copyright) { copyright_from_work }
-          self.mark_as_representative = attributes.fetch(:mark_as_representative) { representative_attachment_from_work }
+          self.representative_attachment_id = attributes.fetch(:representative_attachment_id) { representative_attachment_from_work }
         end
 
         # Because I am using `#fields_for` for rendering
@@ -17,14 +17,14 @@ module Sipity
         end
 
         attr_reader :accessible_objects_attributes
-        attr_accessor :copyright, :mark_as_representative
+        attr_accessor :copyright, :representative_attachment_id
 
-        private(:copyright=, :mark_as_representative=)
+        private(:copyright=, :representative_attachment_id=)
 
         validate :each_accessible_objects_attributes_are_valid
         validate :at_lease_one_accessible_objects_attributes_entry
         validates :copyright, presence: true
-        validates :mark_as_representative, presence: true
+        validates :representative_attachment_id, presence: true
 
         def accessible_objects
           if @accessible_objects_attributes.present?
@@ -62,7 +62,7 @@ module Sipity
           super do
             repository.apply_access_policies_to(work: work, user: requested_by, access_policies: access_objects_attributes_for_persistence)
             repository.update_work_attribute_values!(work: work, key: 'copyright', values: copyright)
-            repository.set_as_representative_attachment(work: work, pid: mark_as_representative, user: requested_by)
+            repository.set_as_representative_attachment(work: work, pid: representative_attachment_id, user: requested_by)
           end
         end
 

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -38,6 +38,10 @@ module Sipity
           repository.get_controlled_vocabulary_for_predicate_name(name: 'copyright')
         end
 
+        def available_representative_attachments
+          repository.work_attachments(work: work)
+        end
+
         private
 
         def representative_attachment_from_work

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -62,7 +62,7 @@ module Sipity
           super do
             repository.apply_access_policies_to(work: work, user: requested_by, access_policies: access_objects_attributes_for_persistence)
             repository.update_work_attribute_values!(work: work, key: 'copyright', values: copyright)
-            repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
+            repository.set_as_representative_attachment(work: work, pid: mark_as_representative, user: requested_by)
           end
         end
 

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -8,6 +8,7 @@ module Sipity
           super
           self.accessible_objects_attributes = attributes.fetch(:accessible_objects_attributes) { {} }
           self.copyright = attributes.fetch(:copyright) { copyright_from_work }
+          self.mark_as_representative = attributes.fetch(:mark_as_representative) { representative_attachment_from_work }
         end
 
         # Because I am using `#fields_for` for rendering
@@ -16,13 +17,14 @@ module Sipity
         end
 
         attr_reader :accessible_objects_attributes
-        attr_accessor :copyright
+        attr_accessor :copyright, :mark_as_representative
 
-        private :copyright=
+        private(:copyright=, :mark_as_representative=)
 
         validate :each_accessible_objects_attributes_are_valid
         validate :at_lease_one_accessible_objects_attributes_entry
         validates :copyright, presence: true
+        validates :mark_as_representative, presence: true
 
         def accessible_objects
           if @accessible_objects_attributes.present?
@@ -37,6 +39,10 @@ module Sipity
         end
 
         private
+
+        def representative_attachment_from_work
+          repository.representative_attachment_for(work: work)
+        end
 
         def each_accessible_objects_attributes_are_valid
           return true if accessible_objects_attributes.all?(&:valid?)

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -58,6 +58,7 @@ module Sipity
           super do
             repository.apply_access_policies_to(work: work, user: requested_by, access_policies: access_objects_attributes_for_persistence)
             repository.update_work_attribute_values!(work: work, key: 'copyright', values: copyright)
+            repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
           end
         end
 

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -8,7 +8,7 @@ module Sipity
           super
           self.accessible_objects_attributes = attributes.fetch(:accessible_objects_attributes) { {} }
           self.copyright = attributes.fetch(:copyright) { copyright_from_work }
-          self.representative_attachment_id = attributes.fetch(:representative_attachment_id) { representative_attachment_from_work }
+          self.representative_attachment_id = attributes.fetch(:representative_attachment_id) { representative_attachment_id_from_work }
         end
 
         # Because I am using `#fields_for` for rendering
@@ -44,8 +44,8 @@ module Sipity
 
         private
 
-        def representative_attachment_from_work
-          repository.representative_attachment_for(work: work)
+        def representative_attachment_id_from_work
+          repository.representative_attachment_for(work: work).to_param
         end
 
         def each_accessible_objects_attributes_are_valid

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -75,10 +75,7 @@ module Sipity
         end
 
         def attachments_from_work
-          return [] unless work
-          # I don't want this to be draped because the collection appeared to be
-          # treated as a single model instead of as an enumeration of items.
-          work.attachments.map { |attachment| AttachmentFormElement.new(attachment) }
+          repository.work_attachments(work: work).map { |attachment| AttachmentFormElement.new(attachment) }
         end
 
         # Responsible for exposing a means of displaying and marking the object

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -6,16 +6,12 @@ module Sipity
         def initialize(attributes = {})
           super
           self.files = attributes[:files]
-          self.representative_attachment_id = attributes[:representative_attachment_id]
+          self.representative_attachment_id = attributes.fetch(:representative_attachment_id) { representative_attachment_id_from_work }
           self.attachments_attributes = attributes.fetch(:attachments_attributes, {})
         end
 
         attr_accessor :files, :representative_attachment_id
         private(:files=, :representative_attachment_id=)
-
-        def representative_attachment
-          repository.representative_attachment_for(work: work)
-        end
 
         def attachments
           @attachments ||= attachments_from_work
@@ -28,6 +24,10 @@ module Sipity
         end
 
         private
+
+        def representative_attachment_id_from_work
+          repository.representative_attachment_for(work: work).to_param
+        end
 
         def save(requested_by:)
           super do

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -5,13 +5,13 @@ module Sipity
       class AttachForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
           super
-          @files = attributes[:files]
-          @representative_attachment_id = attributes[:representative_attachment_id]
+          self.files = attributes[:files]
+          self.representative_attachment_id = attributes[:representative_attachment_id]
           self.attachments_attributes = attributes.fetch(:attachments_attributes, {})
         end
 
-        attr_accessor :files
-        attr_accessor :representative_attachment_id
+        attr_accessor :files, :representative_attachment_id
+        private(:files=, :representative_attachment_id=)
 
         def representative_attachment
           repository.representative_attachment_for(work: work)

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -6,12 +6,12 @@ module Sipity
         def initialize(attributes = {})
           super
           @files = attributes[:files]
-          @mark_as_representative = attributes[:mark_as_representative]
+          @representative_attachment_id = attributes[:representative_attachment_id]
           self.attachments_attributes = attributes.fetch(:attachments_attributes, {})
         end
 
         attr_accessor :files
-        attr_accessor :mark_as_representative
+        attr_accessor :representative_attachment_id
 
         def representative_attachment
           repository.representative_attachment_for(work: work)
@@ -32,7 +32,7 @@ module Sipity
         def save(requested_by:)
           super do
             repository.attach_files_to(work: work, files: files, user: requested_by)
-            repository.set_as_representative_attachment(work: work, pid: mark_as_representative, user: requested_by)
+            repository.set_as_representative_attachment(work: work, pid: representative_attachment_id, user: requested_by)
             repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
             repository.amend_files_metadata(work: work, user: requested_by, metadata: attachments_metadata)
             # HACK: This is expanding the knowledge of what action is being

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -32,7 +32,7 @@ module Sipity
         def save(requested_by:)
           super do
             repository.attach_files_to(work: work, files: files, user: requested_by)
-            repository.mark_as_representative(work: work, pid: mark_as_representative, user: requested_by)
+            repository.set_as_representative_attachment(work: work, pid: mark_as_representative, user: requested_by)
             repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
             repository.amend_files_metadata(work: work, user: requested_by, metadata: attachments_metadata)
             # HACK: This is expanding the knowledge of what action is being

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -94,7 +94,7 @@ module Sipity
         end
       end
 
-      def mark_as_representative(work:, pid:, user: user)
+      def set_as_representative_attachment(work:, pid:, user: user)
         attachment = Models::Attachment.find_by(pid: pid)
         return true unless attachment.present?
         Models::Attachment.where(work_id: work.id, is_representative_file: true).update_all(is_representative_file: false)

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -3,7 +3,7 @@ module Sipity
     # Queries
     module AttachmentQueries
       def work_attachments(work:)
-        Models::Attachment.includes(:work).where(work_id: work)
+        Models::Attachment.includes(:work).where(work_id: work.id)
       end
 
       def accessible_objects(work:)

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -19,7 +19,7 @@ module Sipity
       end
 
       def representative_attachment_for(work:)
-        Models::Attachment.where(work_id: work.id, is_representative_file: true)
+        Models::Attachment.where(work_id: work.id, is_representative_file: true).first
       end
     end
   end

--- a/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
@@ -18,7 +18,7 @@
     <%= content_tag :p, t("sipity/decorators/entitiy_enrichments.panels.#{ model.enrichment_type }.hint_html"), class: 'panel-hint' %>
     <%= f.error_notification %>
     <table class="table">
-      <caption></caption>
+      <caption><!--TODO? Should we have a caption? --></caption>
       <thead>
         <tr>
           <th>&nbsp;</th>
@@ -67,19 +67,14 @@
           </tr>
         <% end %>
       </tbody>
-      <tfoot>
-        <tr class="borderless">
-          <%# TODO: styling and position of the place to where it should appear %>
-          <td colspan="5">
-            <%= f.input :copyright, collection: model.available_copyrights,
-                label_method: :predicate_value, value_method: :predicate_value_code,
-                include_blank: false, input_html: { class: 'form-control', selected: model.copyright} %>
-          </td>
-        </tr>
-      </tfoot>
     </table>
+    <div>
+      <%= f.input :mark_as_representative, collection: model.available_representative_attachments, label_method: :name, value_method: :id, input_html: { class: 'form-control' } %>
+      <%= f.input :copyright, collection: model.available_copyrights,
+            label_method: :predicate_value, value_method: :predicate_value_code,
+            include_blank: false, input_html: { class: 'form-control', selected: model.copyright} %>
+    </div>
   </fieldset>
-
   <div class="panel-footer action-pane">
     <%= f.submit nil, name: "form/#{model.enrichment_type}/submit" %>
   </div>

--- a/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/access_policy.html.erb
@@ -69,7 +69,7 @@
       </tbody>
     </table>
     <div>
-      <%= f.input :mark_as_representative, collection: model.available_representative_attachments, label_method: :name, value_method: :id, input_html: { class: 'form-control' } %>
+      <%= f.input :representative_attachment_id, collection: model.available_representative_attachments, input_html: { class: 'form-control' } %>
       <%= f.input :copyright, collection: model.available_copyrights,
             label_method: :predicate_value, value_method: :predicate_value_code,
             include_blank: false, input_html: { class: 'form-control', selected: model.copyright} %>

--- a/app/views/sipity/controllers/work_enrichments/attach.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/attach.html.erb
@@ -37,7 +37,7 @@
       <% end %>
     </ol>
 
-    <%= f.input :mark_as_representative, collection: model.attachments, label_method: :name, value_method: :id, input_html: { class: 'form-control' } %>
+    <%= f.input :representative_attachment_id, collection: model.attachments, label_method: :name, value_method: :id, input_html: { class: 'form-control' } %>
 
   <% end %>
 

--- a/app/views/sipity/controllers/work_enrichments/attach.html.erb
+++ b/app/views/sipity/controllers/work_enrichments/attach.html.erb
@@ -37,7 +37,7 @@
       <% end %>
     </ol>
 
-    <%= f.input :representative_attachment_id, collection: model.attachments, label_method: :name, value_method: :id, input_html: { class: 'form-control' } %>
+    <%= f.input :representative_attachment_id, collection: model.attachments, input_html: { class: 'form-control' } %>
 
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,7 @@ en:
       citation:
         type: 'Citation format'
       work:
-        mark_as_representative: 'Please select which file is your manuscript'
+        representative_attachment_id: 'Please select which file is your manuscript'
         files: 'Select files to upload'
   errors:
     messages:

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -80,7 +80,7 @@ module Sipity
           before { allow(subject).to receive(:valid?).and_return(true) }
 
           it 'will mark_as_representative' do
-            expect(repository).to receive(:mark_as_representative).and_call_original
+            expect(repository).to receive(:set_as_representative_attachment).and_call_original
             subject.submit(requested_by: user)
           end
 

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -19,7 +19,7 @@ module Sipity
 
         it { should respond_to :accessible_objects_attributes= }
         it { should respond_to :copyright }
-        it { should respond_to :mark_as_representative }
+        it { should respond_to :representative_attachment_id }
 
         it 'will expose accessible_objects' do
           expect(subject.accessible_objects.size).to eq(2)
@@ -45,9 +45,9 @@ module Sipity
         end
 
         it 'will validate the presence of a representative attachment' do
-          subject = described_class.new(work: work, repository: repository, mark_as_representative: '')
+          subject = described_class.new(work: work, repository: repository, representative_attachment_id: '')
           subject.valid?
-          expect(subject.errors[:mark_as_representative]).to be_present
+          expect(subject.errors[:representative_attachment_id]).to be_present
         end
 
         it 'will validate each of the given attributes' do
@@ -74,12 +74,12 @@ module Sipity
           subject do
             described_class.new(
               work: work, repository: repository, accessible_objects_attributes: attributes, copyright: rights,
-              mark_as_representative: attachment.to_param
+              representative_attachment_id: attachment.to_param
             )
           end
           before { allow(subject).to receive(:valid?).and_return(true) }
 
-          it 'will mark_as_representative' do
+          it 'will representative_attachment_id' do
             expect(repository).to receive(:set_as_representative_attachment).and_call_original
             subject.submit(requested_by: user)
           end

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -59,12 +59,31 @@ module Sipity
 
         context '#submit' do
           let(:rights) { 'All rights reserved' }
-          it 'will capture accessible_objects_attributes' do
-            attributes = {
+          let(:attributes) do
+            {
               "0" => { "id" => work.to_param, "access_right_code" => 'open_access', "release_date" => "" },
               "1" => { "id" => attachment.to_param, "access_right_code" => 'embargo_then_open_access', "release_date" => "2032-12-01" }
             }
-            subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: attributes, copyright: rights)
+          end
+          subject do
+            described_class.new(
+              work: work, repository: repository, accessible_objects_attributes: attributes, copyright: rights,
+              mark_as_representative: attachment.to_param
+            )
+          end
+          before { allow(subject).to receive(:valid?).and_return(true) }
+
+          it 'will mark_as_representative' do
+            expect(repository).to receive(:mark_as_representative).and_call_original
+            subject.submit(requested_by: user)
+          end
+
+          it 'will update_work_attribute_values!' do
+            expect(repository).to receive(:update_work_attribute_values!).and_call_original
+            subject.submit(requested_by: user)
+          end
+
+          it 'will capture accessible_objects_attributes' do
             expect(repository).to receive(:apply_access_policies_to).with(
               work: work, user: user, access_policies:
               [

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -27,7 +27,7 @@ module Sipity
 
         it 'will expose available_representative_attachments' do
           enumerable = [double]
-          expect(repository).to receive(:available_representative_attachments).and_return(enumerable)
+          expect(repository).to receive(:work_attachments).and_return(enumerable)
           expect(subject.available_representative_attachments).to eq(enumerable)
         end
 

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -14,10 +14,12 @@ module Sipity
         before do
           allow(repository).to receive(:work_attribute_values_for).with(work: work, key: 'copyright').and_return([])
           allow(repository).to receive(:access_rights_for_accessible_objects_of).with(work: work).and_return([work, attachment])
+          allow(repository).to receive(:representative_attachment_for).with(work: work).and_return(attachment)
         end
 
         it { should respond_to :accessible_objects_attributes= }
         it { should respond_to :copyright }
+        it { should respond_to :mark_as_representative }
 
         it 'will expose accessible_objects' do
           expect(subject.accessible_objects.size).to eq(2)
@@ -34,6 +36,12 @@ module Sipity
           subject = described_class.new(work: work, repository: repository, accessible_objects_attributes: {})
           subject.valid?
           expect(subject.errors[:base]).to be_present
+        end
+
+        it 'will validate the presence of a representative attachment' do
+          subject = described_class.new(work: work, repository: repository, mark_as_representative: '')
+          subject.valid?
+          expect(subject.errors[:mark_as_representative]).to be_present
         end
 
         it 'will validate each of the given attributes' do

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -25,6 +25,12 @@ module Sipity
           expect(subject.accessible_objects.size).to eq(2)
         end
 
+        it 'will expose available_representative_attachments' do
+          enumerable = [double]
+          expect(repository).to receive(:available_representative_attachments).and_return(enumerable)
+          expect(subject.available_representative_attachments).to eq(enumerable)
+        end
+
         it 'will validate that a copyright is given' do
           expect(repository).to receive(:work_attribute_values_for).with(work: work, key: 'copyright').and_return([])
           subject = described_class.new(work: work, repository: repository)

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -116,7 +116,7 @@ module Sipity
             end
 
             it 'will mark a file as representative' do
-              expect(repository).to receive(:mark_as_representative).and_call_original
+              expect(repository).to receive(:set_as_representative_attachment).and_call_original
               subject.submit(requested_by: user)
             end
           end

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -12,6 +12,8 @@ module Sipity
         its(:enrichment_type) { should eq('attach') }
 
         it { should respond_to :attachments }
+        it { should respond_to :representative_attachment_id }
+        it { should respond_to :files }
 
         context 'validations' do
           it 'will require a work' do

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -26,7 +26,7 @@ module Sipity
           it 'will have #representative_for_attachment_id' do
             expect(repository).to receive(:representative_attachment_for).
               with(work: work).and_return(representative_for_attachment)
-            subject.representative_attachment
+            subject.representative_attachment_id
           end
 
           let(:attachment) { [double('Attachment')] }

--- a/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/attach_form_spec.rb
@@ -22,16 +22,16 @@ module Sipity
             expect(subject.errors[:work]).to_not be_empty
           end
 
-          let(:representative_for_attachment) { [double('Attachment')] }
           it 'will have #representative_for_attachment_id' do
+            representative_for_attachment = [double('Attachment')]
             expect(repository).to receive(:representative_attachment_for).
               with(work: work).and_return(representative_for_attachment)
             subject.representative_attachment_id
           end
 
-          let(:attachment) { [double('Attachment')] }
           it 'will have #attachments' do
-            expect(work).to receive(:attachments).and_return(attachment)
+            attachment = [double('Attachment')]
+            expect(repository).to receive(:work_attachments).and_return(attachment)
             expect(subject.attachments).to_not be_empty
           end
         end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -164,7 +164,7 @@ module Sipity
         end
       end
 
-      context '#mark_as_representative' do
+      context '#set_as_representative_attachment' do
         let(:file) { FileUpload.fixture_file_upload('attachments/hello-world.txt') }
         let(:file_name) { "hello-world.txt" }
         let(:user) { User.new(id: 1234) }
@@ -172,11 +172,11 @@ module Sipity
         let(:pid_minter) { -> { 'abc123' } }
         before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will mark the given attachments as representative in the system' do
-          expect { test_repository.mark_as_representative(work: work, pid: pid_minter.call, user: user) }.
+          expect { test_repository.set_as_representative_attachment(work: work, pid: pid_minter.call, user: user) }.
             to change { Models::Attachment.where(is_representative_file: true).count }.by(1)
         end
         it 'will not mark the given attachments as representative in the system' do
-          expect { test_repository.mark_as_representative(work: work, pid: 'bogus', user: user) }.
+          expect { test_repository.set_as_representative_attachment(work: work, pid: 'bogus', user: user) }.
             not_to change { Models::Attachment.where(is_representative_file: true).count }
         end
       end

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -31,9 +31,11 @@ module Sipity
 
       context '#representative_attachment_for' do
         it 'returns attachment marked as representative for work' do
-          attachment = Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment',
-                                     file: file, is_representative_file: true)
-          expect(subject.representative_attachment_for(work: work).count).to eq(attachment)
+          attachment = Models::Attachment.create!(
+            work_id: work.id, pid: 'attach1', predicate_name: 'attachment',
+            file: file, is_representative_file: true
+          )
+          expect(subject.representative_attachment_for(work: work)).to eq(attachment)
         end
       end
 

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -31,9 +31,9 @@ module Sipity
 
       context '#representative_attachment_for' do
         it 'returns attachment marked as representative for work' do
-          Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment',
+          attachment = Models::Attachment.create!(work_id: work.id, pid: 'attach1', predicate_name: 'attachment',
                                      file: file, is_representative_file: true)
-          expect(subject.representative_attachment_for(work: work).count).to eq(1)
+          expect(subject.representative_attachment_for(work: work).count).to eq(attachment)
         end
       end
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -201,10 +201,6 @@ module Sipity
     def manage_collaborators_for(work:, collaborators:)
     end
 
-    # @see ./app/repositories/sipity/commands/work_commands.rb
-    def set_as_representative_attachment(work:, pid:, user: user)
-    end
-
     # @see ./app/repositories/sipity/queries/processing_queries.rb
     def non_user_collaborators_that_have_taken_the_action_on_the_entity(entity:, action:)
     end
@@ -303,6 +299,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/queries/event_log_queries.rb
     def sequence_of_events_for(options = {})
+    end
+
+    # @see ./app/repositories/sipity/commands/work_commands.rb
+    def set_as_representative_attachment(work:, pid:, user: user)
     end
 
     # @see ./app/repositories/sipity/commands/doi_commands.rb

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -202,7 +202,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def mark_as_representative(work:, pid:, user: user)
+    def set_as_representative_attachment(work:, pid:, user: user)
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb


### PR DESCRIPTION
The original ticket said to move the attribute; However, I have opted to instead render it on both forms.

## Tweaking representative_attachment_for return val

@178f31ff6416a145a3abc19f71f11dc107b689d1

Instead of returning an ActiveRecord::Relation return the found
object, if applicable.

## Moving mark_as_representative to AccessPolicyForm

@5e2a74aef9f617855a8d08b6b7ba5985bd4c2821

This involves exposing validation and retrieval.

## Ensuring the representative image is persisted

@e78b397335f2e286b8d738a0805b2324128acf83


## Exposing available_representative_attachments

@ec85642cc11faa5684daa42356ff4b99956fec09

This method is used for building the select criteria.

## Renaming mark_as_representative repository method

@e93ab5306f89c30ad6b26aa8338d1b08a63ce053

To reduce confusion on an attribute for a form and a repository
method, I am opting to rename this.

I then want to rename the attribute :mark_as_representative to
:representative_attachment_id

## Renaming mark_as_representative

@d50db3d93dbe8faf08c800d9ee796e85821531eb

I have found the name confusing. Mark as representative implies an
action not a property; That is it implies transformative changes. This
is made confusing when we rendering on the view:

```erb
<%= f.input :mark_as_representative %>
```

I would rather clarify by saying:

```erb
<%= f.input :representative_attachment_id %>
```

The latter implies a property, and thus data that is manipulated via a
form object.

## Switching from instance variables to accessors

@7519b3be5b83a6dc34c896cdc2dcca07a1489139

Instance variables are nice, but if I want to extend a form, they
become cumbersome; `attr_accessor`s are so cheap that I should use
those.

## Ensuring that persisted attributes are rendered

@0c157f71f10fa88e84878f414f8f86d0e6769546

Prior to this commit, even though we were capturing the information
and persisting it, when you would go back to the page, it would not
show your persisted decision.

## Fixing broken tests

@bbdd9627e53febbec9ac931250eb989c2448832f


## Fixing a typo

@c6627fc5f6c2d71f2ee7fe39f0bcd7cf3827b5a9

While this did work, it looks funny. I'm saying where the work_id
equals the given work; Rails interpolates what I mean but its sloppy
and somewhat confusing.

## Vanity cleanup

@d96d7c653513bab638ac9c65f5f68f3703860c09

Defering to repository methods instead of data structure knowledge.
For me, the jury is still out on this; Is it better to have a data
structure with lots of methods or is it better to leverage a
repository method to convey this information?

Miss you @jimweirich because I believe you would have a helpful
answer.

Closes #353
