### PR TITLE
Working through response handler

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -15,6 +15,13 @@ module Sipity
     class NonPrimativeParameterError < RuntimeError
     end
 
+    # Uh oh! It looks like our response handler didn't know what to do.
+    class UnhandledResponseError < RuntimeError
+      def initialize(handler)
+        super("Expected to be able to handle #{handler.inspect}.")
+      end
+    end
+
     # This is not a defined resourceful action
     class UnprocessableResourcefulActionNameError < RuntimeError
       def initialize(container:, object:)

--- a/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
@@ -3,17 +3,39 @@ module Sipity
     # This is an Experimental module and concept
     module SubmissionWindowHandler
       # Responsible for handling a :success-ful action
-      #
-      # TODO: Extract a proper base class, if one exists
-      #
-      # :Success
-      # :Submitted
-      # :FailedToSubmit
       class SuccessResponse < ResponseHandlers::WorkAreaHandler::SuccessResponse
       end
 
-      # TODO: This should do something
-      class FailureResponse < SuccessResponse
+      # Forms that are submitted have a different success handling.
+      class SubmitSuccessResponse < SuccessResponse
+        # TODO: Need to Guard these methods
+        delegate :redirect_to, :work_submission_path, :submission_window_path, to: :context
+        delegate :object, to: :handled_response, prefix: :response
+
+        def respond
+          case response_object
+          when Models::SubmissionWindow
+            respond_for_submission_window
+          when Models::Work
+            redirect_to work_submission_path(work_id: response_object.id)
+          else
+            # Fallback to converting to a submission window.
+            submission_window = PowerConverter.convert(response_object, to: :submission_window)
+            respond_for_submission_window(submission_window: submission_window)
+          end
+        end
+
+        private
+
+        def respond_for_submission_window(submission_window: response_object)
+          redirect_to(
+            submission_window_path(work_area_slug: submission_window.work_area_slug, submission_window_slug: submission_window.slug)
+          )
+        end
+      end
+
+      # Forms that fail to submit may have different errors.
+      class SubmitFailureResponse < SuccessResponse
       end
     end
   end

--- a/app/runners/sipity/runners/submission_window_runners.rb
+++ b/app/runners/sipity/runners/submission_window_runners.rb
@@ -13,7 +13,7 @@ module Sipity
             submission_window: submission_window, processing_action_name: processing_action_name, attributes: attributes
           )
           authorization_layer.enforce!(processing_action_name => form) do
-            yield(form, submission_window)
+            yield(form)
           end
         end
       end
@@ -23,7 +23,7 @@ module Sipity
       # case).
       class QueryAction < CommandQueryAction
         def run(**keywords)
-          super do |form, _submission_window|
+          super do |form|
             callback(:success, form)
           end
         end
@@ -33,7 +33,7 @@ module Sipity
       # case).
       class CommandAction < CommandQueryAction
         def run(**keywords)
-          super do |form, submission_window|
+          super do |form|
             returned_object = form.submit(requested_by: current_user)
             if returned_object
               callback(:submit_success, returned_object)

--- a/app/runners/sipity/runners/submission_window_runners.rb
+++ b/app/runners/sipity/runners/submission_window_runners.rb
@@ -34,10 +34,11 @@ module Sipity
       class CommandAction < CommandQueryAction
         def run(**keywords)
           super do |form, submission_window|
-            if form.submit(requested_by: current_user)
-              callback(:success, submission_window)
+            returned_object = form.submit(requested_by: current_user)
+            if returned_object
+              callback(:submit_success, returned_object)
             else
-              callback(:failure, form)
+              callback(:submit_failure, form)
             end
           end
         end

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -24,6 +24,11 @@ module Sipity
       its(:message) { should be_a(String) }
     end
 
+    RSpec.describe UnhandledResponseError do
+      subject { described_class.new('hello') }
+      its(:message) { should be_a(String) }
+    end
+
     RSpec.describe InterfaceExpectationError do
       subject { described_class.new(object: 'hello', expectation: :fly) }
       its(:message) { should be_a(String) }

