### PR TITLE
Normalizing routing for actions

### DIFF
--- a/app/controllers/sipity/controllers/submission_windows_controller.rb
+++ b/app/controllers/sipity/controllers/submission_windows_controller.rb
@@ -8,11 +8,6 @@ module Sipity
       self.runner_container = Sipity::Runners::SubmissionWindowRunners
       self.response_handler_container = Sipity::ResponseHandlers::SubmissionWindowHandler
 
-      def show
-        runner_response = run(work_area_slug: work_area_slug, submission_window_slug: submission_window_slug)
-        handle_response(runner_response)
-      end
-
       def query_action
         runner_response = run(
           work_area_slug: work_area_slug,

--- a/app/controllers/sipity/controllers/work_areas_controller.rb
+++ b/app/controllers/sipity/controllers/work_areas_controller.rb
@@ -8,11 +8,6 @@ module Sipity
       self.runner_container = Sipity::Runners::WorkAreaRunners
       self.response_handler_container = Sipity::ResponseHandlers::WorkAreaHandler
 
-      def show
-        runner_response = run(work_area_slug: work_area_slug)
-        handle_response(runner_response)
-      end
-
       def query_action
         runner_response = run(
           work_area_slug: work_area_slug,

--- a/app/controllers/sipity/controllers/work_submissions_controller.rb
+++ b/app/controllers/sipity/controllers/work_submissions_controller.rb
@@ -3,10 +3,8 @@ module Sipity
     # The controller for creating works.
     class WorkSubmissionsController < ApplicationController
       class_attribute :response_handler_container
-      # TODO: Review this
-      self.runner_container = Sipity::Runners::WorkRunners
-      # TODO: This is a stop-gap
-      self.response_handler_container = Sipity::ResponseHandlers::WorkAreaHandler
+      self.runner_container = Sipity::Runners::WorkSubmissionsRunners
+      self.response_handler_container = Sipity::ResponseHandlers::WorkSubmissionHandler
 
       def query_action
         runner_response = run(

--- a/app/controllers/sipity/controllers/work_submissions_controller.rb
+++ b/app/controllers/sipity/controllers/work_submissions_controller.rb
@@ -1,0 +1,73 @@
+module Sipity
+  module Controllers
+    # The controller for creating works.
+    class WorkSubmissionsController < ApplicationController
+      class_attribute :response_handler_container
+      # TODO: Review this
+      self.runner_container = Sipity::Runners::WorkRunners
+      # TODO: This is a stop-gap
+      self.response_handler_container = Sipity::ResponseHandlers::WorkAreaHandler
+
+      def query_action
+        runner_response = run(
+          work_id: work_id,
+          processing_action_name: query_action_name,
+          attributes: query_or_command_attributes
+        )
+
+        # I could use action instead of template, but I feel the explicit path
+        # for template is better than the implicit pathing of :action
+        handle_response(runner_response, template: "sipity/controllers/work_submissions/#{query_action_name}")
+      end
+
+      def command_action
+        runner_response = run(
+          work_id: work_id,
+          processing_action_name: command_action_name,
+          attributes: query_or_command_attributes
+        )
+
+        # I could use action instead of template, but I feel the explicit path
+        # for template is better than the implicit pathing of :action
+        handle_response(runner_response, template: "sipity/controllers/work_submissions/#{command_action_name}")
+      end
+
+      attr_accessor :view_object
+      helper_method :view_object
+
+      private
+
+      def work_id
+        params.require(:work_id)
+      end
+
+      def query_action_name
+        params.require(:query_action_name)
+      end
+
+      def command_action_name
+        params.require(:command_action_name)
+      end
+
+      def query_or_command_attributes
+        params.fetch(:work) { HashWithIndifferentAccess.new }
+      end
+
+      def handle_response(handled_response, template:)
+        Sipity::ResponseHandlers.handle_response(
+          context: self,
+          handled_response: handled_response,
+          container: response_handler_container,
+          template: template
+        )
+      end
+
+      def run(*args)
+        # TODO: This is an intermediary step that will be wrapped into the
+        #   existing #run method; However it should be considered experimental
+        status, object = super(*args)
+        Parameters::HandledResponseParameter.new(status: status, object: object)
+      end
+    end
+  end
+end

--- a/app/controllers/sipity/controllers/work_submissions_controller.rb
+++ b/app/controllers/sipity/controllers/work_submissions_controller.rb
@@ -15,7 +15,7 @@ module Sipity
 
         # I could use action instead of template, but I feel the explicit path
         # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/work_submissions/#{query_action_name}")
+        handle_response(runner_response, template: "sipity/controllers/works/#{query_action_name}")
       end
 
       def command_action
@@ -27,11 +27,13 @@ module Sipity
 
         # I could use action instead of template, but I feel the explicit path
         # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/work_submissions/#{command_action_name}")
+        handle_response(runner_response, template: "sipity/controllers/works/#{command_action_name}")
       end
 
       attr_accessor :view_object
       helper_method :view_object
+      alias_method :model, :view_object
+      helper_method :model
 
       private
 

--- a/app/forms/sipity/forms/core/submission_windows/show_form.rb
+++ b/app/forms/sipity/forms/core/submission_windows/show_form.rb
@@ -1,0 +1,29 @@
+module Sipity
+  module Forms
+    module Core
+      module SubmissionWindows
+        # Responsible for "showing" a Submission Window.
+        #
+        # @note This is the result of changing the SubmissionsWindows controller
+        #   to be two actions.
+        class ShowForm < SimpleDelegator
+          class_attribute :policy_enforcer
+          self.policy_enforcer = Sipity::Policies::SubmissionWindowPolicy
+
+          def initialize(submission_window:, processing_action_name:, **_keywords)
+            self.submission_window = submission_window
+            self.processing_action_name = processing_action_name
+            super(submission_window)
+          end
+
+          attr_reader :processing_action_name
+
+          private
+
+          attr_writer :processing_action_name
+          attr_accessor :submission_window
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/core/work_areas/show_form.rb
+++ b/app/forms/sipity/forms/core/work_areas/show_form.rb
@@ -1,0 +1,29 @@
+module Sipity
+  module Forms
+    module Core
+      module WorkAreas
+        # Responsible for "showing" a Work Area.
+        #
+        # @note This is the result of changing the WorkAreas controller
+        #   to be two actions.
+        class ShowForm < SimpleDelegator
+          class_attribute :policy_enforcer
+          self.policy_enforcer = Sipity::Policies::WorkAreaPolicy
+
+          def initialize(work_area:, processing_action_name:, **_keywords)
+            self.work_area = work_area
+            self.processing_action_name = processing_action_name
+            super(work_area)
+          end
+
+          attr_reader :processing_action_name
+
+          private
+
+          attr_writer :processing_action_name
+          attr_accessor :work_area
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/core/work_submissions/show_form.rb
+++ b/app/forms/sipity/forms/core/work_submissions/show_form.rb
@@ -1,0 +1,34 @@
+module Sipity
+  module Forms
+    module Core
+      module WorkSubmissions
+        # Responsible for "showing" a Work.
+        #
+        # @note This is the result of changing the Work controller
+        #   to be two actions.
+        class ShowForm < SimpleDelegator
+          class_attribute :policy_enforcer
+          self.policy_enforcer = Sipity::Policies::WorkPolicy
+
+          def initialize(work:, processing_action_name:, **_keywords)
+            self.work = work
+            self.processing_action_name = processing_action_name
+            # A concession regard
+            super(decorated_work)
+          end
+
+          attr_reader :processing_action_name
+
+          private
+
+          def decorated_work
+            Sipity::Decorators::WorkDecorator.decorate(work)
+          end
+
+          attr_writer :processing_action_name
+          attr_accessor :work
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/etd/work_areas.rb
+++ b/app/forms/sipity/forms/etd/work_areas.rb
@@ -1,0 +1,9 @@
+module Sipity
+  module Forms
+    module Etd
+      # Container module for WorkAreas within Etd
+      module WorkAreas
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/submission_window_forms.rb
+++ b/app/forms/sipity/forms/submission_window_forms.rb
@@ -11,7 +11,7 @@ module Sipity
 
         # ASSUMPTION: We will not have custom forms for the given
         # Submission Window.
-        "#{self}::#{namespace}::SubmissionWindows::#{form_name}".constantize.new(
+        "Sipity::Forms::#{namespace}::SubmissionWindows::#{form_name}".constantize.new(
           submission_window: submission_window,
           processing_action_name: processing_action_name,
           attributes: attributes

--- a/app/forms/sipity/forms/submission_window_forms.rb
+++ b/app/forms/sipity/forms/submission_window_forms.rb
@@ -5,18 +5,26 @@ module Sipity
       module_function
 
       def build_the_form(submission_window:, processing_action_name:, attributes:)
-        work_area = PowerConverter.convert(submission_window, to: :work_area)
-        namespace = work_area.demodulized_class_prefix_name
-        form_name = "#{processing_action_name}_form".classify
-
         # ASSUMPTION: We will not have custom forms for the given
         # Submission Window.
-        "Sipity::Forms::#{namespace}::SubmissionWindows::#{form_name}".constantize.new(
+        find_the_form(submission_window: submission_window, processing_action_name: processing_action_name).new(
           submission_window: submission_window,
           processing_action_name: processing_action_name,
           attributes: attributes
         )
       end
+
+      def find_the_form(submission_window:, processing_action_name:)
+        work_area = PowerConverter.convert(submission_window, to: :work_area)
+        form_name = "#{processing_action_name}_form".classify
+        begin
+          namespace = work_area.demodulized_class_prefix_name
+          "Sipity::Forms::#{namespace}::SubmissionWindows::#{form_name}".constantize
+        rescue NameError
+          "Sipity::Forms::Core::SubmissionWindows::#{form_name}".constantize
+        end
+      end
+      private_class_method :find_the_form
     end
   end
 end

--- a/app/forms/sipity/forms/ulra.rb
+++ b/app/forms/sipity/forms/ulra.rb
@@ -1,0 +1,7 @@
+module Sipity
+  module Forms
+    # The container module for all ULRA related forms.
+    module Ulra
+    end
+  end
+end

--- a/app/forms/sipity/forms/ulra/submission_windows.rb
+++ b/app/forms/sipity/forms/ulra/submission_windows.rb
@@ -1,0 +1,9 @@
+module Sipity
+  module Forms
+    module Ulra
+      # Container module for SubmissionWindows within ULRA
+      module SubmissionWindows
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/work_area_forms.rb
+++ b/app/forms/sipity/forms/work_area_forms.rb
@@ -5,14 +5,23 @@ module Sipity
       module_function
 
       def build_the_form(work_area:, processing_action_name:, attributes:)
-        namespace = work_area.demodulized_class_prefix_name
-        form_name = "#{processing_action_name}_form".classify
-        "Sipity::Forms::#{namespace}::WorkAreas::#{form_name}".constantize.new(
+        find_the_form(work_area: work_area, processing_action_name: processing_action_name).new(
           work_area: work_area,
           processing_action_name: processing_action_name,
           attributes: attributes
         )
       end
+
+      def find_the_form(work_area:, processing_action_name:)
+        form_name = "#{processing_action_name}_form".classify
+        begin
+          namespace = work_area.demodulized_class_prefix_name
+          "Sipity::Forms::#{namespace}::WorkAreas::#{form_name}".constantize
+        rescue NameError
+          "Sipity::Forms::Core::WorkAreas::#{form_name}".constantize
+        end
+      end
+      private_class_method :find_the_form
     end
   end
 end

--- a/app/forms/sipity/forms/work_area_forms.rb
+++ b/app/forms/sipity/forms/work_area_forms.rb
@@ -7,7 +7,7 @@ module Sipity
       def build_the_form(work_area:, processing_action_name:, attributes:)
         namespace = work_area.demodulized_class_prefix_name
         form_name = "#{processing_action_name}_form".classify
-        "#{self}::#{namespace}::#{form_name}".constantize.new(
+        "Sipity::Forms::#{namespace}::WorkAreas::#{form_name}".constantize.new(
           work_area: work_area,
           processing_action_name: processing_action_name,
           attributes: attributes

--- a/app/forms/sipity/forms/work_submission_forms.rb
+++ b/app/forms/sipity/forms/work_submission_forms.rb
@@ -1,0 +1,28 @@
+module Sipity
+  module Forms
+    # A container for looking up the correct forms related to work submissions.
+    module WorkSubmissionForms
+      module_function
+
+      def build_the_form(work:, processing_action_name:, attributes:)
+        find_the_form(work: work, processing_action_name: processing_action_name).new(
+          work: work,
+          processing_action_name: processing_action_name,
+          attributes: attributes
+        )
+      end
+
+      def find_the_form(work:, processing_action_name:)
+        work_area = PowerConverter.convert(work, to: :work_area)
+        form_name = "#{processing_action_name}_form".classify
+        begin
+          namespace = work_area.demodulized_class_prefix_name
+          "Sipity::Forms::#{namespace}::WorkSubmissions::#{form_name}".constantize
+        rescue NameError
+          "Sipity::Forms::Core::WorkSubmissions::#{form_name}".constantize
+        end
+      end
+      private_class_method :find_the_form
+    end
+  end
+end

--- a/app/presenters/sipity/controllers/submission_window_presenter.rb
+++ b/app/presenters/sipity/controllers/submission_window_presenter.rb
@@ -15,6 +15,8 @@ module Sipity
       attr_reader :submission_window
       private :submission_window
 
+      delegate :slug, to: :submission_window
+
       def link
         link_to(submission_window.slug, path)
       end

--- a/app/presenters/sipity/controllers/submission_windows/show_presenter.rb
+++ b/app/presenters/sipity/controllers/submission_windows/show_presenter.rb
@@ -1,7 +1,9 @@
 module Sipity
   module Controllers
     module SubmissionWindows
-      # Responsible for presenting a work area
+      # Responsible for presenting a submission window
+      #
+      # @see Sipity::Forms::Core::SubmissionWindows::ShowForm for interface
       class ShowPresenter < SubmissionWindowPresenter
         RENDER_METHOD_PREFIX = "render_submission_window_for_".freeze
         RENDER_METHOD_WORK_TYPE_REGEXP = /\A#{RENDER_METHOD_PREFIX}.*\Z/
@@ -24,7 +26,7 @@ module Sipity
         end
 
         def render_general_submission_window
-          render partial: "#{action_name}_#{submission_window.work_area_partial_suffix}", object: self
+          render partial: "#{submission_window.processing_action_name}_#{submission_window.work_area_partial_suffix}", object: self
         end
 
         def render_submission_window_for_etd

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -2,13 +2,27 @@ module Sipity
   module Queries
     # Queries
     module WorkQueries
-      BASE_HEADER_ATTRIBUTES = [:title, :work_publication_strategy].freeze
       def find_work(work_id)
-        Models::Work.includes(:processing_entity, work_submission: [:work_area, :submission_window]).find(work_id)
+        find_work_by(id: work_id)
+      end
+
+      def find_work_by(id:)
+        Models::Work.includes(:processing_entity, work_submission: [:work_area, :submission_window]).find(id)
       end
 
       def build_dashboard_view(user:, filter: {})
         Decorators::DashboardView.new(repository: self, user: user, filter: filter)
+      end
+
+      # TODO: Rename this method; Keeping it separate for now.
+      def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {})
+        # Leveraging an obvious inflection point, namely each work area may well
+        # have its own form module.
+        Forms::WorkSubmissionForms.build_the_form(
+          work: work,
+          processing_action_name: processing_action_name,
+          attributes: attributes
+        )
       end
 
       def find_works_for(user:, processing_state: nil)

--- a/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
@@ -1,0 +1,12 @@
+module Sipity
+  module ResponseHandlers
+    # This is an Experimental module and concept
+    module WorkSubmissionHandler
+      # Responsible for handling a :success-ful action
+      #
+      # TODO: Extract a porper base class, if one exists
+      class SuccessResponse < ResponseHandlers::WorkAreaHandler::SuccessResponse
+      end
+    end
+  end
+end

--- a/app/runners/sipity/runners/submission_window_runners.rb
+++ b/app/runners/sipity/runners/submission_window_runners.rb
@@ -1,20 +1,6 @@
 module Sipity
   module Runners
     module SubmissionWindowRunners
-      # Responsible for responding with a submission window
-      class Show < BaseRunner
-        self.authentication_layer = :default
-        self.authorization_layer = :default
-        self.action_name = :show?
-
-        def run(work_area_slug:, submission_window_slug:)
-          submission_window = repository.find_submission_window_by(slug: submission_window_slug, work_area: work_area_slug)
-          authorization_layer.enforce!(action_name => submission_window) do
-            callback(:success, submission_window)
-          end
-        end
-      end
-
       # :nodoc:
       class CommandQueryAction < BaseRunner
         self.authentication_layer = :default

--- a/app/runners/sipity/runners/submission_window_runners.rb
+++ b/app/runners/sipity/runners/submission_window_runners.rb
@@ -1,5 +1,6 @@
 module Sipity
   module Runners
+    # Responsible for being a collection of SubmissionWindow runners
     module SubmissionWindowRunners
       # :nodoc:
       class CommandQueryAction < BaseRunner
@@ -16,6 +17,7 @@ module Sipity
           end
         end
       end
+      private_constant :CommandQueryAction
 
       # The general handler for general query actions (show may be a customized
       # case).

--- a/app/runners/sipity/runners/work_area_runners.rb
+++ b/app/runners/sipity/runners/work_area_runners.rb
@@ -1,5 +1,6 @@
 module Sipity
   module Runners
+    # Container for WorkArea related "action" runners
     module WorkAreaRunners
       # :nodoc:
       class CommandQueryAction < BaseRunner
@@ -16,6 +17,7 @@ module Sipity
           end
         end
       end
+      private_constant :CommandQueryAction
 
       # The general handler for general query actions (show may be a customized
       # case).

--- a/app/runners/sipity/runners/work_area_runners.rb
+++ b/app/runners/sipity/runners/work_area_runners.rb
@@ -1,49 +1,41 @@
 module Sipity
   module Runners
     module WorkAreaRunners
-      # Responsible for responding with a work area
-      class Show < BaseRunner
+      # :nodoc:
+      class CommandQueryAction < BaseRunner
         self.authentication_layer = :default
         self.authorization_layer = :default
-        self.action_name = :show?
 
-        def run(work_area_slug:)
+        def run(work_area_slug:, processing_action_name:, attributes: {})
           work_area = repository.find_work_area_by(slug: work_area_slug)
-          authorization_layer.enforce!(action_name => work_area) do
-            callback(:success, work_area)
+          form = repository.build_work_area_processing_action_form(
+            work_area: work_area, processing_action_name: processing_action_name, attributes: attributes
+          )
+          authorization_layer.enforce!(processing_action_name => form) do
+            yield(form, work_area)
           end
         end
       end
 
       # The general handler for general query actions (show may be a customized
       # case).
-      class QueryAction < BaseRunner
-        self.authentication_layer = :default
-        self.authorization_layer = :default
-
+      class QueryAction < CommandQueryAction
         def run(work_area_slug:, processing_action_name:, attributes: {})
-          work_area = repository.find_work_area_by(slug: work_area_slug)
-          form = repository.build_work_area_processing_action_form(
-            work_area: work_area, processing_action_name: processing_action_name, attributes: attributes
-          )
-          authorization_layer.enforce!(processing_action_name => form) do
+          super do |form, _work_area|
             callback(:success, form)
           end
         end
       end
 
       # The general handler for all command actions
-      class CommandAction < BaseRunner
-        self.authentication_layer = :default
-        self.authorization_layer = :default
-
+      class CommandAction < CommandQueryAction
         def run(work_area_slug:, processing_action_name:, attributes: {})
-          work_area = repository.find_work_area_by(slug: work_area_slug)
-          form = repository.build_work_area_processing_action_form(
-            work_area: work_area, processing_action_name: processing_action_name, attributes: attributes
-          )
-          authorization_layer.enforce!(processing_action_name => form) do
-            form.submit(requested_by: current_user) ? callback(:success, work_area) : callback(:failure, form)
+          super do |form, work_area|
+            if form.submit(requested_by: current_user)
+              callback(:success, work_area)
+            else
+              callback(:failure, form)
+            end
           end
         end
       end

--- a/app/runners/sipity/runners/work_submissions_runners.rb
+++ b/app/runners/sipity/runners/work_submissions_runners.rb
@@ -1,0 +1,46 @@
+module Sipity
+  module Runners
+    # Container for WorkSubmission's "action" runners
+    module WorkSubmissionsRunners
+      # :nodoc:
+      class CommandQueryAction < BaseRunner
+        self.authentication_layer = :default
+        self.authorization_layer = :default
+
+        def run(work_id:, processing_action_name:, attributes: {})
+          work = repository.find_work_by(id: work_id)
+          form = repository.build_work_submission_processing_action_form(
+            work: work, processing_action_name: processing_action_name, attributes: attributes
+          )
+          authorization_layer.enforce!(processing_action_name => form) do
+            yield(form, work)
+          end
+        end
+      end
+      private_constant :CommandQueryAction
+
+      # The general handler for general query actions (show may be a customized
+      # case).
+      class QueryAction < CommandQueryAction
+        def run(work_id:, processing_action_name:, attributes: {})
+          super do |form, _work|
+            callback(:success, form)
+          end
+        end
+      end
+
+      # The general handler for all command actions
+      class CommandAction < CommandQueryAction
+        def run(work_id:, processing_action_name:, attributes: {})
+          super do |form, work|
+            if form.submit(requested_by: current_user)
+              callback(:success, work)
+            else
+              callback(:failure, form)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/sipity/controllers/submission_windows/_show_ulra.html.erb
+++ b/app/views/sipity/controllers/submission_windows/_show_ulra.html.erb
@@ -1,0 +1,5 @@
+<dl>
+  <dt>Submission Window Slug</dt>
+  <dd><%= show_ulra.slug %></dd>
+</dl>
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,6 @@ Rails.application.routes.draw do
   get 'dashboard', to: 'sipity/controllers/dashboards#index', as: "dashboard"
   get 'start', to: redirect('/works/new'), as: 'start'
 
-
   get 'areas/:work_area_slug', as: 'work_area', to: 'sipity/controllers/work_areas#show'
   get 'areas/:work_area_slug/do/:query_action_name', as: 'work_area_query_action', to: 'sipity/controllers/work_areas#query_action'
 
@@ -46,7 +45,8 @@ Rails.application.routes.draw do
   get(
     'areas/:work_area_slug/:submission_window_slug',
     as: 'submission_window_for_work_area',
-    to: 'sipity/controllers/submission_windows#show'
+    defaults: { query_action_name: 'show'},
+    to: 'sipity/controllers/submission_windows#query_action'
   )
 
   get(
@@ -61,6 +61,12 @@ Rails.application.routes.draw do
       'areas/:work_area_slug/:submission_window_slug/do/:command_action_name',
       to: 'sipity/controllers/submission_windows#command_action'
     )
+  end
+
+  get 'work_submissions/:work_id', as: 'work_submission', to: 'sipity/controllers/work_submissions#query_action', defaults: { query_action_name: 'show' }
+  get 'work_submissions/:work_id/do/:query_action_name', as: 'work_submission_query_action', to: 'sipity/controllers/work_submissions#query_action'
+  [:post, :put, :patch, :delete].each do |http_verb_name|
+    send(http_verb_name, 'work_submissions/:work_id/do/:command_action_name', to: 'sipity/controllers/work_submissions#command_action')
   end
 
   # I need parentheses or `{ }` for the block, because of when the blocks are

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   get 'dashboard', to: 'sipity/controllers/dashboards#index', as: "dashboard"
   get 'start', to: redirect('/works/new'), as: 'start'
 
-  get 'areas/:work_area_slug', as: 'work_area', to: 'sipity/controllers/work_areas#show'
+  get 'areas/:work_area_slug', as: 'work_area', to: 'sipity/controllers/work_areas#query_action', defaults: { query_action_name: 'show' }
   get 'areas/:work_area_slug/do/:query_action_name', as: 'work_area_query_action', to: 'sipity/controllers/work_areas#query_action'
 
   [:post, :put, :patch, :delete].each do |http_verb_name|

--- a/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
@@ -13,16 +13,6 @@ module Sipity
         its(:response_handler_container) { should eq(ResponseHandlers::SubmissionWindowHandler) }
       end
 
-      context 'GET #show' do
-        before { controller.runner = runner }
-        it 'will pass along to the response handler' do
-          expect_any_instance_of(ResponseHandlers::SubmissionWindowHandler::SuccessResponse).to receive(:respond).and_call_original
-          get 'show', work_area_slug: work_area.slug, submission_window_slug: submission_window.slug
-
-          expect(controller.view_object).to be_present
-        end
-      end
-
       context 'GET #query_action' do
         before { controller.runner = runner }
         let(:query_action_name) { 'fun_things' }

--- a/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
@@ -12,16 +12,6 @@ module Sipity
         its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkAreaHandler) }
       end
 
-      context 'GET #show' do
-        before { controller.runner = runner }
-        it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
-          get 'show', work_area_slug: work_area.slug
-
-          expect(controller.view_object).to be_present
-        end
-      end
-
       context 'GET #query_action' do
         before { controller.runner = runner }
         let(:query_action_name) { 'fun_things' }

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -9,8 +9,8 @@ module Sipity
       let(:runner) { double('Runner', run: [status, work]) }
 
       context 'configuration' do
-        its(:runner_container) { should eq(Sipity::Runners::WorkRunners) }
-        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkAreaHandler) }
+        its(:runner_container) { should eq(Sipity::Runners::WorkSubmissionsRunners) }
+        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkSubmissionHandler) }
       end
 
       context 'GET #query_action' do

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module Sipity
+  module Controllers
+    RSpec.describe WorkSubmissionsController, type: :controller do
+      let(:work) { Models::Work.new(id: 'abc') }
+      let(:status) { :success }
+      # REVIEW: It is possible the runner will return a well formed object
+      let(:runner) { double('Runner', run: [status, work]) }
+
+      context 'configuration' do
+        its(:runner_container) { should eq(Sipity::Runners::WorkRunners) }
+        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkAreaHandler) }
+      end
+
+      context 'GET #query_action' do
+        before { controller.runner = runner }
+        let(:query_action_name) { 'fun_things' }
+        it 'will pass along to the response handler' do
+          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
+
+          # I don't want to mess around with all the possible actions
+          expect do
+            get 'query_action', work_id: work.id, query_action_name: query_action_name, work: { title: 'Hello' }
+          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/work_submissions/#{query_action_name}})
+
+          expect(runner).to have_received(:run).with(
+            described_class,
+            work_id: work.id, processing_action_name: query_action_name, attributes: { 'title' => 'Hello' }
+          )
+
+          expect(controller.view_object).to be_present
+        end
+      end
+
+      context 'POST #command_action' do
+        before { controller.runner = runner }
+        let(:command_action_name) { 'fun_things' }
+        it 'will pass along to the response handler' do
+          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
+
+          # I don't want to mess around with all the possible actions
+          expect do
+            post 'command_action', work_id: work.id, command_action_name: command_action_name, work: { title: 'Hello' }
+          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/work_submissions/#{command_action_name}})
+
+          expect(runner).to have_received(:run).with(
+            described_class,
+            work_id: work.id, processing_action_name: command_action_name, attributes: { 'title' => 'Hello' }
+          )
+
+          expect(controller.view_object).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -22,7 +22,7 @@ module Sipity
           # I don't want to mess around with all the possible actions
           expect do
             get 'query_action', work_id: work.id, query_action_name: query_action_name, work: { title: 'Hello' }
