### PR TITLE
Adding brakeman for vulnerability scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@
 db/*.sqlite3
 /db/*.sqlite3-journal
 /log/*
-/tmp/*
+/.tmp.*
 
 # various artifacts
 **.war

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'jshintrb', require: false
   gem 'sqlite3'
+  gem 'brakeman', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,16 @@ GEM
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    brakeman (3.0.2)
+      erubis (~> 2.6)
+      fastercsv (~> 1.5)
+      haml (>= 3.0, < 5.0)
+      highline (~> 1.6.20)
+      multi_json (~> 1.2)
+      ruby2ruby (~> 2.1.1)
+      ruby_parser (~> 3.6.2)
+      sass (~> 3.0)
+      terminal-table (~> 1.4)
     builder (3.2.2)
     byebug (3.5.1)
       columnize (~> 0.8)
@@ -166,6 +176,7 @@ GEM
     execjs (2.4.0)
     faker (1.4.3)
       i18n (~> 0.5)
+    fastercsv (1.5.5)
     ffi (1.9.8)
     figaro (1.1.0)
       thor (~> 0.14)
@@ -285,7 +296,10 @@ GEM
     guard-scss-lint (0.0.1alpha)
       guard (~> 2.0)
       scss-lint (~> 0.30.0)
+    haml (4.0.6)
+      tilt
     high_voltage (2.2.1)
+    highline (1.6.21)
     hike (1.2.3)
     hitimes (1.2.2)
     i18n (0.7.0)
@@ -457,6 +471,11 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.1)
+    ruby2ruby (2.1.3)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.6.5)
+      sexp_processor (~> 4.1)
     rubycas-client (2.3.9)
       activesupport
     rubyzip (1.1.6)
@@ -482,6 +501,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sexp_processor (4.5.0)
     shellany (0.0.1)
     simple_form (3.1.0)
       actionpack (~> 4.0)
@@ -518,6 +538,7 @@ GEM
       tins (~> 1.0)
     terminal-notifier (1.6.2)
     terminal-notifier-guard (1.6.4)
+    terminal-table (1.4.5)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -549,6 +570,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass
+  brakeman
   capistrano (~> 3.1)
   capistrano-bundler
   capistrano-rails

--- a/Rakefile
+++ b/Rakefile
@@ -78,6 +78,7 @@ if defined?(RSpec)
     task travis: [:rubocop, :jshint, 'brakeman:guard_against_deteced_vulnerabilities'] do
       ENV['SPEC_OPTS'] ||= "--profile 5"
       Rake::Task['spec:all'].invoke
+      Rake::Task['spec:validate_coverage_goals'].invoke
     end
 
     desc "Run all features with accessibility checks"

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ Rails.application.load_tasks
 begin
   require 'jshintrb/jshinttask'
   Jshintrb::JshintTask.new :jshint do |t|
-    puts 'Running JSHint...'
     t.pattern = 'app/assets/**/*.js'
     t.exclude_pattern = 'app/assets/javascripts/vendor/*.js'
     t.options = JSON.parse(IO.read('.jshintrc'))


### PR DESCRIPTION
## Adding brakeman gem for vulnerability scans

@03ca9af50f920884a48fd833b01b4e5c3f63c66d

$ bundle install

> Brakeman is a static analysis tool which checks Ruby on Rails
> applications for security vulnerabilities.
>
> https://github.com/presidentbeef/brakeman

I am interested in making this part of the build; If there are
vulnerabilities the build should be considered broken.

## Guarding against detectable vulnerabilities

@d3e87a5efb0a2c342d22ccc32c26d5405847f81f

Brakeman is a static anaylsis security vulnerability scanner. It can
find potential vulnerabilities in our code. By adding this task as
part of the Travis build it is one more means of claiming ownership of
our application.

## Adding coverage threshold for build criteria

@1eb691e891c2ec543bfc6418f4be4bf3362f44b9

This is already locally enforced, but via an oversight it was skipped.
Closing that loop.

## Removing extraneous puts command

@7c9bc8667d793da0f4516a2d7144d5791a725c58

This command was running each time rake was invoked, regardless of
task.
