### PR TITLE
Working on dynamic submission window form retrieval

### DIFF
--- a/app/models/sipity/models/submission_window.rb
+++ b/app/models/sipity/models/submission_window.rb
@@ -5,7 +5,7 @@ module Sipity
       self.table_name = 'sipity_submission_windows'
 
       belongs_to :work_area
-      delegate :slug, to: :work_area, prefix: :work_area
+      delegate :slug, :partial_suffix, to: :work_area, prefix: :work_area
 
       has_many :submission_window_work_types, dependent: :destroy
       has_many :work_submissions, dependent: :destroy

--- a/app/presenters/sipity/controllers/submission_window_presenter.rb
+++ b/app/presenters/sipity/controllers/submission_window_presenter.rb
@@ -20,7 +20,9 @@ module Sipity
       end
 
       def path
-        submission_window_for_work_area_path(work_area_slug: submission_window.work_area_slug, submission_window_slug: submission_window.slug)
+        submission_window_for_work_area_path(
+          work_area_slug: submission_window.work_area_slug, submission_window_slug: submission_window.slug
+        )
       end
 
       delegate(

--- a/app/presenters/sipity/controllers/submission_window_presenter.rb
+++ b/app/presenters/sipity/controllers/submission_window_presenter.rb
@@ -12,17 +12,15 @@ module Sipity
         self.processing_actions = compose_processing_actions
       end
 
-      delegate :work_area, :work_area_slug, :slug, to: :submission_window
-
       attr_reader :submission_window
-      private :submission_window, :work_area
+      private :submission_window
 
       def link
-        link_to(slug, path)
+        link_to(submission_window.slug, path)
       end
 
       def path
-        submission_window_for_work_area_path(work_area_slug: work_area_slug, submission_window_slug: slug)
+        submission_window_for_work_area_path(work_area_slug: submission_window.work_area_slug, submission_window_slug: submission_window.slug)
       end
 
       delegate(

--- a/app/presenters/sipity/controllers/submission_windows/show_presenter.rb
+++ b/app/presenters/sipity/controllers/submission_windows/show_presenter.rb
@@ -3,11 +3,13 @@ module Sipity
     module SubmissionWindows
       # Responsible for presenting a work area
       class ShowPresenter < SubmissionWindowPresenter
+        RENDER_METHOD_PREFIX = "render_submission_window_for_".freeze
+        RENDER_METHOD_WORK_TYPE_REGEXP = /\A#{RENDER_METHOD_PREFIX}.*\Z/
         def render_submission_window
           # HACK: Oh boy is this ugly, but it delivers what I am after.
           # It also draws attention to the new rendering that I'm after
-          slug_to_method_name_suffix = PowerConverter.convert_to_safe_for_method_name(work_area_slug)
-          send("render_submission_window_for_#{slug_to_method_name_suffix}")
+          slug_to_method_name_suffix = PowerConverter.convert_to_safe_for_method_name(submission_window.work_area_slug)
+          send("#{RENDER_METHOD_PREFIX}#{slug_to_method_name_suffix}")
         end
 
         private

--- a/app/presenters/sipity/controllers/submission_windows/show_presenter.rb
+++ b/app/presenters/sipity/controllers/submission_windows/show_presenter.rb
@@ -14,6 +14,19 @@ module Sipity
 
         private
 
+        def method_missing(method_name, *args, &block)
+          match_data = RENDER_METHOD_WORK_TYPE_REGEXP.match(method_name)
+          if match_data
+            render_general_submission_window
+          else
+            super
+          end
+        end
+
+        def render_general_submission_window
+          render partial: "#{action_name}_#{submission_window.work_area_partial_suffix}", object: self
+        end
+
         def render_submission_window_for_etd
           deprecated_render_submission_window_for_etd
         end

--- a/spec/models/sipity/models/submission_window_spec.rb
+++ b/spec/models/sipity/models/submission_window_spec.rb
@@ -14,6 +14,7 @@ module Sipity
       it { should respond_to :processing_strategy }
       it { should respond_to :processing_state }
       it { should respond_to :work_area_slug }
+      it { should respond_to :work_area_partial_suffix }
 
       it 'will have many .submission_window_work_types' do
         expect(subject.submission_window_work_types).to be_a(ActiveRecord::Relation)

--- a/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
@@ -11,10 +11,8 @@ module Sipity
       let(:repository) { QueryRepositoryInterface.new }
       subject { described_class.new(context, submission_window: submission_window, repository: repository) }
 
-      its(:slug) { should eq(submission_window.slug) }
-      its(:work_area_slug) { should eq(submission_window.work_area_slug) }
-      its(:path) { should eq("/areas/#{work_area.slug}/#{submission_window.slug}") }
-      its(:link) { should eq(%(<a href="/areas/#{work_area.slug}/#{submission_window.slug}">the-slug</a>)) }
+      its(:path) { should eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}") }
+      its(:link) { should eq(%(<a href="#{subject.path}">the-slug</a>)) }
 
       it 'will compose actions for the submission window' do
         expect(ComposableElements::ProcessingActionsComposer).to receive(:new).with(user: current_user, entity: submission_window)

--- a/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
@@ -4,18 +4,25 @@ module Sipity
   module Controllers
     module SubmissionWindows
       RSpec.describe ShowPresenter do
-        let(:context) { PresenterHelper::Context.new(current_user: current_user) }
+        let(:context) { PresenterHelper::Context.new(current_user: current_user, action_name: 'show', render: true) }
         let(:current_user) { double('Current User') }
-        let(:submission_window) { double(slug: 'the-slug', work_area: work_area, work_area_slug: work_area.slug) }
-        let(:work_area) { double(slug: 'work-area') }
+        let(:submission_window) { Models::SubmissionWindow.new(slug: 'the-slug', work_area: work_area) }
+        let(:work_area) { Models::WorkArea.new(slug: 'work-area', partial_suffix: 'work_area') }
         subject { described_class.new(context, submission_window: submission_window) }
         it { should be_a SubmissionWindowPresenter }
 
         context '#render_submission_window' do
+          context 'for a ULRA' do
+            it 'will render the partial for ulra' do
+              expect(context).to receive(:render).
+                with(partial: "#{context.action_name}_#{submission_window.work_area_partial_suffix}", object: subject)
+              subject.render_submission_window
+            end
+          end
           context 'for an ETD' do
             let(:controller) { double('Controller') }
             let(:context) { PresenterHelper::Context.new(current_user: current_user, controller: controller) }
-            let(:work_area) { double(slug: 'etd') }
+            let(:work_area) { Models::WorkArea.new(slug: 'etd', partial_suffix: 'etd') }
             let(:etd_form) { double }
             let(:decorated_form) { double }
 


### PR DESCRIPTION
## Retrieving dynamic SubmissionWindow forms

@2adfaad0730f0c62a50748def6de77220f9ce02f

In preparation for the ULRA work form retrieval normalizing the
underlying elements.

## Adding SubmissionWindow#work_area_partial_prefix

@14b6f8066e78d70fddde64817ae8b6971cfc2c0d

I want to have access to this method without undo antics.

## Removing extra delegations

@ae9cffbbfe3baa44c4910ff442f517aa5c81a7d2

Thusfar there has been no violation of the law of demeter

## Allowing dynamic show rendering

@8b4b6057b62f37374d4bdeacc3da1bcf8c4d96b2

Given that Show is a "glorified use case" of the query actions, I'm
contemplating revoking its highlighted privilege and replacing it with
a query action.