-          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/work_submissions/#{query_action_name}})
+          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/works/#{query_action_name}})
 
           expect(runner).to have_received(:run).with(
             described_class,
@@ -30,6 +30,7 @@ module Sipity
           )
 
           expect(controller.view_object).to be_present
+          expect(controller.model).to eq(controller.view_object)
         end
       end
 
@@ -42,7 +43,7 @@ module Sipity
           # I don't want to mess around with all the possible actions
           expect do
             post 'command_action', work_id: work.id, command_action_name: command_action_name, work: { title: 'Hello' }
-          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/work_submissions/#{command_action_name}})
+          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/works/#{command_action_name}})
 
           expect(runner).to have_received(:run).with(
             described_class,
@@ -50,6 +51,7 @@ module Sipity
           )
 
           expect(controller.view_object).to be_present
+          expect(controller.model).to eq(controller.view_object)
         end
       end
     end

--- a/spec/forms/sipity/forms/core/submission_windows/show_form_spec.rb
+++ b/spec/forms/sipity/forms/core/submission_windows/show_form_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'sipity/forms/core/submission_windows/show_form'
+
+module Sipity
+  module Forms
+    module Core
+      module SubmissionWindows
+        RSpec.describe ShowForm do
+          let(:processing_action_name) { 'show' }
+          let(:submission_window) { double }
+          subject { described_class.new(submission_window: submission_window, processing_action_name: processing_action_name) }
+
+          its(:policy_enforcer) { should eq Sipity::Policies::SubmissionWindowPolicy }
+          its(:processing_action_name) { should eq processing_action_name }
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/core/work_areas/show_form_spec.rb
+++ b/spec/forms/sipity/forms/core/work_areas/show_form_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'sipity/forms/core/work_areas/show_form'
+
+module Sipity
+  module Forms
+    module Core
+      module WorkAreas
+        RSpec.describe ShowForm do
+          let(:processing_action_name) { 'show' }
+          let(:work_area) { double }
+          subject { described_class.new(work_area: work_area, processing_action_name: processing_action_name) }
+
+          its(:policy_enforcer) { should eq Sipity::Policies::WorkAreaPolicy }
+          its(:processing_action_name) { should eq processing_action_name }
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/core/work_submissions/show_form_spec.rb
+++ b/spec/forms/sipity/forms/core/work_submissions/show_form_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'sipity/forms/core/work_submissions/show_form'
+
+module Sipity
+  module Forms
+    module Core
+      module WorkSubmissions
+        RSpec.describe ShowForm do
+          let(:processing_action_name) { 'show' }
+          let(:work) { double }
+          subject { described_class.new(work: work, processing_action_name: processing_action_name) }
+
+          its(:policy_enforcer) { should eq Sipity::Policies::WorkPolicy }
+          its(:processing_action_name) { should eq processing_action_name }
+          it { should be_decorated }
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/submission_window_forms_spec.rb
+++ b/spec/forms/sipity/forms/submission_window_forms_spec.rb
@@ -4,19 +4,17 @@ module Sipity
   module Forms
     RSpec.describe SubmissionWindowForms do
       before do
