### PR TITLE
Replacing init instance variable with setter

### DIFF
--- a/app/decorators/sipity/decorators/application_decorator.rb
+++ b/app/decorators/sipity/decorators/application_decorator.rb
@@ -5,13 +5,13 @@ module Sipity
     # @see #repository
     class ApplicationDecorator < Draper::Decorator
       def initialize(object, options = {})
-        @repository = options.fetch(:repository) { default_repository }
+        self.repository = options.fetch(:repository) { default_repository }
         super(object, options.except(:repository))
       end
-      attr_reader :repository
-      private :repository
 
       private
+
+      attr_accessor :repository
 
       # A decorator need not have the keys to the kingdom.
       def default_repository

--- a/app/decorators/sipity/decorators/dashboard_view.rb
+++ b/app/decorators/sipity/decorators/dashboard_view.rb
@@ -4,13 +4,13 @@ module Sipity
     # dashboard.
     class DashboardView
       def initialize(repository: default_repository, user:, filter: {})
-        @repository = repository
-        @filter = filter
-        @user = user
+        self.repository = repository
+        self.filter = filter
+        self.user = user
       end
 
-      attr_reader :repository, :user, :filter
-      private :repository, :user, :filter
+      attr_accessor :repository, :user, :filter
+      private :repository=, :user=, :filter=
 
       def search_path
         view_context.dashboard_path

--- a/app/decorators/sipity/decorators/emails/processing_comment_decorator.rb
+++ b/app/decorators/sipity/decorators/emails/processing_comment_decorator.rb
@@ -5,8 +5,11 @@ module Sipity
       # too fancy.
       class ProcessingCommentDecorator
         def initialize(processing_comment)
-          @processing_comment = processing_comment
+          self.processing_comment = processing_comment
         end
+
+        attr_accessor :processing_comment
+        private :processing_comment=, :processing_comment
 
         def name_of_commentor
           actor.proxy_for.name
@@ -16,7 +19,7 @@ module Sipity
           work.work_type.titleize
         end
 
-        delegate :comment, :actor, :entity, to: :@processing_comment
+        delegate :comment, :actor, :entity, to: :processing_comment
         delegate :title, to: :work
         private :actor, :entity
 

--- a/app/decorators/sipity/decorators/emails/registered_action_decorator.rb
+++ b/app/decorators/sipity/decorators/emails/registered_action_decorator.rb
@@ -6,11 +6,12 @@ module Sipity
       class RegisteredActionDecorator
         def initialize(registered_action, repository: default_repository)
           self.registered_action = registered_action
-          @repository = repository
+          self.repository = repository
         end
 
-        attr_reader :repository, :registered_action
-        private :repository
+        attr_reader :registered_action
+        attr_accessor :repository
+        private :repository, :repository=
 
         delegate :entity, to: :registered_action
 

--- a/app/decorators/sipity/decorators/emails/work_email_decorator.rb
+++ b/app/decorators/sipity/decorators/emails/work_email_decorator.rb
@@ -6,11 +6,8 @@ module Sipity
       class WorkEmailDecorator
         def initialize(work, repository: default_repository)
           self.work = work
-          @repository = repository
+          self.repository = repository
         end
-
-        attr_reader :work, :repository
-        private :work, :repository
 
         delegate :title, to: :work
 
@@ -51,6 +48,9 @@ module Sipity
         end
 
         private
+
+        attr_reader :work
+        attr_accessor :repository
 
         include Conversions::ConvertToWork
         def work=(object)

--- a/app/decorators/sipity/decorators/entity_enrichment_action.rb
+++ b/app/decorators/sipity/decorators/entity_enrichment_action.rb
@@ -7,9 +7,13 @@ module Sipity
     #   template to render different elements.
     class EntityEnrichmentAction
       def initialize(entity:, name:, state:)
-        @entity, @name, @state = entity, name, state
+        self.entity = entity
+        self.name = name
+        self.state = state
       end
