### PR TITLE
Loosening Ruby vesrion requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: bundler
 sudo: false
 rvm:
   - "2.1.5"
+  - "2.2.1"
 
 script: 'bundle exec rake spec:travis'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby '2.1.5'
 gem 'rails', '~> 4.2'
 gem 'responders', '~> 2.0'
 gem 'sass-rails'


### PR DESCRIPTION
* Rails 5 will require Ruby 2.2.1 and greater
* There are notable performance increases in Ruby 2.2.1 vs. Ruby 2.1.5