### PR TITLE
Removing unused parameter from method

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -63,7 +63,7 @@ module Sipity
           super do
             repository.apply_access_policies_to(work: work, user: requested_by, access_policies: access_objects_attributes_for_persistence)
             repository.update_work_attribute_values!(work: work, key: 'copyright', values: copyright)
-            repository.set_as_representative_attachment(work: work, pid: representative_attachment_id, user: requested_by)
+            repository.set_as_representative_attachment(work: work, pid: representative_attachment_id)
           end
         end
 

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -33,7 +33,7 @@ module Sipity
         def save(requested_by:)
           super do
             repository.attach_files_to(work: work, files: files, user: requested_by)
-            repository.set_as_representative_attachment(work: work, pid: representative_attachment_id, user: requested_by)
+            repository.set_as_representative_attachment(work: work, pid: representative_attachment_id)
             repository.remove_files_from(work: work, user: requested_by, pids: ids_for_deletion)
             repository.amend_files_metadata(work: work, user: requested_by, metadata: attachments_metadata)
             # HACK: This is expanding the knowledge of what action is being

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -94,7 +94,7 @@ module Sipity
         end
       end
 
-      def set_as_representative_attachment(work:, pid:, user: user)
+      def set_as_representative_attachment(work:, pid:)
         attachment = Models::Attachment.find_by(pid: pid)
         return true unless attachment.present?
         Models::Attachment.where(work_id: work.id, is_representative_file: true).update_all(is_representative_file: false)

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -180,11 +180,11 @@ module Sipity
         let(:pid_minter) { -> { 'abc123' } }
         before { test_repository.attach_files_to(work: work, files: file, user: user, pid_minter: pid_minter) }
         it 'will mark the given attachments as representative in the system' do
-          expect { test_repository.set_as_representative_attachment(work: work, pid: pid_minter.call, user: user) }.
+          expect { test_repository.set_as_representative_attachment(work: work, pid: pid_minter.call) }.
             to change { Models::Attachment.where(is_representative_file: true).count }.by(1)
         end
         it 'will not mark the given attachments as representative in the system' do
-          expect { test_repository.set_as_representative_attachment(work: work, pid: 'bogus', user: user) }.
+          expect { test_repository.set_as_representative_attachment(work: work, pid: 'bogus') }.
             not_to change { Models::Attachment.where(is_representative_file: true).count }
         end
       end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -306,7 +306,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def set_as_representative_attachment(work:, pid:, user: user)
+    def set_as_representative_attachment(work:, pid:)
     end
 
     # @see ./app/repositories/sipity/commands/doi_commands.rb


### PR DESCRIPTION
Detected a warning in Ruby 2.2.1

```
warning: circular argument reference - user
```