### PR TITLE
Replacing explicit module call with collaborator

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/search_term_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/search_term_form.rb
@@ -28,19 +28,19 @@ module Sipity
         end
 
         def subject_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'subject')
+          repository.work_attribute_values_for(work: work, key: 'subject')
         end
 
         def language_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'language')
+          repository.work_attribute_values_for(work: work, key: 'language')
         end
 
         def temporal_coverage_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'temporal_coverage')
+          repository.work_attribute_values_for(work: work, key: 'temporal_coverage')
         end
 
         def spatial_coverage_from_work
-          Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: 'spatial_coverage')
+          repository.work_attribute_values_for(work: work, key: 'spatial_coverage')
         end
       end
     end

--- a/spec/forms/sipity/forms/work_enrichments/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/search_term_form_spec.rb
@@ -21,6 +21,18 @@ module Sipity
         it { should respond_to :spatial_coverage }
         it { should respond_to :spatial_coverage= }
 
+        context 'without specified values' do
+          before do
+            allow(repository).to receive(:work_attribute_values_for)
+          end
+          ['subject', 'language', 'temporal_coverage', 'spatial_coverage'].each do |key|
+            it "will retrieve the #{key} from the repository" do
+              expect(repository).to receive(:work_attribute_values_for).with(work: work, key: key.to_s).and_return("#{key}_value")
+              expect(subject.send(key)).to eq("#{key}_value")
+            end
+          end
+        end
+
         context '#submit' do
           let(:user) { double('User') }
           let(:subject_attr) { 'Literature' }
@@ -29,10 +41,11 @@ module Sipity
           let(:spatial_coverage) { '20 sq miles' }
           context 'with valid data' do
             subject do
-              described_class.new(work: work, subject: subject_attr, language: language,
-                                  temporal_coverage: temporal_coverage, spatial_coverage: spatial_coverage,
-                                  repository: repository
-                                 )
+              described_class.new(
+                work: work, subject: subject_attr, language: language,
+                temporal_coverage: temporal_coverage, spatial_coverage: spatial_coverage,
+                repository: repository
+              )
             end
             before do
               expect(subject).to receive(:valid?).and_return(true)


### PR DESCRIPTION
Instead of referencing the module functions, instead prefer to use
the collaborating repository object for querying the work's attribute
values.