### PR TITLE
Paying down tech debt

### DIFF
--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -81,10 +81,9 @@ module Sipity
         end
       end
 
-      def selected_copyright(copyright)
-        saved_copyright = available_copyrights.where(predicate_value_code: copyright)
-        return nil unless saved_copyright.any?
-        build_copyright_link(saved_copyright.first.predicate_value, copyright)
+      def selected_copyright(copyright_url)
+        copyright_value = repository.get_controlled_vocabulary_value_for(name: 'copyright', predicate_value_code: copyright_url)
+        "<a href='#{copyright_url}'>#{copyright_value}</a>"
       end
 
       private
@@ -95,14 +94,6 @@ module Sipity
 
       def processing_actions(user:)
         @processing_actions ||= ProcessingActions.new(user: user, entity: self)
-      end
-
-      def available_copyrights
-        @available_copyrights ||= repository.get_controlled_vocabulary_entries_for_predicate_name(name: 'copyright')
-      end
-
-      def build_copyright_link(copyright_text, copyright_link)
-        "<a href='#{copyright_link}'>#{copyright_text}</a>"
       end
     end
   end

--- a/app/decorators/sipity/decorators/work_decorator.rb
+++ b/app/decorators/sipity/decorators/work_decorator.rb
@@ -98,7 +98,7 @@ module Sipity
       end
 
       def available_copyrights
-        @available_copyrights ||= repository.get_controlled_vocabulary_for_predicate_name(name: 'copyright')
+        @available_copyrights ||= repository.get_controlled_vocabulary_entries_for_predicate_name(name: 'copyright')
       end
 
       def build_copyright_link(copyright_text, copyright_link)

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -35,7 +35,7 @@ module Sipity
         end
 
         def available_copyrights
-          repository.get_controlled_vocabulary_for_predicate_name(name: 'copyright')
+          repository.get_controlled_vocabulary_entries_for_predicate_name(name: 'copyright')
         end
 
         def available_representative_attachments

--- a/app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
+++ b/app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
@@ -3,10 +3,10 @@ module Sipity
     # Queries
     module SimpleControlledVocabularyQueries
       def get_controlled_vocabulary_values_for_predicate_name(name:)
-        get_controlled_vocabulary_for_predicate_name(name: name).pluck(:predicate_value)
+        get_controlled_vocabulary_entries_for_predicate_name(name: name).pluck(:predicate_value)
       end
 
-      def get_controlled_vocabulary_for_predicate_name(name:)
+      def get_controlled_vocabulary_entries_for_predicate_name(name:)
         Models::SimpleControlledVocabulary.where(predicate_name: name).order(:predicate_value)
       end
     end

--- a/app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
+++ b/app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
@@ -9,6 +9,12 @@ module Sipity
       def get_controlled_vocabulary_entries_for_predicate_name(name:)
         Models::SimpleControlledVocabulary.where(predicate_name: name).order(:predicate_value)
       end
+
+      def get_controlled_vocabulary_value_for(name:, predicate_value_code:)
+        Models::SimpleControlledVocabulary.
+          where(predicate_name: name, predicate_value_code: predicate_value_code).
+          pluck(:predicate_value).first || predicate_value_code
+      end
     end
   end
 end

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -91,19 +91,11 @@ module Sipity
       context "#selected_copyright" do
         let(:predicate_value_code) { "http://creativecommons.org/licenses/by/3.0/us/" }
         let(:predicate_value) { "Attribution 3.0 United States" }
-        let(:obtained_copyrights) do
-          [Sipity::Models::SimpleControlledVocabulary.new(
-            predicate_name: 'copyright', predicate_value: predicate_value, predicate_value_code: predicate_value_code
-          )]
-        end
-        let(:copyrights) do
-          double(ActiveRecord::Relation)
-        end
         let(:copyright_link) { "<a href='#{predicate_value_code}'>#{predicate_value}</a>" }
         it 'will have #selected_copyrights' do
-          expect(repository).to receive(:get_controlled_vocabulary_entries_for_predicate_name).with(name: 'copyright').
-            and_return(copyrights)
-          expect(copyrights).to receive(:where).and_return(obtained_copyrights)
+          expect(repository).to receive(:get_controlled_vocabulary_value_for).
+            with(name: 'copyright', predicate_value_code: predicate_value_code).
+            and_return(predicate_value)
           expect(subject.selected_copyright(predicate_value_code)).to eq(copyright_link)
         end
       end

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -101,7 +101,7 @@ module Sipity
         end
         let(:copyright_link) { "<a href='#{predicate_value_code}'>#{predicate_value}</a>" }
         it 'will have #selected_copyrights' do