-      attr_reader :entity, :name, :state
+
+      attr_accessor :entity, :name, :state
+      private :entity=, :name=, :state=
 
       def path
         # REVIEW: Does EntityEnrichment even make sense?

--- a/app/decorators/sipity/decorators/processing/enrichment_action_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/enrichment_action_decorator.rb
@@ -6,11 +6,12 @@ module Sipity
       class EnrichmentActionDecorator < BaseDecorator
         def initialize(options = {})
           super
-          @is_complete = options.fetch(:is_complete) { false }
-          @is_a_prerequisite = options.fetch(:is_a_prerequisite) { false }
+          self.is_complete = options.fetch(:is_complete) { false }
+          self.is_a_prerequisite = options.fetch(:is_a_prerequisite) { false }
         end
 
-        attr_reader :is_complete, :is_a_prerequisite
+        attr_accessor :is_complete, :is_a_prerequisite
+        private :is_complete=, :is_a_prerequisite=
 
         alias_method :is_complete?, :is_complete
         alias_method :is_a_prerequisite?, :is_a_prerequisite

--- a/app/decorators/sipity/decorators/processing/processing_comment_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/processing_comment_decorator.rb
@@ -5,7 +5,7 @@ module Sipity
       # too fancy.
       class ProcessingCommentDecorator < ApplicationDecorator
         def initialize(processing_comment, _opts = {})
-          @processing_comment = processing_comment
+          self.processing_comment = processing_comment
         end
 
         def name_of_commentor
@@ -16,10 +16,12 @@ module Sipity
           work.work_type.titleize
         end
 
-        delegate :comment, :actor, :entity, to: :@processing_comment
+        delegate :comment, :actor, :entity, to: :processing_comment
         private :actor, :entity
 
         private
+
+        attr_accessor :processing_comment
 
         def work
           entity.proxy_for

--- a/app/decorators/sipity/decorators/processing/state_advancing_action_decorator.rb
+++ b/app/decorators/sipity/decorators/processing/state_advancing_action_decorator.rb
@@ -5,7 +5,7 @@ module Sipity
       class StateAdvancingActionDecorator < BaseDecorator
         def initialize(options = {})
           super
-          @repository = options.fetch(:repository) { default_repository }
+          self.repository = options.fetch(:repository) { default_repository }
         end
 
         def availability_state
@@ -18,8 +18,7 @@ module Sipity
 
         private
 
-        attr_reader :repository
-        private :repository
+        attr_accessor :repository
 
         def default_repository
           QueryRepository.new

--- a/app/decorators/sipity/decorators/processing_actions.rb
+++ b/app/decorators/sipity/decorators/processing_actions.rb
@@ -3,13 +3,13 @@ module Sipity
     # For the given :user and :entity what are the available actions?
     class ProcessingActions
       def initialize(user:, entity:, repository: default_repository, action_decorator: default_action_decorator)
-        @user = user
-        @entity = entity
-        @repository = repository
-        @action_decorator = action_decorator
+        self.user = user
+        self.entity = entity
+        self.repository = repository
+        self.action_decorator = action_decorator
       end
-      attr_reader :user, :entity, :repository, :action_decorator
-      private :repository, :action_decorator
+      attr_accessor :user, :entity, :repository, :action_decorator
+      private :repository, :action_decorator, :user=, :entity=, :repository=, :action_decorator=
 
       def enrichment_actions
         fetch(Models::Processing::StrategyAction::ENRICHMENT_ACTION)

--- a/app/forms/sipity/forms/assign_a_citation_form.rb
+++ b/app/forms/sipity/forms/assign_a_citation_form.rb
@@ -4,9 +4,11 @@ module Sipity
     class AssignACitationForm < WorkEnrichmentForm
       def initialize(attributes = {})
         super
-        @type, @citation = attributes.values_at(:type, :citation)
+        self.type = attributes[:type]
+        self.citation = attributes[:citation]
       end
