### PR TITLE
Removing ruby build versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ cache: bundler
 sudo: false
 rvm:
   - "2.1.5"
-  - "2.1.6"
-  - "2.2.1"
   - "2.2.2"
 
 script: 'bundle exec rake spec:travis'


### PR DESCRIPTION
Now that we are running 2.2.2 locally, we need not test these other
ruby versions.