### PR TITLE
Reworking create work area

### DIFF
--- a/app/models/sipity/models/submission_window.rb
+++ b/app/models/sipity/models/submission_window.rb
@@ -8,6 +8,8 @@ module Sipity
 
       has_many :submission_window_work_types, dependent: :destroy
 
+      has_one :strategy_usage, as: :usage, class_name: 'Sipity::Models::Processing::StrategyUsage', dependent: :destroy
+
       def slug=(value)
         super(PowerConverter.convert(value, to: :slug))
       end

--- a/app/models/sipity/models/work_area.rb
+++ b/app/models/sipity/models/work_area.rb
@@ -15,6 +15,8 @@ module Sipity
 
       Processing.configure_as_a_processible_entity(self)
 
+      has_one :strategy_usage, as: :usage, class_name: 'Sipity::Models::Processing::StrategyUsage', dependent: :destroy
+
       def to_s
         name
       end

--- a/app/services/sipity/services/create_work_area_service.rb
+++ b/app/services/sipity/services/create_work_area_service.rb
@@ -24,7 +24,7 @@ module Sipity
 
       def call
         create_processing_strategy!
-        create_work_area!
+        create_work_area_processing_entity!
         associate_work_area_with_processing_strategy!
         associate_work_area_manager_with_processing_strategy!
         grant_permission_for_the_work_area_manager_to_see_the_area!
@@ -43,7 +43,7 @@ module Sipity
         Models::WorkArea.find_by(attributes.slice(:name)) || Models::WorkArea.create!(attributes)
       end
 
-      def create_work_area!
+      def create_work_area_processing_entity!
         work_area.processing_entity || work_area.create_processing_entity!(
           strategy: processing_strategy, strategy_state: processing_strategy.initial_strategy_state
         )

--- a/app/services/sipity/services/create_work_area_service.rb
+++ b/app/services/sipity/services/create_work_area_service.rb
@@ -40,7 +40,8 @@ module Sipity
       attr_reader :processing_strategy, :work_area_managers, :strategy_role
 
       def find_or_create_work_area(attributes)
-        Models::WorkArea.find_by(attributes.slice(:name)) || Models::WorkArea.create!(attributes)
+        # Going with slug because these are "more permanent"
+        Models::WorkArea.find_by(attributes.slice(:slug)) || Models::WorkArea.create!(attributes)
       end
 
       def create_work_area_processing_entity!

--- a/app/services/sipity/services/find_or_create_submission_window_service.rb
+++ b/app/services/sipity/services/find_or_create_submission_window_service.rb
@@ -1,0 +1,45 @@
+module Sipity
+  module Services
+    # Responsible for creating a SubmissionWindow within a given WorkArea
+    #
+    # It will also attempt to reuse an existing
+    # Sipity::Models::ProcessingStrategy
+    class FindOrCreateSubmissionWindowService
+      def self.call(**keywords, &block)
+        new(**keywords).call(&block)
+      end
+
+      def initialize(slug:, work_area:)
+        self.slug = slug
+        self.work_area = work_area
+      end
+
+      private
+
+      attr_accessor :slug, :work_area
+      attr_reader :submission_window
+
+      public
+
+      def call
+        submission_window = create_submission_window!
+        associate_submission_window_with_processing_strategy_usage(submission_window)
+        yield(submission_window) if block_given?
+      end
+
+      private
+
+      def create_submission_window!
+        Models::SubmissionWindow.find_or_create_by!(work_area_id: work_area.id, slug: PowerConverter.convert_to_slug(slug))
+      end
+
+      def associate_submission_window_with_processing_strategy_usage(submission_window)
+        return submission_window.strategy_usage if submission_window.strategy_usage.present?
+        another_window = Models::SubmissionWindow.where(work_area_id: work_area.id).includes(:strategy_usage).first
+        submission_window.create_strategy_usage!(strategy_id: another_window.strategy_usage.strategy_id) if another_window.strategy_usage
+        # TODO: Create templated workflow for submission window and work area if
+        # there is not an existing window with a strategy_usage
+      end
+    end
+  end
+end

--- a/app/services/sipity/services/find_or_create_submission_window_service.rb
+++ b/app/services/sipity/services/find_or_create_submission_window_service.rb
@@ -17,7 +17,11 @@ module Sipity
       private
 
       attr_accessor :slug, :work_area
-      attr_reader :submission_window
+      attr_reader :submission_window, :work_area
+
+      def work_area=(input)
+        @work_area = PowerConverter.convert(input, to: :work_area)
+      end
 
       public
 

--- a/db/seeds/etd_work_area_seeds.rb
+++ b/db/seeds/etd_work_area_seeds.rb
@@ -7,6 +7,8 @@ def find_or_initialize_or_create!(attributes = {})
   receiver.send(method_name, attributes.except(:context, :receiver))
 end
 
+Sipity::Services::CreateWorkAreaService.call(name: 'Electronic Thesis and Dissertation', slug: 'etd')
+
 ['doctoral_dissertation', 'master_thesis'].each do |work_type_name|
   $stdout.puts "Creating #{work_type_name} State Machine"
   Sipity::Services::FindOrCreateWorkTypeService.call(name: work_type_name) do |work_type, etd_strategy, _initial_strategy_state|