-      attr_reader :type, :citation
+      attr_accessor :type, :citation
+      private :type=, :citation=
 
       validates :citation, presence: true
       validates :type, presence: true

--- a/app/forms/sipity/forms/assign_a_doi_form.rb
+++ b/app/forms/sipity/forms/assign_a_doi_form.rb
@@ -7,13 +7,12 @@ module Sipity
 
       def initialize(attributes = {})
         self.work = attributes.fetch(:work)
-        @identifier = attributes.fetch(:identifier, nil)
-        @enrichment_type = attributes.fetch(:enrichment_type, default_enrichment_type)
+        self.identifier = attributes.fetch(:identifier, nil)
+        self.enrichment_type = attributes.fetch(:enrichment_type, default_enrichment_type)
       end
 
-      attr_reader :enrichment_type, :identifier
-      attr_accessor :work
-      private(:work=) # Adding parenthesis because Beautify ruby was going crazy
+      attr_accessor :enrichment_type, :identifier, :work
+      private(:work=, :enrichment_type=, :identifier=) # Adding parenthesis because Beautify ruby was going crazy
 
       validates :work, presence: true
       validates :identifier, presence: true

--- a/app/forms/sipity/forms/create_orcid_account_placeholder_form.rb
+++ b/app/forms/sipity/forms/create_orcid_account_placeholder_form.rb
@@ -5,9 +5,11 @@ module Sipity
       ORCID_IDENTIFIER_REGEXP = /\A\w{4}-\w{4}-\w{4}-\w{4}\Z/
 
       def initialize(attributes = {})
-        @identifier, @name = attributes.values_at(:identifier, :name)
+        self.identifier = attributes[:identifier]
+        self.name = attributes[:name]
       end
-      attr_reader :identifier, :name
+      attr_accessor :identifier, :name
+      private(:identifier=, :name=)
 
       validates :identifier, presence: true, format: { with: ORCID_IDENTIFIER_REGEXP }
       validates :name, presence: true

--- a/app/forms/sipity/forms/create_work_form.rb
+++ b/app/forms/sipity/forms/create_work_form.rb
@@ -12,15 +12,14 @@ module Sipity
 
       def initialize(attributes = {})
         self.title = attributes[:title]
-        @work_publication_strategy = attributes[:work_publication_strategy]
-        @work_type = attributes[:work_type]
-        @access_rights_answer = attributes.fetch(:access_rights_answer) { default_access_rights_answer }
+        self.work_publication_strategy = attributes[:work_publication_strategy]
+        self.work_type = attributes[:work_type]
+        self.access_rights_answer = attributes.fetch(:access_rights_answer) { default_access_rights_answer }
         self.repository = attributes.fetch(:repository) { default_repository }
       end
 
-      attr_reader :title, :work_publication_strategy, :work_type, :access_rights_answer
-      attr_accessor :repository
-      private(:repository, :repository=)
+      attr_accessor :repository, :title, :work_publication_strategy, :work_type, :access_rights_answer
+      private(:repository, :repository=, :title=, :work_publication_strategy=, :work_type=, :access_rights_answer=)
 
       validates :title, presence: true
       validates :work_publication_strategy, presence: true, inclusion: { in: :possible_work_publication_strategies }

--- a/app/forms/sipity/forms/etd/advisor_requests_change_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_requests_change_form.rb
@@ -6,10 +6,11 @@ module Sipity
       class AdvisorRequestsChangeForm < Forms::StateAdvancingActionForm
         def initialize(attributes = {})
           super
-          @comment = attributes[:comment]
+          self.comment = attributes[:comment]
         end
 
-        attr_reader :comment
+        attr_accessor :comment
+        private(:comment=)
         validates :comment, presence: true
 
         # @param f SimpleFormBuilder

--- a/app/forms/sipity/forms/etd/advisor_signoff_form.rb
+++ b/app/forms/sipity/forms/etd/advisor_signoff_form.rb
@@ -6,11 +6,10 @@ module Sipity
       class AdvisorSignoffForm < Forms::StateAdvancingActionForm
         def initialize(attributes = {})
           super