--- a/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+require 'sipity/response_handlers/submission_window_handler'
+
+module Sipity
+  module ResponseHandlers
+    module SubmissionWindowHandler
+      RSpec.describe SuccessResponse do
+        let(:context) { double(render: 'rendered', :view_object= => true) }
+        let(:viewable_object) { double }
+        let(:handled_response) { double(object: viewable_object) }
+        subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
+        it 'will #respond by rendering the context' do
+          expect(subject.respond).to eq(context.render)
+        end
+
+        it 'will .respond by rendering the context' do
+          expect(described_class.respond(context: context, handled_response: handled_response, template: 'show')).to eq(context.render)
+          expect(context).to have_received(:render).with(template: 'show')
+        end
+
+        context 'collaborating objects expected interface' do
+          it '#context must implement #view_object=' do
+            expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
+              to raise_error(Exceptions::InterfaceExpectationError)
+          end
+          it '#context must implement #render' do
+            expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
+              to raise_error(Exceptions::InterfaceExpectationError)
+          end
+          it '#handled_response must implement #object' do
+            expect { described_class.new(context: context, handled_response: double, template: 'show') }.
+              to raise_error(Exceptions::InterfaceExpectationError)
+          end
+        end
+      end
+
+      RSpec.describe SubmitSuccessResponse do
+        let(:submission_window) { Models::SubmissionWindow.new(slug: 'a_slug', work_area: work_area) }
+        let(:viewable_object) { submission_window }
+        let(:work_area) { Models::WorkArea.new(slug: 'area_slug') }
+        let(:context) { double(render: :rendered, redirect_to: :redirected_to, :view_object= => true) }
+        let(:handled_response) { double(object: viewable_object) }
+        subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
+
+        it 'will .respond by delegating to an instance' do
+          expect_any_instance_of(described_class).to receive(:respond)
+          described_class.respond(context: context, handled_response: handled_response, template: 'show')
+        end
+
+        context 'for a SubmissionWindow' do
+          it "will #respond by redirecting to the submission window's path" do
+            path = '/path/to/submission_window'
+            expect(context).to receive(:submission_window_path).
+              with(work_area_slug: work_area.slug, submission_window_slug: submission_window.slug).
+              and_return(path)
+            expect(context).to receive(:redirect_to).with(path)
+            subject.respond
+          end
+        end
+
+        context 'for a Work' do
+          let(:viewable_object) { Models::Work.new(id: 'an_id') }
+
+          it "will #respond by redirecting to the submission window's path" do
+            path = '/path/to/work'
+            expect(context).to receive(:work_submission_path).with(work_id: viewable_object.id).and_return(path)
+            expect(context).to receive(:redirect_to).with(path)
+            subject.respond
+          end
+        end
+
+        context 'for something that can be converted to a submission window' do
+          let(:viewable_object) { double(to_submission_window: submission_window) }
+          it "will attempt to convert the object" do
+            path = '/path/to/submission_window'
+            expect(context).to receive(:submission_window_path).
+              with(work_area_slug: work_area.slug, submission_window_slug: submission_window.slug).
+              and_return(path)
+            expect(context).to receive(:redirect_to).with(path)
+            subject.respond
+          end
+        end
+
+        context 'for something else' do
+          let(:viewable_object) { double }
+          it "will attempt to convert the object" do
+            expect(PowerConverter).to receive(:convert).with(viewable_object, to: :submission_window).and_call_original
+            expect { subject.respond }.to raise_error(PowerConverter::ConversionError)
+          end
+        end
+
+        context 'collaborating objects expected interface' do
+          it '#context must implement #view_object=' do
+            expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
+              to raise_error(Exceptions::InterfaceExpectationError)
+          end
+          it '#context must implement #render' do
+            expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
+              to raise_error(Exceptions::InterfaceExpectationError)
+          end
+          it '#handled_response must implement #object' do
+            expect { described_class.new(context: context, handled_response: double, template: 'show') }.
+              to raise_error(Exceptions::InterfaceExpectationError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/runners/sipity/runners/submission_window_runners_spec.rb
+++ b/spec/runners/sipity/runners/submission_window_runners_spec.rb
@@ -56,8 +56,8 @@ module Sipity
 
         subject do
           described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|
-            on.success { |a| handler.invoked("SUCCESS", a) }
-            on.failure { |a| handler.invoked("FAILURE", a) }
+            on.submit_success { |a| handler.invoked("SUCCESS", a) }
+            on.submit_failure { |a| handler.invoked("FAILURE", a) }
           end
         end
 
@@ -69,22 +69,22 @@ module Sipity
           expect(described_class.authorization_layer).to eq(:default)
         end
 
-        it 'issues the :success callback when form is submitted' do
-          expect(form).to receive(:submit).with(requested_by: user).and_return(true)
+        it 'issues the :submit_success callback when form is submitted' do
+          expect(form).to receive(:submit).with(requested_by: user).and_return(submission_window)
           response = subject.run(
             work_area_slug: 'a_work_area', submission_window_slug: 'a_submission_window', processing_action_name: 'a_funny'
           )
           expect(handler).to have_received(:invoked).with("SUCCESS", submission_window)
-          expect(response).to eq([:success, submission_window])
+          expect(response).to eq([:submit_success, submission_window])
         end
 
-        it 'issues the :failure callback when form fails to submit' do
+        it 'issues the :submit_failure callback when form fails to submit' do
           expect(form).to receive(:submit).with(requested_by: user).and_return(false)
           response = subject.run(
             work_area_slug: 'a_work_area', submission_window_slug: 'a_submission_window', processing_action_name: 'a_funny'
           )
           expect(handler).to have_received(:invoked).with("FAILURE", form)
-          expect(response).to eq([:failure, form])
+          expect(response).to eq([:submit_failure, form])
         end
       end
     end


### PR DESCRIPTION
## Reworking form object for better response handling

@6bee7778415e0dce366ebcec89e17409fd0f469d

Consider that I am submitting a form for a submission window to create
a work within that submission window:

* I would expect the returned object to be the work that I submitted
* I would expect to handle that form's response differently than an
  update to the submission window.

## Adding response handler error

@67ce71498334496f3c7343e0b6532a0465f0bfb7


## Adding response handlers for SubmissionWindow

@84846a12cde996d047effb340cc36603d8610554

Expanding on the current response handling
