### PR TITLE
Removing already initialized warning for specs

### DIFF
--- a/spec/decorators/sipity/decorators/processing/base_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/base_decorator_spec.rb
@@ -4,15 +4,14 @@ module Sipity
   module Decorators
     module Processing
       RSpec.describe BaseDecorator do
-        ENTITY_ID = '1234'
-        let(:entity) { Models::Work.new(id: ENTITY_ID) }
+        let(:entity) { Models::Work.new(id: '1234') }
         let(:action) { double(name: 'herd', action_type: 'cattle') }
         let(:user) { double('User') }
         subject { described_class.new(action: action, entity: entity, user: user) }
 
         its(:name) { should eq(action.name) }
         its(:action_type) { should eq(action.action_type) }
-        its(:path) { should eq('/works/1234/herd') }
+        its(:path) { should eq("/works/#{entity.id}/herd") }
       end
     end
   end

--- a/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/resourceful_action_decorator_spec.rb
@@ -4,7 +4,7 @@ module Sipity
   module Decorators
     module Processing
       RSpec.describe ResourcefulActionDecorator do
-        ENTITY_ID = '1234'
+        ENTITY_ID = '1234' unless defined?(ENTITY_ID)
         let(:entity) { Models::Work.new(id: ENTITY_ID) }
         let(:user) { double }
 


### PR DESCRIPTION
The following message has been around for quite awhile. Getting rid of
it.

```console
resourceful_action_decorator_spec.rb:7: warning: already initialized
constant Sipity::Decorators::Processing::ENTITY_ID
base_decorator_spec.rb:7: warning: previous definition of ENTITY_ID
was here
```