-          @signoff_service = attributes.fetch(:signoff_service) { default_signoff_service }
+          self.signoff_service = attributes.fetch(:signoff_service) { default_signoff_service }
           self.agree_to_signoff = attributes[:agree_to_signoff]
         end
 
-        attr_reader :signoff_service
         attr_reader :agree_to_signoff
         validates :agree_to_signoff, acceptance: { accept: true }
 
@@ -48,7 +47,7 @@ module Sipity
           Draper::ViewContext.current
         end
 
-        private :signoff_service
+        attr_accessor :signoff_service
         def default_signoff_service
           Services::AdvisorSignsOff
         end

--- a/app/forms/sipity/forms/etd/grad_school_requests_change_form.rb
+++ b/app/forms/sipity/forms/etd/grad_school_requests_change_form.rb
@@ -6,10 +6,11 @@ module Sipity
       class GradSchoolRequestsChangeForm < Forms::StateAdvancingActionForm
         def initialize(attributes = {})
           super
-          @comment = attributes[:comment]
+          self.comment = attributes[:comment]
         end
 
-        attr_reader :comment
+        attr_accessor :comment
+        private(:comment=)
         validates :comment, presence: true
 
         # @param f SimpleFormBuilder

--- a/app/forms/sipity/forms/etd/respond_to_advisor_request_form.rb
+++ b/app/forms/sipity/forms/etd/respond_to_advisor_request_form.rb
@@ -6,10 +6,11 @@ module Sipity
       class RespondToAdvisorRequestForm < Forms::StateAdvancingActionForm
         def initialize(attributes = {})
           super
-          @comment = attributes[:comment]
+          self.comment = attributes[:comment]
         end
 
-        attr_reader :comment
+        attr_accessor :comment
+        private(:comment=)
         validates :comment, presence: true
 
         # @param f SimpleFormBuilder

--- a/app/forms/sipity/forms/etd/respond_to_grad_school_request_form.rb
+++ b/app/forms/sipity/forms/etd/respond_to_grad_school_request_form.rb
@@ -6,10 +6,11 @@ module Sipity
       class RespondToGradSchoolRequestForm < Forms::StateAdvancingActionForm
         def initialize(attributes = {})
           super
-          @comment = attributes[:comment]
+          self.comment = attributes[:comment]
         end
 
-        attr_reader :comment
+        attr_accessor :comment
+        private(:comment=)
         validates :comment, presence: true
 
         # @param f SimpleFormBuilder

--- a/app/forms/sipity/forms/processing_action_form.rb
+++ b/app/forms/sipity/forms/processing_action_form.rb
@@ -25,15 +25,15 @@ module Sipity
       self.policy_enforcer = Policies::Processing::WorkProcessingPolicy
 
       def initialize(attributes = {})
-        @work = attributes.fetch(:work)
-        @repository = attributes.fetch(:repository) { default_repository }
+        self.work = attributes.fetch(:work)
+        self.repository = attributes.fetch(:repository) { default_repository }
       end
 
-      attr_reader :work, :repository
+      attr_accessor :work, :repository
       delegate :to_processing_entity, :work_type, to: :work
       delegate :strategy_id, :strategy, to: :to_processing_entity
       alias_method :to_model, :work
-      private :repository
+      private(:repository, :repository=, :work=)
 
       validates :work, presence: true
 

--- a/app/forms/sipity/forms/request_a_doi_form.rb
+++ b/app/forms/sipity/forms/request_a_doi_form.rb
@@ -6,14 +6,13 @@ module Sipity
 
       def initialize(attributes = {})
         self.work = attributes.fetch(:work)