-        module SubmissionWindowForms
-          module MockEtd
-            module SubmissionWindows
-              class DoFunThingForm
-                def initialize(**_keywords)
-                end
+        module MockEtd
+          module SubmissionWindows
+            class DoFunThingForm
+              def initialize(**_keywords)
               end
             end
           end
         end
       end
       after do
-        SubmissionWindowForms.send(:remove_const, :MockEtd)
+        Forms.send(:remove_const, :MockEtd)
       end
 
       context '#build_the_form' do
@@ -28,7 +26,7 @@ module Sipity
             described_class.build_the_form(
               submission_window: submission_window, processing_action_name: processing_action_name, attributes: {}
             )
-          ).to be_a(SubmissionWindowForms::MockEtd::SubmissionWindows::DoFunThingForm)
+          ).to be_a(Forms::MockEtd::SubmissionWindows::DoFunThingForm)
         end
       end
     end

--- a/spec/forms/sipity/forms/submission_window_forms_spec.rb
+++ b/spec/forms/sipity/forms/submission_window_forms_spec.rb
@@ -12,9 +12,18 @@ module Sipity
             end
           end
         end
+        module Core
+          module SubmissionWindows
+            class FallbackForm
+              def initialize(**_keywords)
+              end
+            end
+          end
+        end
       end
       after do
         Forms.send(:remove_const, :MockEtd)
