### PR TITLE
Skipping reporting of authorization errors

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -4,4 +4,5 @@ Airbrake.configure do |config|
   config.port    = 443
   config.secure  = config.port == 443
   config.user_attributes = [:id, :username]
+  config.ignore << "Sipity::Exceptions::AuthorizationFailureError"
 end


### PR DESCRIPTION
We don't need to know each time someone hits the back button on a task
that they don't have permission to take.

[skip ci]