-        @publisher, @publication_date = attributes.values_at(:publisher, :publication_date)
-        @enrichment_type = attributes.fetch(:enrichment_type, default_enrichment_type)
-        @repository = attributes.fetch(:repository) { default_repository }
+        self.publisher, @publication_date = attributes.values_at(:publisher, :publication_date)
+        self.enrichment_type = attributes.fetch(:enrichment_type, default_enrichment_type)
+        self.repository = attributes.fetch(:repository) { default_repository }
       end
 
-      attr_accessor :work
-      attr_reader :enrichment_type, :repository, :publisher, :publication_date
-      private :work=, :repository
+      attr_accessor :work, :enrichment_type, :repository, :publisher, :publication_date
+      private(:work=, :repository, :enrichment_type=, :repository=, :publisher=, :publication_date=)
 
       delegate :title, to: :work
 

--- a/app/forms/sipity/forms/update_work_form.rb
+++ b/app/forms/sipity/forms/update_work_form.rb
@@ -17,12 +17,13 @@ module Sipity
       end
 
       def initialize(work:, exposed_attribute_names: [], attributes: {})
-        @work = work
-        @attributes = attributes.stringify_keys
+        self.work = work
+        self.attributes = attributes.stringify_keys
         self.exposed_attribute_names = exposed_attribute_names
       end
 
-      attr_reader :work
+      attr_accessor :work, :attributes, :exposed_attribute_names
+      private :work=, :attributes=, :exposed_attribute_names=, :attributes, :exposed_attribute_names
       delegate :to_key, :to_param, :persisted?, :to_processing_entity, to: :work
 
       def to_model

--- a/app/forms/sipity/forms/work_enrichment_form.rb
+++ b/app/forms/sipity/forms/work_enrichment_form.rb
@@ -5,9 +5,10 @@ module Sipity
     class WorkEnrichmentForm < ProcessingActionForm
       def initialize(attributes = {})
         super
-        @enrichment_type = attributes.fetch(:enrichment_type) { default_enrichment_type }
+        self.enrichment_type = attributes.fetch(:enrichment_type) { default_enrichment_type }
       end
-      attr_reader :enrichment_type
+      attr_accessor :enrichment_type
+      private(:enrichment_type=)
 
       private
 

--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -106,8 +106,7 @@ module Sipity
             @access_right_code = attributes[:access_right_code]
             self.release_date = extract_input_date_from_input(:release_date, attributes) { nil }
           end
-          attr_reader :access_right_code, :release_date, :persisted_object
-          private :persisted_object
+          attr_reader :release_date
 
           delegate :to_param, :id, :to_s, :human_model_name, to: :persisted_object
 
@@ -140,6 +139,8 @@ module Sipity
           end
 
           private
+
+          attr_accessor :access_right_code, :persisted_object
 
           include Conversions::ConvertToDate
           def release_date=(value)

--- a/app/forms/sipity/forms/work_enrichments/attach_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/attach_form.rb
@@ -90,12 +90,14 @@ module Sipity
         # for deletion.
         class AttachmentFormElement
           def initialize(attachment)
-            @attachment = attachment
+            self.attachment = attachment
           end
           delegate :id, :name, :thumbnail_url, :persisted?, :file_url, to: :attachment
           attr_accessor :delete
-          attr_reader :attachment
-          private :attachment
+
+          private
+
+          attr_accessor :attachment
         end
         private_constant :AttachmentFormElement
       end

--- a/app/forms/sipity/forms/work_enrichments/search_term_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/search_term_form.rb
@@ -5,16 +5,14 @@ module Sipity
       class SearchTermForm < Forms::WorkEnrichmentForm
         def initialize(attributes = {})
           super
-          @subject = attributes.fetch(:subject) { subject_from_work }
-          @language = attributes.fetch(:language) { language_from_work }
-          @temporal_coverage = attributes.fetch(:temporal_coverage) { temporal_coverage_from_work }
-          @spatial_coverage = attributes.fetch(:spatial_coverage) { spatial_coverage_from_work }
+          self.subject = attributes.fetch(:subject) { subject_from_work }
+          self.language = attributes.fetch(:language) { language_from_work }
+          self.temporal_coverage = attributes.fetch(:temporal_coverage) { temporal_coverage_from_work }
+          self.spatial_coverage = attributes.fetch(:spatial_coverage) { spatial_coverage_from_work }
         end
 
