### PR TITLE
Extracting a proper SubmissionWindowQueries mod

### DIFF
--- a/app/repositories/sipity/queries/submission_window_queries.rb
+++ b/app/repositories/sipity/queries/submission_window_queries.rb
@@ -1,0 +1,11 @@
+module Sipity
+  module Queries
+    # Queries related to SubmissionWindows.
+    module SubmissionWindowQueries
+      def find_submission_window_by(slug:, work_area:)
+        work_area = PowerConverter.convert_to_work_area(work_area)
+        Models::SubmissionWindow.find_by!(slug: slug, work_area_id: work_area.id)
+      end
+    end
+  end
+end

--- a/app/repositories/sipity/queries/work_area_queries.rb
+++ b/app/repositories/sipity/queries/work_area_queries.rb
@@ -3,14 +3,7 @@ module Sipity
     # Queries related to work areas.
     module WorkAreaQueries
       def find_work_area_by(slug:)
-        Models::WorkArea.where(slug: slug).first!
-      end
-
-      # TODO: Extract to a Submission Window query? Not necessary but may be
-      # helpful going forward.
-      def find_submission_window_by(slug:, work_area:)
-        work_area = PowerConverter.convert_to_work_area(work_area)
-        Models::SubmissionWindow.find_by!(slug: slug, work_area: work_area)
+        Models::WorkArea.find_by!(slug: slug)
       end
 
       def build_work_area_processing_action_form(work_area:, processing_action_name:, attributes: {})

--- a/app/repositories/sipity/query_repository.rb
+++ b/app/repositories/sipity/query_repository.rb
@@ -16,6 +16,7 @@ module Sipity
     include Queries::NotificationQueries
     include Queries::ProcessingQueries
     include Queries::SimpleControlledVocabularyQueries
+    include Queries::SubmissionWindowQueries
     include Queries::WorkAreaQueries
     include Queries::WorkQueries
   end

--- a/spec/repositories/sipity/queries/submission_window_queries_spec.rb
+++ b/spec/repositories/sipity/queries/submission_window_queries_spec.rb
@@ -1,0 +1,35 @@
+module Sipity
+  module Queries
+    RSpec.describe SubmissionWindowQueries, type: :isolated_repository_module do
+      let(:work_area) do
+        Models::WorkArea.new(id: 1, name: 'worm', slug: 'worm', partial_suffix: 'worm', demodulized_class_prefix_name: 'Worm')
+      end
+      context '#find_submission_window_by' do
+        let(:submission_window) do
+          Models::SubmissionWindow.create!(work_area_id: work_area.id, slug: 'segment')
+        end
+
+        it 'will find by slug and work area' do
+          expect(test_repository.find_submission_window_by(slug: submission_window.slug, work_area: work_area)).
+            to eq(submission_window)
+        end
+
+        it 'will raise an error if we have a bad work area' do
+          expect { test_repository.find_submission_window_by(slug: submission_window.slug, work_area: nil) }.
+            to raise_error(PowerConverter::ConversionError)
+        end
+
+        it 'will raise an error if the submission window and work area are out of sync' do
+          submission_window = Models::SubmissionWindow.create!(work_area_id: work_area.id + 1, slug: 'segment')
+          expect { test_repository.find_submission_window_by(slug: submission_window.slug, work_area: work_area) }.
+            to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'will raise an error if the submission window does not exist' do
+          expect { test_repository.find_submission_window_by(slug: 'another-slug', work_area: work_area) }.
+            to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end

--- a/spec/repositories/sipity/queries/work_area_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_area_queries_spec.rb
@@ -2,23 +2,18 @@ module Sipity
   module Queries
     RSpec.describe WorkAreaQueries, type: :isolated_repository_module do
       let(:work_area) do
-        Models::WorkArea.create!(name: 'worm', slug: 'worm', partial_suffix: 'worm', demodulized_class_prefix_name: 'Worm')
+        Models::WorkArea.new(name: 'worm', slug: 'worm', partial_suffix: 'worm', demodulized_class_prefix_name: 'Worm')
       end
       context '#find_works_area_by' do
         it 'will find by slug' do
+          work_area.save!
           expect(test_repository.find_work_area_by(slug: work_area.slug)).to eq(work_area)
         end
-      end
-      context '#find_submission_window_by' do
-        let(:submission_window) do
-          Models::SubmissionWindow.create!(work_area: work_area, slug: 'segment')
-        end
-        it 'will find by slug and work area' do
-          expect(test_repository.find_submission_window_by(slug: submission_window.slug, work_area: work_area.slug)).
-            to eq(submission_window)
-        end
-      end
 
+        it 'will raise an exception if none is found' do
+          expect { test_repository.find_work_area_by(slug: 'another') }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
       context '#build_work_area_processing_action_form' do
         let(:parameters) { { work_area: double, processing_action_name: double, attributes: double } }
         let(:form) { double }

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -149,7 +149,7 @@ module Sipity
     def find_or_initialize_collaborators_by(work:, id:, &block)
     end
 
-    # @see ./app/repositories/sipity/queries/work_area_queries.rb
+    # @see ./app/repositories/sipity/queries/submission_window_queries.rb
     def find_submission_window_by(slug:, work_area:)
     end
 

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -85,7 +85,7 @@ module Sipity
     def find_or_initialize_collaborators_by(work:, id:, &block)
     end
 
-    # @see ./app/repositories/sipity/queries/work_area_queries.rb
+    # @see ./app/repositories/sipity/queries/submission_window_queries.rb
     def find_submission_window_by(slug:, work_area:)
     end
 


### PR DESCRIPTION
Instead of overworking the WorkAreaQueries, I want a separate query.
This is in preparation for SubmissionWindow action rendering.

Once the SubmissionWindow action rendering is complete, I can bring
that to the ETD work space.

The goal is to move quickly on it so I can add the requisite new
actions.