+        Forms.send(:remove_const, :Core)
       end
 
       context '#build_the_form' do
@@ -27,6 +36,20 @@ module Sipity
               submission_window: submission_window, processing_action_name: processing_action_name, attributes: {}
             )
           ).to be_a(Forms::MockEtd::SubmissionWindows::DoFunThingForm)
+        end
+
+        it 'will fall back to the core namespace' do
+          expect(
+            described_class.build_the_form(
+              submission_window: submission_window, processing_action_name: 'fallback', attributes: {}
+            )
+          ).to be_a(Forms::Core::SubmissionWindows::FallbackForm)
+        end
+
+        it 'will raise an exception if neither is found' do
+          expect do
+            described_class.build_the_form(submission_window: submission_window, processing_action_name: 'missing', attributes: {})
+          end.to raise_error(NameError)
         end
       end
     end

--- a/spec/forms/sipity/forms/submission_window_forms_spec.rb
+++ b/spec/forms/sipity/forms/submission_window_forms_spec.rb
@@ -23,7 +23,8 @@ module Sipity
       end
       after do
         Forms.send(:remove_const, :MockEtd)
-        Forms.send(:remove_const, :Core)
+        # Because autoload doesn't like me removing "live" modules
+        Forms::Core::SubmissionWindows.send(:remove_const, :FallbackForm)
       end
 
       context '#build_the_form' do

