### PR TITLE
Adding DataGenerators module

### DIFF
--- a/app/data_generators/sipity/data_generators.rb
+++ b/app/data_generators/sipity/data_generators.rb
@@ -1,0 +1,14 @@
+module Sipity
+  # Sipity levereages a lot of data-driven configuration. This module is a place
+  # to provide classes and infrastructure for bootstrapping the configuration
+  # related data entries.
+  #
+  # ## Why Not Factories?
+  #
+  # Because of the ubiquitous FactoryGirl, I am avoiding the name of Factory.
+  # In using the term DataScaffolds I hope to convey that these more closely
+  # resemble a rails generator; In other words, use the data generators to
+  # help bootstrap the application.
+  module DataGenerators
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module Sipity
         request_specs: false
     end
 
-    %w(conversions forms jobs policies runners services response_handlers).each do |concept|
+    %w(conversions forms jobs policies runners services response_handlers data_generators).each do |concept|
       config.autoload_paths << Rails.root.join("app/#{concept}")
     end
 


### PR DESCRIPTION
> Sipity levereages a lot of data-driven configuration. This module is
> a place to provide classes and infrastructure for bootstrapping the
> configuration related data entries.
>
> ## Why Not Factories?
>
> Because of the ubiquitous FactoryGirl, I am avoiding the name of
> Factory. In using the term DataScaffolds I hope to convey that these
> more closely resemble a rails generator; In other words, use the
> data generators to help bootstrap the application.