### PR TITLE
Normalizing create work services

### DIFF
--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -22,17 +22,10 @@ module Sipity
       attr_accessor :repository
       private(:repository, :repository=)
 
-      validates :title,
-                presence: { message: I18n.t('sipity/forms.create_work_form.error_messages.title') }
-      validates :work_publication_strategy,
-                presence: { message: I18n.t('sipity/forms.create_work_form.error_messages.work_publication_strategy') },
-                inclusion: { in: :possible_work_publication_strategies, message: I18n.t('sipity/forms.error_messages.inclusion') }
-      validates :work_type,
-                presence: { message: I18n.t('sipity/forms.create_work_form.error_messages.work_type') },
-                inclusion: { in: :possible_work_types, message: I18n.t('sipity/forms.error_messages.inclusion') }
-      validates :access_rights_answer,
-                presence: { message: I18n.t('sipity/forms.create_work_form.error_messages.access_rights_answer') },
-                inclusion: { in: :possible_access_right_answers, message: I18n.t('sipity/forms.error_messages.inclusion') }
+      validates :title, presence: true
+      validates :work_publication_strategy, presence: true, inclusion: { in: :possible_work_publication_strategies }
+      validates :work_type, presence: true, inclusion: { in: :possible_work_types }
+      validates :access_rights_answer, presence: true, inclusion: { in: :possible_access_right_answers }
 
       def access_rights_answer_for_select
         possible_access_right_answers.map(&:to_sym)

--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -12,13 +12,12 @@ module Sipity
       def initialize(attributes = {})
         @title = attributes[:title]
         @work_publication_strategy = attributes[:work_publication_strategy]
-        @publication_date = attributes[:publication_date]
         @work_type = attributes[:work_type]
         @access_rights_answer = attributes.fetch(:access_rights_answer) { default_access_rights_answer }
         self.repository = attributes.fetch(:repository) { default_repository }
       end
 
-      attr_reader :title, :work_publication_strategy, :publication_date, :work_type, :access_rights_answer
+      attr_reader :title, :work_publication_strategy, :work_type, :access_rights_answer
       attr_accessor :repository
       private(:repository, :repository=)
 
@@ -45,7 +44,6 @@ module Sipity
           # I believe this form has too much knowledge of what is going on;
           # Consider pushing some of the behavior down into the repository.
           repository.handle_transient_access_rights_answer(entity: work, answer: access_rights_answer)
-          repository.update_work_publication_date!(work: work, publication_date: publication_date)
           repository.grant_creating_user_permission_for!(entity: work, user: requested_by)
           repository.send_notification_for_entity_trigger(
             notification: "confirmation_of_entity_created", entity: work, acting_as: 'creating_user'

--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -15,6 +15,7 @@ module Sipity
         @publication_date = attributes[:publication_date]
         @work_type = attributes[:work_type]
         @access_rights_answer = attributes.fetch(:access_rights_answer) { default_access_rights_answer }
+        self.repository = attributes.fetch(:repository) { default_repository }
       end
 
       attr_reader :title
@@ -22,6 +23,8 @@ module Sipity
       attr_reader :publication_date
       attr_reader :work_type
       attr_reader :access_rights_answer
+      attr_accessor :repository
+      private :repository, :repository=
 
       validates :title,
                 presence: { message: I18n.t('sipity/forms.create_work_form.error_messages.title') }
@@ -47,7 +50,7 @@ module Sipity
         possible_work_types.map { |elem| elem.first.to_sym }
       end
 
-      def submit(repository:, requested_by:)
+      def submit(requested_by:)
         super() do |f|
           # This method shows an intimate knowledge of the data structure of
           # what goes into a work. It works for now, but is something to consider.
@@ -83,6 +86,10 @@ module Sipity
 
       def event_name
         File.join(self.class.to_s.demodulize.underscore, 'submit')
+      end
+
+      def default_repository
+        CommandRepository.new
       end
     end
   end

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -20,7 +20,7 @@ module Sipity
       end
 
       def build_create_work_form(attributes: {})
-        Forms::CreateWorkForm.new(attributes)
+        Forms::CreateWorkForm.new(attributes.merge(repository: self))
       end
 
       def build_update_work_form(work:, attributes: {})

--- a/app/runners/sipity/runners/work_runners.rb
+++ b/app/runners/sipity/runners/work_runners.rb
@@ -25,7 +25,7 @@ module Sipity
         def run(attributes:)
           form = repository.build_create_work_form(attributes: attributes)
           authorization_layer.enforce!(action_name => form) do
-            work = form.submit(repository: repository, requested_by: current_user)
+            work = form.submit(requested_by: current_user)
             if work
               callback(:success, work)
             else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,15 +235,23 @@ en:
       citation_already_assigned: 'Citation Already Assigned'
       citation_not_assigned: 'Citation Not Yet Assigned'
     name: 'Citation'
+  activemodel:
+    errors:
+      models:
+        sipity/forms/base_form:
+          attributes:
+            title:
+              blank: 'You must provide a title'
+            work_publication_strategy:
+              blank: 'Please tell us if you intend to publish this work'
+            work_type:
+              inclusion: 'Please select an option from the above list'
+              blank: 'Please select a work type'
+            access_rights_answer:
+              blank: 'Please select an option'
+              inclusion: 'Please select an option from the list'
   sipity/forms:
     error_messages:
-      inclusion: 'Please select an option from the above list'
-    create_work_form:
-      error_messages:
-        access_rights_answer: 'You must select an option'
-        title: 'You must provide a title'
-        work_publication_strategy: 'Please tell us if you intend to publish this work'
-        work_type: 'Please select a work type'
     state_advancing_actions:
       legend:
         etd/advisor_requests_change: 'Changes are Required to Meet My Approval'

--- a/spec/forms/sipity/forms/create_work_form_spec.rb
+++ b/spec/forms/sipity/forms/create_work_form_spec.rb
@@ -76,7 +76,6 @@ module Sipity
           described_class.new(
             title: 'This is my title',
             work_publication_strategy: 'do_not_know',
-            publication_date: '2014-11-12',
             access_rights_answer: Models::TransientAnswer::ACCESS_RIGHTS_PRIVATE,
             repository: repository
           )
@@ -107,6 +106,11 @@ module Sipity
 
           it 'will log the event' do
             expect(repository).to receive(:log_event!).and_call_original
+            subject.submit(requested_by: user)
+          end
+
+          it 'will grant creating user permission for' do
+            expect(repository).to receive(:grant_creating_user_permission_for!).and_call_original
             subject.submit(requested_by: user)
           end
 


### PR DESCRIPTION
## Pushing CreateWork towards normal form

@c728b4d61998ece6532adae6f83cdbd51aa3519a

With this commit, the CreateWorkForm is more like the other forms in
the application.

## Tidying up create_work_form

@27c0691e14e23fd7ff2c48fbaeaa4050caa385e1

The method complexity had become too high, so I needed to tease apart
the form submission.

## Normalizing I18n for create work errors

@73bdd346cb574453f664ce82c0622e08ec3dd28f

This removes some of the chatter from the form, and helps keep the
concern more narrow.

## Removing publication_date from create work form

@94ac3f4d32b228716909550b2068207c877491fe

This is a hold over from a previous setup; we don't need it.
