### PR TITLE
House keeping

### DIFF
--- a/app/models/sipity/models/work_area.rb
+++ b/app/models/sipity/models/work_area.rb
@@ -1,3 +1,4 @@
+require 'sipity/models/processing'
 module Sipity
   module Models
     # A WorkArea is a container for performing common work against a

--- a/spec/repositories/sipity/queries/event_trigger_queries_spec.rb
+++ b/spec/repositories/sipity/queries/event_trigger_queries_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Sipity
+  module Queries
+    RSpec.describe EventTriggerQueries, type: :isolated_repository_module  do
+      context '#build_event_trigger_form' do
+        let(:attributes) { { processing_action_name: 'hello', work: Models::Work.new, chicken: 'soup' } }
+        let(:builder) { double('Builder', new: true) }
+        it 'will find the correct form and initialize it' do
+          expect(Forms::WorkEventTriggers).to receive(:find_event_trigger_form_builder).
+            and_return(builder)
+          test_repository.build_event_trigger_form(attributes)
+          expect(builder).to have_received(:new).with(attributes.merge(repository: test_repository))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Adding missing require

@56a336549d918f1ef4e6f14c072abd48fd007ec1

When I ran `$ rake spec:coverage:models` I encountered:

```console
./app/models/sipity/models/work_area.rb:15:in `<class:WorkArea>':
  undefined method `configure_as_a_processible_entity' for
  Sipity::Models::Processing:Module (NoMethodError)
```

This fixes that problem.

## Adding isolated test

@987c5e85b180dcce82da025b2c89fcd1ebc0157a

After running `$ rake spec:coverage:repositories` I saw that the test
coverage was 99.64%. The event_trigger_queries test was missing.
