### PR TITLE
Removing unneeded gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'hesburgh-lib', github: 'ndlib/hesburgh-lib'
 gem 'ezid-client', github: 'duke-libraries/ezid-client'
 gem 'noids_client', git: 'git://github.com/ndlib/noids_client'
 gem 'dragonfly', '~> 1.0.7'
-gem 'net-ldap'
 gem 'execjs'
 
 group :doc do

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'draper', '~> 1.4'
 gem 'devise_cas_authenticatable'
 gem 'hesburgh-lib', github: 'ndlib/hesburgh-lib'
 gem 'ezid-client', github: 'duke-libraries/ezid-client'
-gem 'micromachine', github: 'jeremyf/micromachine' # Ensuring code continues to exist
 gem 'noids_client', git: 'git://github.com/ndlib/noids_client'
 gem 'dragonfly', '~> 1.0.7'
 gem 'net-ldap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,6 @@ GIT
     ezid-client (0.11.0)
 
 GIT
-  remote: git://github.com/jeremyf/micromachine.git
-  revision: bf4f68d34e5e568d92c0a34257e502a6f2583951
-  specs:
-    micromachine (1.1.0)
-
-GIT
   remote: git://github.com/ndlib/hesburgh-lib.git
   revision: a22bae11b65f1eabbdba3e02fabf1c5cded63ac0
   specs:
@@ -563,7 +557,6 @@ DEPENDENCIES
   launchy
   letter_opener
   meta_request
-  micromachine!
   mysql2
   net-ldap
   noids_client!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,6 @@ GEM
     multi_json (1.11.0)
     mysql2 (0.3.18)
     nenv (0.1.1)
-    net-ldap (0.11)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -558,7 +557,6 @@ DEPENDENCIES
   letter_opener
   meta_request
   mysql2
-  net-ldap
   noids_client!
   poltergeist
   pry-byebug


### PR DESCRIPTION
## Removing Micromachine dependency

@23b339615e61936b6a608b765ae1829de7ea790c

I was using this gem to model state machines, but since I've pushed
those concerns into the database, this is no longer needed.

## Removing net-ldap dependency

@b694abb8a346c86eb517801dc0faa4029f6f38aa

By using the Hesburgh API, we no longer need the net-ldap gem.