--- a/spec/forms/sipity/forms/work_area_forms_spec.rb
+++ b/spec/forms/sipity/forms/work_area_forms_spec.rb
@@ -23,7 +23,8 @@ module Sipity
       end
       after do
         Forms.send(:remove_const, :MockEtd)
-        Forms.send(:remove_const, :Core)
+        # Because autoload doesn't like me removing "live" modules
+        Forms::Core::WorkAreas.send(:remove_const, :FallbackForm)
       end
 
       context '#build_the_form' do

--- a/spec/forms/sipity/forms/work_area_forms_spec.rb
+++ b/spec/forms/sipity/forms/work_area_forms_spec.rb
@@ -12,9 +12,18 @@ module Sipity
             end
           end
         end
+        module Core
+          module WorkAreas
+            class FallbackForm
+              def initialize(**_keywords)
+              end
+            end
+          end
+        end
       end
       after do
         Forms.send(:remove_const, :MockEtd)
+        Forms.send(:remove_const, :Core)
       end
 
       context '#build_the_form' do
@@ -23,6 +32,16 @@ module Sipity
         it 'will use the work area and action name to find the correct object' do
           expect(described_class.build_the_form(work_area: work_area, processing_action_name: processing_action_name, attributes: {})).
             to be_a(Forms::MockEtd::WorkAreas::DoFunThingForm)
