### PR TITLE
Adding power converter for work area

### DIFF
--- a/config/initializers/power_converters.rb
+++ b/config/initializers/power_converters.rb
@@ -34,3 +34,22 @@ PowerConverter.define_conversion_for(:demodulized_class_name) do |input|
     ''
   end
 end
+
+PowerConverter.define_conversion_for(:work_type) do |input|
+  case input
+  when Symbol, String
+    Sipity::Models::WorkType.find_by(name: input.to_s)
+  when Sipity::Models::WorkType
+    input
+  end
+end
+
+PowerConverter.define_conversion_for(:work_area) do |input|
+  # TODO: Add the case for a Work, ProcessingEntity
+  case input
+  when Sipity::Models::WorkArea
+    input
+  when Symbol, String
+    Sipity::Models::WorkArea.find_by(name: input.to_s) || Sipity::Models::WorkArea.find_by(slug: input.to_s)
+  end
+end

--- a/config/initializers/power_converters.rb
+++ b/config/initializers/power_converters.rb
@@ -49,6 +49,8 @@ PowerConverter.define_conversion_for(:work_area) do |input|
   case input
   when Sipity::Models::WorkArea
     input
+  when Sipity::Models::SubmissionWindow
+    input.work_area
   when Symbol, String
     Sipity::Models::WorkArea.find_by(name: input.to_s) || Sipity::Models::WorkArea.find_by(slug: input.to_s)
   end

--- a/spec/config/initializers/power_converters_spec.rb
+++ b/spec/config/initializers/power_converters_spec.rb
@@ -102,6 +102,8 @@ RSpec.describe 'power converters' do
       end
 
       expect(PowerConverter.convert_to_work_area(work_area)).to eq(work_area)
+      submission_window = Sipity::Models::SubmissionWindow.new(work_area: work_area)
+      expect(PowerConverter.convert_to_work_area(submission_window)).to eq(work_area)
 
       [
         'The Missing Name'

--- a/spec/config/initializers/power_converters_spec.rb
+++ b/spec/config/initializers/power_converters_spec.rb
@@ -60,4 +60,54 @@ RSpec.describe 'power converters' do
       end
     end
   end
+
+  context "work_type" do
+    let(:a_work_type) { Sipity::Models::WorkType.new }
+    it 'will attempt to find the given String' do
+      expect(Sipity::Models::WorkType).to receive(:find_by).with(name: 'doctoral_dissertation').and_return(a_work_type)
+      expect(PowerConverter.convert('doctoral_dissertation', to: :work_type)).to eq(a_work_type)
+    end
+
+    it 'will attempt to find the given Symbol' do
+      expect(Sipity::Models::WorkType).to receive(:find_by).with(name: 'doctoral_dissertation').and_return(a_work_type)
+      expect(PowerConverter.convert(:doctoral_dissertation, to: :work_type)).to eq(a_work_type)
+    end
+
+    it 'will raise an error if not found' do
+      expect(Sipity::Models::WorkType).to receive(:find_by).with(name: 'doctoral_dissertation').and_return(nil)
+      expect { PowerConverter.convert(:doctoral_dissertation, to: :work_type) }.
+        to raise_error(PowerConverter::ConversionError)
+    end
+
+    it 'will pass through a given WorkType' do
+      expect(PowerConverter.convert(a_work_type, to: :work_type)).to eq(a_work_type)
+    end
+  end
+
+  context 'work_area' do
+    it "will convert based on the given scenarios" do
+
+      # Putting these all in one scenario as there is a database hit that occurs
+      # It breaks the "convention" of one assertion per spec, but speed is nice.
+
+      work_area = Sipity::Models::WorkArea.create!(
+        name: 'The Name', slug: 'the-slug', partial_suffix: 'the-partial-suffix', demodulized_class_prefix_name: 'TheName'
+      )
+      [
+        { to_convert: 'The Name', expected_name: 'The Name' },
+        { to_convert: 'the-slug', expected_name: 'The Name' }
+      ].each do |scenario|
+        to_convert = scenario.fetch(:to_convert)
+        expect(PowerConverter.convert_to_work_area(to_convert).name).to eq(scenario.fetch(:expected_name))
+      end
+
+      expect(PowerConverter.convert_to_work_area(work_area)).to eq(work_area)
+
+      [
+        'The Missing Name'
+      ].each do |to_convert_but_will_fail|
+        expect { PowerConverter.convert_to_work_area(to_convert_but_will_fail) }.to raise_error(PowerConverter::ConversionError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Working on PowerConverter for WorkArea

@da7c24c092db05c5cc7e2eca8978996ee3c51d74

The WorkArea is going to inform the module space used for building
forms. As such, I want a way to "quickly" convert an object to the
Work Area.

The main goal is to convert a ProcessingEntity or Work into the
WorkArea, but for now I'm not certain what direction that would be.
There is a clear query path based on the current ERD, but I believe
the ERD may represent the final design as we tease apart the
Submission Window behavior.

## Handling SubmissionWindow convert_to_work_area

@a33de0d84d570720cc212fef6f392c16ede4ba00
