### PR TITLE
Ensuring method visibility for access policy

### DIFF
--- a/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_enrichments/access_policy_form.rb
@@ -102,11 +102,11 @@ module Sipity
           include Conversions::ExtractInputDateFromInput
 
           def initialize(persisted_object, attributes = {})
-            @persisted_object = persisted_object
-            @access_right_code = attributes[:access_right_code]
+            self.persisted_object = persisted_object
+            self.access_right_code = attributes[:access_right_code]
             self.release_date = extract_input_date_from_input(:release_date, attributes) { nil }
           end
-          attr_reader :release_date
+          attr_reader :release_date, :access_right_code
 
           delegate :to_param, :id, :to_s, :human_model_name, to: :persisted_object
 
@@ -140,7 +140,8 @@ module Sipity
 
           private
 
-          attr_accessor :access_right_code, :persisted_object
+          attr_accessor :persisted_object
+          attr_writer :access_right_code
 
           include Conversions::ConvertToDate
           def release_date=(value)

--- a/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_enrichments/access_policy_form_spec.rb
@@ -127,6 +127,14 @@ module Sipity
         its(:persisted?) { should be_truthy }
         its(:human_model_name) { should eq(persisted_object.human_model_name) }
 
+        it 'will have a public :access_right_code' do
+          expect { subject.access_right_code }.to_not raise_error
+        end
+
+        it 'will have a public :release_date' do
+          expect { subject.release_date }.to_not raise_error
+        end
+
         it 'will parse the input date' do
           subject = described_class.new(persisted_object, release_date: '2014-12-1')
           expect(subject.release_date).to eq(Date.new(2014, 12, 1))


### PR DESCRIPTION
> NoMethodError:
>   private method `access_right_code' called for
>   #<Sipity::Forms::WorkEnrichments::AccessPolicyForm::
>       AccessibleObjectFromInput:0x007ff3d6e61fa0
>    >