+        end
+
+        it 'will fall back to the core namespace' do
+          expect(described_class.build_the_form(work_area: work_area, processing_action_name: 'fallback', attributes: {})).
+            to be_a(Forms::Core::WorkAreas::FallbackForm)
+        end
+
+        it 'will raise an exception if neither is found' do
+          expect { described_class.build_the_form(work_area: work_area, processing_action_name: 'missing', attributes: {}) }.
+            to raise_error(NameError)
         end
       end
     end

--- a/spec/forms/sipity/forms/work_area_forms_spec.rb
+++ b/spec/forms/sipity/forms/work_area_forms_spec.rb
@@ -4,8 +4,8 @@ module Sipity
   module Forms
     RSpec.describe WorkAreaForms do
       before do
-        module WorkAreaForms
-          module MockEtd
+        module MockEtd
+          module WorkAreas
             class DoFunThingForm
               def initialize(**_keywords)
               end
@@ -14,7 +14,7 @@ module Sipity
         end
       end
       after do
-        WorkAreaForms.send(:remove_const, :MockEtd)
+        Forms.send(:remove_const, :MockEtd)
       end
 
       context '#build_the_form' do
@@ -22,7 +22,7 @@ module Sipity
         let(:processing_action_name) { 'do_fun_thing' }
         it 'will use the work area and action name to find the correct object' do
           expect(described_class.build_the_form(work_area: work_area, processing_action_name: processing_action_name, attributes: {})).
-            to be_a(WorkAreaForms::MockEtd::DoFunThingForm)
+            to be_a(Forms::MockEtd::WorkAreas::DoFunThingForm)
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submission_forms_spec.rb
+++ b/spec/forms/sipity/forms/work_submission_forms_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+module Sipity
+  module Forms
+    RSpec.describe WorkSubmissionForms do
+      before do
+        module MockEtd
+          module WorkSubmissions
+            class DoFunThingForm
+              def initialize(**_keywords)
+              end
+            end
+          end
+        end
+        module Core
+          module WorkSubmissions
+            class FallbackForm
+              def initialize(**_keywords)
+              end
+            end
+          end
+        end
+      end
+      after do
+        Forms.send(:remove_const, :MockEtd)
+        # Because autoload doesn't like me removing "live" modules
+        Forms::Core::WorkSubmissions.send(:remove_const, :FallbackForm)
+      end
+
+      context '#build_the_form' do
+        let(:work_area) { Models::WorkArea.new(demodulized_class_prefix_name: 'MockEtd') }
+        let(:work) { Models::Work.new }
+        let(:processing_action_name) { 'do_fun_thing' }
+        before { expect(work).to receive(:work_area).and_return(work_area) }
+        it 'will use the work area and action name to find the correct object' do
+          expect(
+            described_class.build_the_form(
+              work: work, processing_action_name: processing_action_name, attributes: {}
+            )
+          ).to be_a(Forms::MockEtd::WorkSubmissions::DoFunThingForm)
+        end
+
+        it 'will fall back to the core namespace' do
+          expect(
+            described_class.build_the_form(
+              work: work, processing_action_name: 'fallback', attributes: {}
+            )
+          ).to be_a(Forms::Core::WorkSubmissions::FallbackForm)
+        end
+
+        it 'will raise an exception if neither is found' do
+          expect do
+            described_class.build_the_form(work: work, processing_action_name: 'missing', attributes: {})
+          end.to raise_error(NameError)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/sipity/models/notification_spec.rb
+++ b/spec/models/sipity/models/notification_spec.rb
@@ -1,3 +1,6 @@
+require 'spec_helper'
+require 'sipity/models/notification'
+
 module Sipity
   module Models
     RSpec.describe Notification do

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity'
 
 RSpec.describe Sipity do
   subject { described_class }

--- a/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
@@ -13,6 +13,7 @@ module Sipity
 
       its(:path) { should eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}") }
       its(:link) { should eq(%(<a href="#{subject.path}">the-slug</a>)) }
+      its(:slug) { should eq(submission_window.slug) }
 
       it 'will compose actions for the submission window' do
         expect(ComposableElements::ProcessingActionsComposer).to receive(:new).with(user: current_user, entity: submission_window)

--- a/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
@@ -4,10 +4,11 @@ module Sipity
   module Controllers
     module SubmissionWindows
       RSpec.describe ShowPresenter do
-        let(:context) { PresenterHelper::Context.new(current_user: current_user, action_name: 'show', render: true) }
+        let(:context) { PresenterHelper::Context.new(current_user: current_user, render: true) }
         let(:current_user) { double('Current User') }
-        let(:submission_window) { Models::SubmissionWindow.new(slug: 'the-slug', work_area: work_area) }
-        let(:work_area) { Models::WorkArea.new(slug: 'work-area', partial_suffix: 'work_area') }
+        let(:submission_window) do
+          double(slug: 'the-slug', work_area_slug: 'another', work_area_partial_suffix: 'work_area', processing_action_name: 'hello')
+        end
         subject { described_class.new(context, submission_window: submission_window) }
         it { should be_a SubmissionWindowPresenter }
 
@@ -15,14 +16,16 @@ module Sipity
           context 'for a ULRA' do
             it 'will render the partial for ulra' do
               expect(context).to receive(:render).
-                with(partial: "#{context.action_name}_#{submission_window.work_area_partial_suffix}", object: subject)
+                with(partial: "#{submission_window.processing_action_name}_#{submission_window.work_area_partial_suffix}", object: subject)
               subject.render_submission_window
             end
           end
           context 'for an ETD' do
             let(:controller) { double('Controller') }
             let(:context) { PresenterHelper::Context.new(current_user: current_user, controller: controller) }
-            let(:work_area) { Models::WorkArea.new(slug: 'etd', partial_suffix: 'etd') }
+            let(:submission_window) do
+              double(slug: 'the-slug', work_area_slug: 'etd', work_area_partial_suffix: 'etd', processing_action_name: 'hello')
+            end
             let(:etd_form) { double }
             let(:decorated_form) { double }
 

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -21,6 +21,25 @@ module Sipity
         end
       end
 