--- a/db/seeds/etd_work_area_seeds.rb
+++ b/db/seeds/etd_work_area_seeds.rb
@@ -7,7 +7,11 @@ def find_or_initialize_or_create!(attributes = {})
   receiver.send(method_name, attributes.except(:context, :receiver))
 end
 
-Sipity::Services::CreateWorkAreaService.call(name: 'Electronic Thesis and Dissertation', slug: 'etd')
+# TODO: Assign work_area_manager to Grad School Group
+etd_work_area = Sipity::Services::CreateWorkAreaService.call(name: 'Electronic Thesis and Dissertation', slug: 'etd')
+
+# TODO: Assign submission_window_manager to Grad School Group
+submission_window = Sipity::Services::FindOrCreateSubmissionWindowService.call(slug: 'start', work_area: etd_work_area)
 
 ['doctoral_dissertation', 'master_thesis'].each do |work_type_name|
   $stdout.puts "Creating #{work_type_name} State Machine"

--- a/spec/models/sipity/models/submission_window_spec.rb
+++ b/spec/models/sipity/models/submission_window_spec.rb
@@ -15,6 +15,10 @@ module Sipity
         expect(subject.submission_window_work_types).to be_a(ActiveRecord::Relation)
       end
 
+      it 'will have one .strategy_usage' do
+        expect(subject.association(:strategy_usage)).to be_a(ActiveRecord::Associations::HasOneAssociation)
+      end
+
       context '#slug' do
         it 'will transform the slug to a URI safe item' do
           subject.slug = 'Hello World'

--- a/spec/models/sipity/models/work_area_spec.rb
+++ b/spec/models/sipity/models/work_area_spec.rb
@@ -18,6 +18,10 @@ module Sipity
         expect(subject.to_s).to eq(subject.name)
       end
 
+      it 'will have one .strategy_usage' do
+        expect(subject.association(:strategy_usage)).to be_a(ActiveRecord::Associations::HasOneAssociation)
+      end
+
       context '#to_processing_entity' do
         it 'will raise an exception if one has not been created' do
           expect { subject.to_processing_entity }.to raise_error(Exceptions::ProcessingEntityConversionError)

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -31,8 +31,7 @@ module Sipity
       end
 
       it 'has one :strategy_usage' do
-        expect(described_class.reflect_on_association(:strategy_usage)).
-          to be_a(ActiveRecord::Reflection::AssociationReflection)
+        expect(subject.association(:strategy_usage)).to be_a(ActiveRecord::Associations::HasOneAssociation)
       end
     end
   end

--- a/spec/services/sipity/services/find_or_create_submission_window_service_spec.rb
+++ b/spec/services/sipity/services/find_or_create_submission_window_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+module Sipity
+  module Services
+    RSpec.describe FindOrCreateSubmissionWindowService do
+      subject { described_class }
+      let(:work_area) { Models::WorkArea.new(slug: 'etd', id: 1) }
+      let(:strategy_id) { 888_999_111 }
+      let(:slug) { 'start' }
+      it 'will create a submission window for the given work area' do
+        expect { subject.call(slug: slug, work_area: work_area) }.
+          to change(Models::SubmissionWindow, :count).by(1)
+      end
+      it 'will yield the created submission window' do
+        expect { |b| subject.call(slug: slug, work_area: work_area, &b) }.
+          to yield_with_args(Models::SubmissionWindow)
+      end
+
+      it 'will reuse an existing strategy usage for the given work area' do
+        another_submission_window = Models::SubmissionWindow.create!(slug: 'start-2', work_area_id: work_area.id)
+        Models::Processing::StrategyUsage.create!(usage: another_submission_window, strategy_id: strategy_id)
+
+        expect { subject.call(slug: slug, work_area: work_area) }.
+          to change { Models::Processing::StrategyUsage.where(strategy_id: strategy_id).count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Renaming method for improved clarity

@dac0a6ba4760868311b33146fa14486c77617645


## Refactoring to use slug instead of name

@83515727cafda20a836f904b98b54845fe1efd41

For building a work area, I want it to be based on the slug.

## Create ETD Work Area as part of slug

@d69bc0231d1ca5d88c2e7684de3dee1e5ef9ba94


## Adding SubmissionWindow.strategy_usage

@118f69944262d94d4e9d612af018875d439c0266

Because submission window's have workflows

## Adding WorkArea.strategy_usage

@ffe730e7634aeedbd9e44f2369e9bc47f0bb7071

Because work area's have workflows

## Adding WorkType.strategy_usage

@275e3c4dea2f3f02c0d0fae1a7f0f13cf0da1fd9

Because work type's have workflows

## Adding FindOrCreateSubmissionWindowService

@b7d7e8786ab6aa4d1302319e77f52ae465c2b718

I want to begin encoding the "factory" services (perhaps a new
directory) for what happens when we want to create a new submission
window.

## Applying PowerConverter to work area

@c25d15d7377b2ac8a8f90f82175661d5f78de8ef

Instead of assuming I have a work area, convert the value to a work
area.

## Adding submission window creation to ETDs

@dc9b29019798b2c88c2b7f9496c2cf844e6fa0a4

I still need to resolve the Submission Window templating behavior.
