### PR TITLE
Enforcing that less than 100% code coverage breaks the build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,10 +54,20 @@ if defined?(RSpec)
       t.pattern = './spec/features/**/*_spec.rb'
     end
 
+    desc "Validate the code coverage goals"
+    task validate_coverage_goals: :environment do
+      default_percentage_coverage_goal = '100'
+      json_document = Rails.root.join('coverage/.last_run.json').read
+      coverage_percentage = JSON.parse(json_document).fetch('result').fetch('covered_percent').to_i
+      goal_percentage = (Figaro.env.percent_coverage_goal || default_percentage_coverage_goal).to_i
+      if goal_percentage > coverage_percentage
+        abort("Code Coverage Goal Not Met:\n\t#{goal_percentage}%\tExpected\n\t#{coverage_percentage}%\tActual")
+      end
+    end
   end
 
   Rake::Task["default"].clear
-  task default: ['db:schema:load', 'rubocop', 'spec:all']
+  task default: ['db:schema:load', 'rubocop', 'spec:all', 'spec:validate_coverage_goals']
   task spec: ['sipity:rebuild_interfaces']
   task stats: ['sipity:stats_setup']
 end


### PR DESCRIPTION
The 100% is a configurable options.

What I mean by code is `.rb` files in the `app` or `lib` directory.

As this is a goal under discussion (see #372), and one that can be
enforced, I'd like to advocate for automated enforcement.

First: It is a configurable value; If we find that 100% is to
aggressive we can dial that back. We already have 100% coverage, so
keeping to that is less expensive than on code bases we are picking up
to maintain.

Second: My goal for the group is to still push towards Test Drive
Development; I understand the reality of the learning curve for
testing. However, as a reviewer of the code I would like to leverage
any and all tools available to help in the review process. One of
those is making sure that new code is tested; Code coverage is, in my
estimation, a proxy for that.

Third: Similar to Rubocop's enforcement of style guides, this task
again reduces the chatter of pull requests; As a reviewer I will not
need to bug you about tests being written. I can instead focus on
reviewing the code for clarity, consistency, and efficacy.

I am passionate about this but want to make sure I am honoring each of
the team members contributions and perspectives.

So lets discuss this; Is it something you are willing to try for two
sprints? I'm also hear to help you write those tests to reach our
goal.