+      context '#find_work_by' do
+        it 'raises an exception if nothing is found' do
+          expect { test_repository.find_work_by(id: '8675309') }.to raise_error
+        end
+        it 'returns the Work when the object is found' do
+          work = Models::Work.create!(id: '8675309', title: "Hello")
+          expect(test_repository.find_work_by(id: '8675309')).to eq(work)
+        end
+      end
+
+      context '#build_work_submission_processing_action_form' do
+        let(:parameters) { { work: double, processing_action_name: double, attributes: double } }
+        let(:form) { double }
+        it 'will delegate the heavy lifting to a builder' do
+          expect(Forms::WorkSubmissionForms).to receive(:build_the_form).with(parameters).and_return(form)
+          expect(test_repository.build_work_submission_processing_action_form(parameters)).to eq(form)
+        end
+      end
+
       context '#work_access_right_codes' do
         let(:work) { Models::Work.new(title: 'Hello World', id: '123') }
         it 'will expose access_right_code of the underlying work' do

--- a/spec/routing/work_area_routing_spec.rb
+++ b/spec/routing/work_area_routing_spec.rb
@@ -6,7 +6,7 @@ describe 'work area routing spec' do
     [
       [
         :get,
-        { path: "/areas/my_slug", action: 'show', work_area_slug: 'my_slug' }
+        { path: "/areas/my_slug", action: 'query_action', work_area_slug: 'my_slug', query_action_name: 'show' }
       ], [
         :get,
         { path: "/areas/my_slug/do/fun_things", action: 'query_action', work_area_slug: 'my_slug', query_action_name: 'fun_things' }

--- a/spec/routing/work_submission_routing_spec.rb
+++ b/spec/routing/work_submission_routing_spec.rb
@@ -1,60 +1,54 @@
 require 'spec_helper'
 
 describe 'work area routing spec' do
-  context 'sipity/controllers/submission_windows' do
-    let(:controller) { 'sipity/controllers/submission_windows' }
+  context 'sipity/controllers/work_submissions' do
+    let(:controller) { 'sipity/controllers/work_submissions' }
     [
       [
         :get,
         {
-          path: "/areas/area-slug/start",
+          path: "/work_submissions/1234",
+          work_id: '1234',
           action: 'query_action',
-          work_area_slug: 'area-slug',
-          submission_window_slug: 'start',
           query_action_name: 'show'
         }
       ], [
         :get,
         {
-          path: "/areas/area-slug/start/do/edit",
-          work_area_slug: 'area-slug',
-          submission_window_slug: 'start',
+          path: "/work_submissions/1234/do/edit",
+          work_id: '1234',
           action: 'query_action',
           query_action_name: 'edit'
         }
       ], [
         :post,
         {
-          path: "/areas/area-slug/start/do/edit",
-          work_area_slug: 'area-slug',
-          submission_window_slug: 'start',
+          path: "/work_submissions/1234/do/edit",
+          work_id: '1234',
           action: 'command_action',
           command_action_name: 'edit'
         }
       ], [
         :patch,
         {
-          path: "/areas/area-slug/start/do/edit",
-          work_area_slug: 'area-slug',
-          submission_window_slug: 'start',
+          path: "/work_submissions/1234/do/edit",
+          work_id: '1234',
           action: 'command_action',
           command_action_name: 'edit'
         }
       ], [
         :put,
         {
-          path: "/areas/area-slug/start/do/edit",
-          work_area_slug: 'area-slug',
-          submission_window_slug: 'start',
+          path: "/work_submissions/1234/do/edit",
+          work_id: '1234',
           action: 'command_action',
           command_action_name: 'edit'
         }
       ], [
         :delete,
         {
-          path: "/areas/area-slug/start/do/edit",
-          work_area_slug: 'area-slug',
-          submission_window_slug: 'start',
+          path: "/work_submissions/1234/do/edit",
+          work_id: '1234',
           action: 'command_action',
           command_action_name: 'edit'
         }

--- a/spec/runners/sipity/runners/submission_window_runners_spec.rb
+++ b/spec/runners/sipity/runners/submission_window_runners_spec.rb
@@ -5,35 +5,6 @@ module Sipity
   module Runners
     module SubmissionWindowRunners
       include RunnersSupport
-      RSpec.describe Show do
-        let(:submission_window) { double('Submission Window') }
-        let(:user) { double('User') }
-        let(:context) { TestRunnerContext.new(find_submission_window_by: submission_window, current_user: user) }
-        let(:handler) { double(invoked: true) }
-
-        subject do
-          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
-            on.success { |a| handler.invoked("SUCCESS", a) }
-          end
-        end
-
-        its(:action_name) { should eq(:show?) }
-
-        it 'will require authentication by default' do
-          expect(described_class.authentication_layer).to eq(:default)
-        end
-
-        it 'enforces authorization' do
-          expect(described_class.authorization_layer).to eq(:default)
-        end
-
-        it 'issues the :success callback' do
-          response = subject.run(work_area_slug: 'a_work_area', submission_window_slug: 'a_submission_window')
-          expect(handler).to have_received(:invoked).with("SUCCESS", submission_window)
-          expect(response).to eq([:success, submission_window])
-        end
-      end
-
       RSpec.describe QueryAction do
         let(:submission_window) { double('Submission Window') }
         let(:form) { double('Form') }

--- a/spec/runners/sipity/runners/work_area_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_area_runners_spec.rb
@@ -5,34 +5,6 @@ module Sipity
   module Runners
     module WorkAreaRunners
       include RunnersSupport
-      RSpec.describe Show do
-        let(:work_area) { double('Work Area') }
-        let(:user) { double('User') }
-        let(:context) { TestRunnerContext.new(find_work_area_by: work_area, current_user: user) }
-        let(:handler) { double(invoked: true) }
-
-        subject do
-          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
-            on.success { |a| handler.invoked("SUCCESS", a) }
-          end
-        end
-
-        its(:action_name) { should eq(:show?) }
-
-        it 'will require authentication by default' do
-          expect(described_class.authentication_layer).to eq(:default)
-        end
-
-        it 'enforces authorization' do
-          expect(described_class.authorization_layer).to eq(:default)
-        end
-
-        it 'issues the :success callback' do
-          response = subject.run(work_area_slug: 'a_work_area')
-          expect(handler).to have_received(:invoked).with("SUCCESS", work_area)
-          expect(response).to eq([:success, work_area])
-        end
-      end
 
       RSpec.describe QueryAction do
         let(:work_area) { double('Work Area') }

--- a/spec/runners/sipity/runners/work_submissions_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_submissions_runners_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'sipity/runners/work_submissions_runners'
+
+module Sipity
+  module Runners
+    module WorkSubmissionsRunners
+      include RunnersSupport
+
+      RSpec.describe QueryAction do
+        let(:work) { double('Work', id: 1) }
+        let(:user) { double('User') }
+        let(:form) { double('Form') }
+        let(:processing_action_name) { 'fun_things' }
+        let(:context) do
+          TestRunnerContext.new(find_work_by: work, current_user: user, build_work_submission_processing_action_form: form)
+        end
+        let(:handler) { double(invoked: true) }
+
+        subject do
+          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
+            on.success { |a| handler.invoked("SUCCESS", a) }
+          end
+        end
+
+        it 'will require authentication by default' do
+          expect(described_class.authentication_layer).to eq(:default)
+        end
+
+        it 'enforces authorization' do
+          expect(described_class.authorization_layer).to eq(:default)
+        end
+
+        it 'issues the :success callback' do
+          response = subject.run(work_id: work.id, processing_action_name: processing_action_name, attributes: double)
+          expect(handler).to have_received(:invoked).with("SUCCESS", form)
+          expect(response).to eq([:success, form])
+        end
+      end
+
+      RSpec.describe CommandAction do
+        let(:work) { double('Work', id: 1) }
+        let(:user) { double('User') }
+        let(:form) { double('Form') }
+        let(:processing_action_name) { 'fun_things' }
+        let(:context) do
+          TestRunnerContext.new(find_work_by: work, current_user: user, build_work_submission_processing_action_form: form)
+        end
+        let(:handler) { double(invoked: true) }
+
+        subject do
+          described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
+            on.success { |a| handler.invoked("SUCCESS", a) }
+            on.failure { |a| handler.invoked("FAILURE", a) }
+          end
+        end
+
+        it 'will require authentication by default' do
+          expect(described_class.authentication_layer).to eq(:default)
+        end
+
+        it 'enforces authorization' do
+          expect(described_class.authorization_layer).to eq(:default)
+        end
+
+        it 'issues the :success callback when form is submitted' do
+          expect(form).to receive(:submit).with(requested_by: user).and_return(true)
+          response = subject.run(work_id: work.id, processing_action_name: processing_action_name, attributes: double)
+          expect(handler).to have_received(:invoked).with("SUCCESS", work)
+          expect(response).to eq([:success, work])
+        end
+
+        it 'issues the :failure callback when form fails to submit' do
+          expect(form).to receive(:submit).with(requested_by: user).and_return(false)
+          response = subject.run(work_id: work.id, processing_action_name: processing_action_name, attributes: double)
+          expect(handler).to have_received(:invoked).with("FAILURE", form)
+          expect(response).to eq([:failure, form])
+        end
+      end
+    end
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -65,6 +65,10 @@ module Sipity
     def build_work_area_processing_action_form(work_area:, processing_action_name:, attributes: {})
     end
 
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {})
+    end
+
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def change_processing_actor_proxy(from_proxy:, to_proxy:)
     end
@@ -151,6 +155,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/queries/work_area_queries.rb
     def find_work_area_by(slug:)
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def find_work_by(id:)
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -49,6 +49,10 @@ module Sipity
     def build_work_area_processing_action_form(work_area:, processing_action_name:, attributes: {})
     end
 
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {})
+    end
+
     # @see ./app/repositories/sipity/queries/collaborator_queries.rb
     def collaborators_that_can_advance_the_current_state_of(work:, id: nil)
     end
@@ -87,6 +91,10 @@ module Sipity
 
     # @see ./app/repositories/sipity/queries/work_area_queries.rb
     def find_work_area_by(slug:)
+    end
+
+    # @see ./app/repositories/sipity/queries/work_queries.rb
+    def find_work_by(id:)
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb


### PR DESCRIPTION
## Adding the container modules

@9ec4460d68d22ea5f1a26e5b31ba1d7c5887506b

As I begin working on modularizing the application, I'm wanting to
have a place to put these concepts.

* Sipity::Forms::Ulra
* Sipity::Forms::Ulra::SubmissionWindows

## Altering lookup path for forms

@0c89420d5132ff1a4a51565a32bcdbf448e81e08

* SubmissionWindows
* WorkAreas

Thinking about the "sort order" of modules, I believe it makes more
sense to expose `Sipity::Forms::Ulra::Concepts` instead of
`Sipity::Forms::Concepts::Ulra`.

The form naming convention is something that can also be further
teased apart in the future; However predictability in where things are
at is important at this point.

## Exposing :slug

@cd7ef8987aca734b3f89eb094faadd0265dc99c5

This is proving to be helpful in the testing of the templates.

## Updating routing to remove show action

@80368e78c66bac7f4f1726a29e3c1f25b5371cad

Attempting to demote the "show" action from its privileged status to
a more normalized status concerning the processing actions.

## Normalizing build_the_form behavior

@6968d6385b5a9731a0c6de689a3241dbc9c8b388

Instead of requiring an exact match, concede that there could be
a viable fallback.

## Adding core show forms

@71ecd59c134c6231d6c8f01d734ead79e1db513b

In working on these, they behave very similar to other forms; They
just don't come with the typical "form" behavior. These are also the
"core" components in that they can be used as a fallback.

## Normalzing WorkAreaRunners

@b3fa411a6efefa4f56a1eb5b8cea92ce23c838d0


## Removing the :show action

@e745b3dcd00cac94efb776de1ac12f88fb79965c

Why should I privilege the show action compared to the "fun_things"
action?

## Removing SubmissionWindowRunners#Show

@09e605d5bb73a4bffc202c20e6d9e7b54086fea4

This is no longer needed, and instead cleaves closer to the query/
command separation.

## Adding require to cope with auto-load

@a19b1940a63ba5f345bb5760e88bcd198d188389


## Adding missing requires

@fc50edf20ac0895d9a256e1a188eef308569e0d0

These are in place to make sure that the specs are referencing the
right file.

Rails magic is dark and wicked sometimes.

## Correcting the constant cleanup

@4ce0cc820db515e32d7670cd157214f245a051dd

As the comment says:

> Because autoload doesn't like me removing "live" modules

## Reworking SubmissionWindows::ShowPresenter

@a6b18ad595663f6d8ef69ec0b25d9809d07e8a2c

Assuming that there will be a ShowForm

## Adding a WorkSubmissionController

@e79c62efc8ab381eab151c67b7d19a5fea7cba24

This is a preliminary commit loaded with stop gap solutions.

## Deprecating find_work in favor of find_work_by

@e0ce1ac739a09c81aae8c14886bdeab320b7c498

I'd prefer to leverage named variables instead of placing a preference
on parameter order.

## Adding Forms::WorkSubmissionForms container

@5f5917e8b8c1a2bfb762ef0b63a0e1dd60afd603

An analogue to the Forms::WorkAreaForms container.

## Privatizing constants

@9ed524a919807a1d964b16d513578adc4ef3c225

I don't want those constants used outside of any other context.

## Adding WorkSubmissionsRunners

@1013164366389c6135e29f920c8834634d47d50b

Analogous to WorkAreaRunners

## Adding response handler

@f9c5bf62b88f1b1e51b3ddf5081d93c542a7fdb4


## Finalizing WorkSubmissions Controller

@f5054705d5afe1488525fa8628bcd27bb071c45d


## Required changes to render a work's show page

@a06085904f7d735d41a87e31c615c897e99d1a0d

The eventual goal is to be able to duplicate the Work behavior within
the WorkSubmission, then remove the old Work behavior and rename
WorkSubmission as Work.

In this way we can preserve the user facing interface as I build
towards completion.