-        attr_accessor :subject
-        attr_accessor :language
-        attr_accessor :temporal_coverage
-        attr_accessor :spatial_coverage
+        attr_accessor :subject, :language, :temporal_coverage, :spatial_coverage
+        private(:subject=, :language=, :temporal_coverage=, :spatial_coverage=)
 
         private
 

--- a/app/jobs/sipity/jobs/doi_creation_request_job.rb
+++ b/app/jobs/sipity/jobs/doi_creation_request_job.rb
@@ -7,13 +7,14 @@ module Sipity
       end
 
       def initialize(work_id, options = {})
-        @repository = options.fetch(:repository) { default_repository }
-        @minter = options.fetch(:minter) { default_minter }
-        @minter_handled_exceptions = options.fetch(:minter_handled_exceptions) { default_minter_handled_exceptions }
-        @work = repository.find_work(work_id)
-        @doi_creation_request = repository.find_doi_creation_request(work: work)
+        self.repository = options.fetch(:repository) { default_repository }
+        self.minter = options.fetch(:minter) { default_minter }
+        self.minter_handled_exceptions = options.fetch(:minter_handled_exceptions) { default_minter_handled_exceptions }
+        self.work = repository.find_work(work_id)
+        self.doi_creation_request = repository.find_doi_creation_request(work: work)
       end
-      attr_reader :work, :doi_creation_request, :minter, :minter_handled_exceptions, :metadata_gatherer, :repository
+      attr_accessor :work, :doi_creation_request, :minter, :minter_handled_exceptions, :metadata_gatherer, :repository
+      private(:work=, :doi_creation_request=, :minter=, :minter_handled_exceptions=, :metadata_gatherer=, :repository=)
 
       def call
         # TODO: Do we need to track history for the given person?

--- a/app/policies/sipity/policies/work_policy.rb
+++ b/app/policies/sipity/policies/work_policy.rb
@@ -44,13 +44,10 @@ module Sipity
         end
 
         def initialize(user, scope, options = {})
-          @user = user
-          @scope = scope
-          @repository = options.fetch(:repository) { default_repository }
+          self.user = user
+          self.scope = scope
+          self.repository = options.fetch(:repository) { default_repository }
         end
-
-        attr_reader :user, :scope, :repository
-        private :user, :scope, :repository
 
         def resolve(options = {})
           repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
@@ -60,6 +57,8 @@ module Sipity
         end
 
         private
+
+        attr_accessor :user, :scope, :repository
 
         def default_repository
           QueryRepository.new

--- a/app/services/sipity/services/advisor_signs_off.rb
+++ b/app/services/sipity/services/advisor_signs_off.rb
@@ -7,12 +7,14 @@ module Sipity
       end
 
       def initialize(form:, requested_by:, repository: default_repository)
-        @form = form
-        @repository = repository
-        @requested_by = requested_by
+        self.form = form
+        self.repository = repository
+        self.requested_by = requested_by
       end
 
-      attr_reader :form, :repository, :requested_by
+      attr_accessor :form, :repository, :requested_by
+      private(:form=, :repository=, :requested_by=)
+
       delegate :resulting_strategy_state, :action, to: :form
 
       def call

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -8,11 +8,12 @@ module Sipity
       end
 
       def initialize(user:, work:, access_policies:)
-        @user = user
-        @work = work
-        @access_policies = Array.wrap(access_policies)
+        self.user = user
+        self.work = work
+        self.access_policies = Array.wrap(access_policies)
       end
-      attr_reader :user, :work, :access_policies, :repository
+      attr_accessor :user, :work, :access_policies
+      private(:user=, :work=, :access_policies=)
 
       def call
         access_policies.each do |attributes|