-          expect(repository).to receive(:get_controlled_vocabulary_for_predicate_name).with(name: 'copyright').
+          expect(repository).to receive(:get_controlled_vocabulary_entries_for_predicate_name).with(name: 'copyright').
             and_return(copyrights)
           expect(copyrights).to receive(:where).and_return(obtained_copyrights)
           expect(subject.selected_copyright(predicate_value_code)).to eq(copyright_link)

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -66,7 +66,7 @@ module Sipity
         end
 
         it 'will have #available_copyrights' do
-          expect(repository).to receive(:get_controlled_vocabulary_for_predicate_name).with(name: 'copyright').
+          expect(repository).to receive(:get_controlled_vocabulary_entries_for_predicate_name).with(name: 'copyright').
             and_return(copyrights)
           expect(subject.available_copyrights).to eq(copyrights)
         end

--- a/spec/repositories/sipity/queries/simple_controlled_vocabulary_queries_spec.rb
+++ b/spec/repositories/sipity/queries/simple_controlled_vocabulary_queries_spec.rb
@@ -13,16 +13,23 @@ module Sipity
             predicate_value_code: 'A code')
         end
 
-        before do
-          vocab
-        end
-
         it 'will get all the values associated with predicate_name' do
+          vocab
           expect(test_repository.get_controlled_vocabulary_values_for_predicate_name(name: name)).to eq([value])
         end
 
         it 'will get records associated with predicate_name' do
+          vocab
           expect(test_repository.get_controlled_vocabulary_entries_for_predicate_name(name: name)).to eq([vocab])
+        end
+
+        it 'will get controlled vocabulary value for the predicate and code' do
+          vocab
+          expect(test_repository.get_controlled_vocabulary_value_for(name: name, predicate_value_code: 'A code')).to eq(value)
+        end
+
+        it 'will default to the given code if nothing is found' do
+          expect(test_repository.get_controlled_vocabulary_value_for(name: name, predicate_value_code: 'A code')).to eq('A code')
         end
       end
     end

--- a/spec/repositories/sipity/queries/simple_controlled_vocabulary_queries_spec.rb
+++ b/spec/repositories/sipity/queries/simple_controlled_vocabulary_queries_spec.rb
@@ -22,7 +22,7 @@ module Sipity
         end
 
         it 'will get records associated with predicate_name' do
-          expect(test_repository.get_controlled_vocabulary_for_predicate_name(name: name)).to eq([vocab])
+          expect(test_repository.get_controlled_vocabulary_entries_for_predicate_name(name: name)).to eq([vocab])
         end
       end
     end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -182,7 +182,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
-    def get_controlled_vocabulary_for_predicate_name(name:)
+    def get_controlled_vocabulary_entries_for_predicate_name(name:)
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -186,6 +186,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
+    def get_controlled_vocabulary_value_for(name:, predicate_value_code:)
+    end
+
+    # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
     def get_controlled_vocabulary_values_for_predicate_name(name:)
     end
 

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -126,6 +126,10 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
+    def get_controlled_vocabulary_value_for(name:, predicate_value_code:)
+    end
+
+    # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
     def get_controlled_vocabulary_values_for_predicate_name(name:)
     end
 

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -122,7 +122,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
-    def get_controlled_vocabulary_for_predicate_name(name:)
+    def get_controlled_vocabulary_entries_for_predicate_name(name:)
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb


### PR DESCRIPTION
## Renaming method for clarity

@333126beeff5ac7eb63198634f098dfcb8f8bb2f

I want the controlled vocabulary entries; There is something more
specific going forward.

## Exposing repository method for controlled vocab

@44dd946a3e6cf7002ffb8d950b51ed4391656312

I want to get the value based on the controlled vocabulary's predicate
and code.

## Tidying up method behavior

@c497c1d35f52fb11d659b484289d46c1e946c287

Instead of relying on the decorator performing transformations of data
let it behave as a simple translator of values. This simplifies the
logic and the mocking that is required.
