### PR TITLE
Tidying up routes for WorkArea & SubmissionWindow

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,16 +49,11 @@ Rails.application.routes.draw do
 
 
   get 'areas/:work_area_slug', as: 'work_area', to: 'sipity/controllers/work_areas#show'
-
-  # The edit action for routing; Experimental and it may be obviated by the processing action
-  get 'areas/:work_area_slug/edit', as: 'edit_work_area', to: 'sipity/controllers/work_areas#edit'
-  get 'areas/:work_area_slug/do/edit', to: 'sipity/controllers/work_areas#edit'
-  put 'areas/:work_area_slug/do/edit', to: 'sipity/controllers/work_areas#update'
-  put 'areas/:work_area_slug', to: 'sipity/controllers/work_areas#update'
-  put 'areas/:work_area_slug/edit', to: 'sipity/controllers/work_areas#update'
-
   get 'areas/:work_area_slug/do/:query_action_name', as: 'work_area_query_action', to: 'sipity/controllers/work_areas#query_action'
-  post 'areas/:work_area_slug/do/:command_action_name', to: 'sipity/controllers/work_areas#command_action'
+
+  [:post, :put, :patch, :delete].each do |http_verb_name|
+    send(http_verb_name, 'areas/:work_area_slug/do/:command_action_name', to: 'sipity/controllers/work_areas#command_action')
+  end
 
   get(
     'areas/:work_area_slug/:submission_window_slug',
@@ -72,10 +67,13 @@ Rails.application.routes.draw do
     to: 'sipity/controllers/submission_windows#query_action'
   )
 
-  post(
-    'areas/:work_area_slug/:submission_window_slug/do/:command_action_name',
-    to: 'sipity/controllers/submission_windows#command_action'
-  )
+  [:post, :put, :patch, :delete].each do |http_verb_name|
+    send(
+      http_verb_name,
+      'areas/:work_area_slug/:submission_window_slug/do/:command_action_name',
+      to: 'sipity/controllers/submission_windows#command_action'
+    )
+  end
 
   # I need parentheses or `{ }` for the block, because of when the blocks are
   # bound.

--- a/spec/routing/submission_window_routing_spec.rb
+++ b/spec/routing/submission_window_routing_spec.rb
@@ -25,6 +25,33 @@ describe 'work area routing spec' do
           action: 'command_action',
           command_action_name: 'edit'
         }
+      ], [
+        :patch,
+        {
+          path: "/areas/area-slug/start/do/edit",
+          work_area_slug: 'area-slug',
+          submission_window_slug: 'start',
+          action: 'command_action',
+          command_action_name: 'edit'
+        }
+      ], [
+        :put,
+        {
+          path: "/areas/area-slug/start/do/edit",
+          work_area_slug: 'area-slug',
+          submission_window_slug: 'start',
+          action: 'command_action',
+          command_action_name: 'edit'
+        }
+      ], [
+        :delete,
+        {
+          path: "/areas/area-slug/start/do/edit",
+          work_area_slug: 'area-slug',
+          submission_window_slug: 'start',
+          action: 'command_action',
+          command_action_name: 'edit'
+        }
       ]
     ].each do |http_method, settings|
       it "will #{http_method.to_s.upcase} #{settings.fetch(:path)}" do

--- a/spec/routing/work_area_routing_spec.rb
+++ b/spec/routing/work_area_routing_spec.rb
@@ -9,24 +9,18 @@ describe 'work area routing spec' do
         { path: "/areas/my_slug", action: 'show', work_area_slug: 'my_slug' }
       ], [
         :get,
-        { path: "/areas/my_slug/edit", action: 'edit', work_area_slug: 'my_slug' }
-      ], [
-        :get,
-        { path: "/areas/my_slug/do/edit", action: 'edit', work_area_slug: 'my_slug' }
-      ], [
-        :get,
         { path: "/areas/my_slug/do/fun_things", action: 'query_action', work_area_slug: 'my_slug', query_action_name: 'fun_things' }
       ], [
-        :put,
-        { path: "/areas/my_slug", action: 'update', work_area_slug: 'my_slug' }
-      ], [
-        :put,
-        { path: "/areas/my_slug/edit", action: 'update', work_area_slug: 'my_slug' }
-      ], [
-        :put,
-        { path: "/areas/my_slug/do/edit", action: 'update', work_area_slug: 'my_slug' }
-      ], [
         :post,
+        { path: "/areas/my_slug/do/fun_things", action: 'command_action', work_area_slug: 'my_slug', command_action_name: 'fun_things' }
+      ], [
+        :put,
+        { path: "/areas/my_slug/do/fun_things", action: 'command_action', work_area_slug: 'my_slug', command_action_name: 'fun_things' }
+      ], [
+        :patch,
+        { path: "/areas/my_slug/do/fun_things", action: 'command_action', work_area_slug: 'my_slug', command_action_name: 'fun_things' }
+      ], [
+        :delete,
         { path: "/areas/my_slug/do/fun_things", action: 'command_action', work_area_slug: 'my_slug', command_action_name: 'fun_things' }
       ]
     ].each do |http_method, settings|


### PR DESCRIPTION
Instead of the "privileged" actions of "edit", "create", etc I'm going
with the more generalized query_action and command_action. This will
mean the forms that are generated may need some TLC as Rails makes
grandiose assumptions/conventions regarding pathing of objects.

However, this will push towards a more normalized experience via both
routes and controllers.