--- a/app/services/sipity/services/authorization_layer.rb
+++ b/app/services/sipity/services/authorization_layer.rb
@@ -32,12 +32,10 @@ module Sipity
       end
 
       def initialize(context, collaborators = {})
-        @context = context
-        @user = context.current_user
-        @policy_authorizer = collaborators.fetch(:policy_authorizer) { default_policy_authorizer }
+        self.context = context
+        self.user = context.current_user
+        self.policy_authorizer = collaborators.fetch(:policy_authorizer) { default_policy_authorizer }
       end
-      attr_reader :user, :context, :policy_authorizer
-      private :user, :context, :policy_authorizer
 
       # Responsible for enforcing policies on the :action_to_authorizes_and_entity_pairs.
       #
@@ -64,6 +62,8 @@ module Sipity
       end
 
       private
+
+      attr_accessor :user, :context, :policy_authorizer
 
       def default_policy_authorizer
         Policies.method(:authorized_for?)

--- a/app/services/sipity/services/doi_creation_request_metadata_gatherer.rb
+++ b/app/services/sipity/services/doi_creation_request_metadata_gatherer.rb
@@ -15,12 +15,10 @@ module Sipity
       end
 
       def initialize(work, options = {})
-        @work = work
+        self.work = work
         # TODO: I don't want to craft a custom repository
-        @repository = options.fetch(:repository) { default_repository }
+        self.repository = options.fetch(:repository) { default_repository }
       end
-      attr_reader :work, :repository
-      private :work, :repository
 
       def as_hash
         {
@@ -33,6 +31,8 @@ module Sipity
       end
 
       private
+
+      attr_accessor :work, :repository
 
       # The permanent URL in which we promise that you can always find this
       # object.

--- a/app/services/sipity/services/netid_query_service.rb
+++ b/app/services/sipity/services/netid_query_service.rb
@@ -12,9 +12,10 @@ module Sipity
       end
 
       def initialize(netid)
-        @netid = netid
+        self.netid = netid
       end
-      attr_reader :netid
+      attr_accessor :netid
+      private(:netid=)
 
       # @return [netid] if the input is not a valid NetID
       # @return [String] if the input is a valid NetID

--- a/app/validators/net_id_validator.rb
+++ b/app/validators/net_id_validator.rb
@@ -2,11 +2,8 @@
 class NetIdValidator < ActiveModel::EachValidator
   def initialize(options = {})
     super
-    @netid_remote_validator = options.fetch(:netid_remote_validator) { default_netid_remote_validator }
+    self.netid_remote_validator = options.fetch(:netid_remote_validator) { default_netid_remote_validator }
   end
-
-  attr_reader :netid_remote_validator
-  private :netid_remote_validator
 
   def default_netid_remote_validator
     Rails.application.config.default_netid_remote_validator
@@ -17,4 +14,8 @@ class NetIdValidator < ActiveModel::EachValidator
     # TODO: validate netid is valid one through ldap
     record.errors.add(attribute, options[:message] || :invalid) unless netid_remote_validator.call(value)
   end
+
+  private
+
+  attr_accessor :netid_remote_validator
 end

--- a/spec/forms/sipity/forms/work_enrichments/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/search_term_form_spec.rb
@@ -13,13 +13,9 @@ module Sipity
 
         it { should respond_to :work }
         it { should respond_to :subject }
-        it { should respond_to :subject= }
         it { should respond_to :language }
-        it { should respond_to :language= }
         it { should respond_to :temporal_coverage }
-        it { should respond_to :temporal_coverage= }
         it { should respond_to :spatial_coverage }
-        it { should respond_to :spatial_coverage= }
 
         context 'without specified values' do
           before do


### PR DESCRIPTION
By leveraging a private setter method instead of setting an instance
variable, the classes are more readily extensible.

See http://ndlib.github.io/practices/leveraging-instance-variables-in-ruby-classes/

NOTE: This is to be a point of discussion and not something that need
be merged straight away.