### PR TITLE
Adding additional test scenarios

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/plan_of_study_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/plan_of_study_form.rb
@@ -14,7 +14,7 @@ module Sipity
         attr_reader :expected_graduation_date, :majors
 
         validates :expected_graduation_date, presence: true
-        validates_presence_of :majors, message: "Can't have blank values"
+        validates :majors, presence: true
 
         private
 

--- a/app/forms/sipity/forms/work_enrichments/plan_of_study_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/plan_of_study_form.rb
@@ -3,8 +3,6 @@ module Sipity
     module WorkEnrichments
       # Responsible for capturing and validating information for plan_of_study.
       class PlanOfStudyForm < Forms::WorkEnrichmentForm
-        include ActiveModel::Validations
-        include Hydra::Validations
         def initialize(attributes = {})
           super
           self.expected_graduation_date = attributes.fetch(:expected_graduation_date) { expected_graduation_date_from_work }
@@ -13,6 +11,7 @@ module Sipity
 
         attr_reader :expected_graduation_date, :majors
 
+        include Hydra::Validations
         validates :expected_graduation_date, presence: true
         validates :majors, presence: true
 

--- a/spec/forms/sipity/forms/work_enrichments/plan_of_study_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/plan_of_study_form_spec.rb
@@ -26,6 +26,19 @@ module Sipity
           subject.valid?
           expect(subject.errors[:majors]).to be_present
         end
+
+        it 'will require at least one non-blank major' do
+          subject = described_class.new(work: work, repository: repository, majors: ['', ''])
+          subject.valid?
+          expect(subject.errors[:majors]).to be_present
+        end
+
+        it 'will require at least one non-blank major' do
+          subject = described_class.new(work: work, repository: repository, majors: ['chocolate', ''])
+          subject.valid?
+          expect(subject.errors[:majors]).to_not be_present
+        end
+
         context 'retrieving values from the repository' do
           context 'with data from the database' do
             let(:expected_graduation_date) { Time.zone.today }


### PR DESCRIPTION
Prefering the composable validations instead of the
`validates_presence_of`.

Also removing the the explicit message; We want to lean on
translations instead of hard-coded messages; Keep in mind that
implementors may want those translations to vary (i.e. Dutch Royal
Libraries).

Related to #495 and #505