### PR TITLE
Working through response handler

### DIFF
--- a/app/controllers/sipity/controllers/submission_windows_controller.rb
+++ b/app/controllers/sipity/controllers/submission_windows_controller.rb
@@ -18,7 +18,7 @@ module Sipity
 
         # I could use action instead of template, but I feel the explicit path
         # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/submission_windows/#{processing_action_name}")
+        handle_response(runner_response)
       end
 
       def command_action
@@ -31,7 +31,7 @@ module Sipity
 
         # I could use action instead of template, but I feel the explicit path
         # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/submission_windows/#{processing_action_name}")
+        handle_response(runner_response)
       end
 
       attr_accessor :view_object
@@ -55,20 +55,17 @@ module Sipity
         params.fetch(:submission_window) { HashWithIndifferentAccess.new }
       end
 
-      def handle_response(handled_response, template:  "sipity/controllers/submission_windows/#{action_name}")
-        Sipity::ResponseHandlers.handle_response(
-          context: self,
-          handled_response: handled_response,
-          container: response_handler_container,
-          template: template
-        )
+      def handle_response(handled_response)
+        Sipity::ResponseHandlers.handle_response(context: self, handled_response: handled_response, container: response_handler_container)
       end
 
       def run(*args)
         # TODO: This is an intermediary step that will be wrapped into the
         #   existing #run method; However it should be considered experimental
         status, object = super(*args)
-        Parameters::HandledResponseParameter.new(status: status, object: object)
+        Parameters::HandledResponseParameter.new(
+          status: status, object: object, template: "sipity/controllers/submission_windows/#{processing_action_name}"
+        )
       end
     end
   end

--- a/app/controllers/sipity/controllers/work_areas_controller.rb
+++ b/app/controllers/sipity/controllers/work_areas_controller.rb
@@ -14,10 +14,7 @@ module Sipity
           processing_action_name: processing_action_name,
           attributes: query_or_command_attributes
         )
-
-        # I could use action instead of template, but I feel the explicit path
-        # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/work_areas/#{processing_action_name}")
+        handle_response(runner_response)
       end
 
       def command_action
@@ -26,10 +23,7 @@ module Sipity
           processing_action_name: processing_action_name,
           attributes: query_or_command_attributes
         )
-
-        # I could use action instead of template, but I feel the explicit path
-        # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/work_areas/#{processing_action_name}")
+        handle_response(runner_response)
       end
 
       attr_accessor :view_object
@@ -49,12 +43,11 @@ module Sipity
         params.fetch(:work_area) { HashWithIndifferentAccess.new }
       end
 
-      def handle_response(handled_response, template:  "sipity/controllers/work_areas/#{action_name}")
+      def handle_response(handled_response)
         Sipity::ResponseHandlers.handle_response(
           context: self,
           handled_response: handled_response,
-          container: response_handler_container,
-          template: template
+          container: response_handler_container
         )
       end
 
@@ -62,7 +55,9 @@ module Sipity
         # TODO: This is an intermediary step that will be wrapped into the
         #   existing #run method; However it should be considered experimental
         status, object = super(*args)
-        Parameters::HandledResponseParameter.new(status: status, object: object)
+        Parameters::HandledResponseParameter.new(
+          status: status, object: object, template: "sipity/controllers/work_areas/#{processing_action_name}"
+        )
       end
     end
   end

--- a/app/controllers/sipity/controllers/work_submissions_controller.rb
+++ b/app/controllers/sipity/controllers/work_submissions_controller.rb
@@ -12,10 +12,7 @@ module Sipity
           processing_action_name: processing_action_name,
           attributes: query_or_command_attributes
         )
-
-        # I could use action instead of template, but I feel the explicit path
-        # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/works/#{processing_action_name}")
+        handle_response(runner_response)
       end
 
       def command_action
@@ -24,10 +21,7 @@ module Sipity
           processing_action_name: processing_action_name,
           attributes: query_or_command_attributes
         )
-
-        # I could use action instead of template, but I feel the explicit path
-        # for template is better than the implicit pathing of :action
-        handle_response(runner_response, template: "sipity/controllers/works/#{processing_action_name}")
+        handle_response(runner_response)
       end
 
       attr_accessor :view_object
@@ -49,12 +43,11 @@ module Sipity
         params.fetch(:work) { HashWithIndifferentAccess.new }
       end
 
-      def handle_response(handled_response, template:)
+      def handle_response(handled_response)
         Sipity::ResponseHandlers.handle_response(
           context: self,
           handled_response: handled_response,
-          container: response_handler_container,
-          template: template
+          container: response_handler_container
         )
       end
 
@@ -62,7 +55,9 @@ module Sipity
         # TODO: This is an intermediary step that will be wrapped into the
         #   existing #run method; However it should be considered experimental
         status, object = super(*args)
-        Parameters::HandledResponseParameter.new(status: status, object: object)
+        Parameters::HandledResponseParameter.new(
+          status: status, object: object, template: "sipity/controllers/work_submissions/#{processing_action_name}"
+        )
       end
     end
   end

--- a/app/parameters/sipity/parameters/handled_response_parameter.rb
+++ b/app/parameters/sipity/parameters/handled_response_parameter.rb
@@ -3,9 +3,10 @@ module Sipity
     # Responsible for defining the mapping interface between the Runners
     # and the ResponseHandlers.
     class HandledResponseParameter
-      def initialize(object:, status:)
+      def initialize(object:, status:, template:)
         self.object = object
         self.status = status
+        self.template = template
       end
 
       # @!attribute [r] object
@@ -23,9 +24,16 @@ module Sipity
       #   @return [Symbol]
       attr_reader :status
 
+      # @!attribute [r] template
+      #   The name of the template that we "may" render.
+      #   @return [Object]
+      #   @note I chose :template instead of :template_name as Rails convention
+      #     for rendering a named template is `render template: 'show'`
+      attr_reader :template
+
       private
 
-      attr_writer :object
+      attr_writer :object, :template
 
       def status=(input)
         fail Exceptions::InvalidHandledResponseStatus, input unless input.is_a?(Symbol)

--- a/app/response_handlers/sipity/response_handlers.rb
+++ b/app/response_handlers/sipity/response_handlers.rb
@@ -49,6 +49,24 @@ module Sipity
 
       private
 
+      PATH_METHOD_REGEXP = /_path\Z/.freeze
+
+      def method_missing(method_name, *args, **keywords, &block)
+        if method_name =~ PATH_METHOD_REGEXP
+          context.public_send(method_name, *args, **keywords, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        if method_name =~ PATH_METHOD_REGEXP
+          context.respond_to?(method_name, include_private)
+        else
+          super
+        end
+      end
+
       attr_accessor :responder
       attr_writer :template
 

--- a/app/response_handlers/sipity/response_handlers.rb
+++ b/app/response_handlers/sipity/response_handlers.rb
@@ -14,13 +14,14 @@ module Sipity
   module ResponseHandlers
     module_function
 
-    def handle_response(context:, handled_response:, container:, template:)
-      response_handler = build_response_handler(container: container, handled_response_status: handled_response.status)
-      response_handler.respond(context: context, handled_response: handled_response, template: template)
+    # TODO: Remove the template as it can be packed into the handled response
+    def handle_response(context:, handled_response:, container:, template:, handler: DefaultHandler)
+      responder = build_responder(container: container, handled_response_status: handled_response.status)
+      handler.respond(context: context, handled_response: handled_response, template: template, responder: responder)
     end
 
-    def build_response_handler(container:, handled_response_status:)
-      container.qualified_const_get("#{handled_response_status.to_s.classify}Response")
+    def build_responder(container:, handled_response_status:)
+      container.qualified_const_get("#{handled_response_status.to_s.classify}Responder")
     end
 
     # The default response handler. It makes sure things are well composed,

--- a/app/response_handlers/sipity/response_handlers.rb
+++ b/app/response_handlers/sipity/response_handlers.rb
@@ -15,9 +15,9 @@ module Sipity
     module_function
 
     # TODO: Remove the template as it can be packed into the handled response
-    def handle_response(context:, handled_response:, container:, template:, handler: DefaultHandler)
+    def handle_response(context:, handled_response:, container:, handler: DefaultHandler)
       responder = build_responder(container: container, handled_response_status: handled_response.status)
-      handler.respond(context: context, handled_response: handled_response, template: template, responder: responder)
+      handler.respond(context: context, handled_response: handled_response, responder: responder)
     end
 
     def build_responder(container:, handled_response_status:)
@@ -31,11 +31,10 @@ module Sipity
         new(**keywords).respond
       end
 
-      attr_reader :context, :handled_response, :template
-      def initialize(context:, handled_response:, template:, responder: default_responder)
+      attr_reader :context, :handled_response
+      def initialize(context:, handled_response:, responder: default_responder)
         self.context = context
         self.handled_response = handled_response
-        self.template = template
         self.responder = responder
         prepare_context_for_response
       end
@@ -46,6 +45,7 @@ module Sipity
 
       delegate :render, :redirect_to, to: :context
       delegate :object, to: :handled_response, prefix: :response
+      delegate :template, to: :handled_response
 
       private
 
@@ -69,7 +69,7 @@ module Sipity
       end
 
       def handled_response=(input)
-        guard_interface_expectation!(input, :object)
+        guard_interface_expectation!(input, :object, :template)
         @handled_response = input
       end
 

--- a/app/response_handlers/sipity/response_handlers.rb
+++ b/app/response_handlers/sipity/response_handlers.rb
@@ -22,5 +22,62 @@ module Sipity
     def build_response_handler(container:, handled_response_status:)
       container.qualified_const_get("#{handled_response_status.to_s.classify}Response")
     end
+
+    # The default response handler. It makes sure things are well composed,
+    # guarding the interface of collaborating objects.
+    class DefaultHandler
+      def self.respond(**keywords)
+        new(**keywords).respond
+      end
+
+      attr_reader :context, :handled_response, :template
+      def initialize(context:, handled_response:, template:, responder: default_responder)
+        self.context = context
+        self.handled_response = handled_response
+        self.template = template
+        self.responder = responder
+        prepare_context_for_response
+      end
+
+      def respond
+        responder.call(handler: self)
+      end
+
+      delegate :render, :redirect_to, to: :context
+      delegate :object, to: :handled_response, prefix: :response
+
+      private
+
+      attr_accessor :responder
+      attr_writer :template
+
+      def default_responder
+        -> (handler:) { handler.render(template: handler.template) }
+      end
+
+      def prepare_context_for_response
+        # Wouldn't it be great if we had proper View objects in Rails? Instead
+        # of this crazy copy instance variables from the controller to the
+        # template (aka 'ActionView') layer.
+        context.view_object = handled_response.object
+      end
+
+      def context=(input)
+        guard_interface_expectation!(input, :view_object=, :render, :redirect_to)
+        @context = input
+      end
+
+      def handled_response=(input)
+        guard_interface_expectation!(input, :object)
+        @handled_response = input
+      end
+
+      # TODO: Extract this concept?
+      def guard_interface_expectation!(input, *expectations)
+        expectations.each do |expectation|
+          fail(Exceptions::InterfaceExpectationError, object: input, expectation: expectation) unless input.respond_to?(expectation)
+        end
+      end
+    end
   end
 end

--- a/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
@@ -2,40 +2,43 @@ module Sipity
   module ResponseHandlers
     # This is an Experimental module and concept
     module SubmissionWindowHandler
-      # Responsible for handling a :success-ful action
-      class SuccessResponse < ResponseHandlers::WorkAreaHandler::SuccessResponse
+      # Success! Huzzah
+      module SuccessResponder
+        def self.call(handler:)
+          handler.render(template: handler.template)
+        end
       end
 
-      # Forms that are submitted have a different success handling.
-      class SubmitSuccessResponse < SuccessResponse
-        # TODO: Need to Guard these methods
-        delegate :redirect_to, :work_submission_path, :submission_window_path, to: :context
-        delegate :object, to: :handled_response, prefix: :response
+      # We have a successful form submission.
+      module SubmitSuccessResponder
+        module_function
 
-        def respond
-          case response_object
+        def call(handler:)
+          case handler.response_object
           when Models::SubmissionWindow
-            respond_for_submission_window
+            respond_for_submission_window(handler: handler, submission_window: handler.response_object)
           when Models::Work
-            redirect_to work_submission_path(work_id: response_object.id)
+            # Violating the Law of Demeter-------------------------------------------V
+            handler.redirect_to handler.work_submission_path(work_id: handler.response_object.id)
           else
             # Fallback to converting to a submission window.
-            submission_window = PowerConverter.convert(response_object, to: :submission_window)
-            respond_for_submission_window(submission_window: submission_window)
+            submission_window = PowerConverter.convert(handler.response_object, to: :submission_window)
+            respond_for_submission_window(handler: handler, submission_window: submission_window)
           end
         end
 
-        private
-
-        def respond_for_submission_window(submission_window: response_object)
-          redirect_to(
-            submission_window_path(work_area_slug: submission_window.work_area_slug, submission_window_slug: submission_window.slug)
+        def respond_for_submission_window(handler:, submission_window:)
+          handler.redirect_to(
+            handler.submission_window_path(work_area_slug: submission_window.work_area_slug, submission_window_slug: submission_window.slug)
           )
         end
       end
 
       # Forms that fail to submit may have different errors.
-      class SubmitFailureResponse < SuccessResponse
+      module SubmitFailureResponder
+        def self.call(handler:)
+          handler.render(template: handler.template, status: :unprocessable_entity)
+        end
       end
     end
   end

--- a/app/response_handlers/sipity/response_handlers/work_area_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_area_handler.rb
@@ -8,6 +8,13 @@ module Sipity
           handler.render(template: handler.template)
         end
       end
+
+      # Forms that fail to submit may have different errors.
+      module SubmitFailureResponder
+        def self.call(handler:)
+          handler.render(template: handler.template, status: :unprocessable_entity)
+        end
+      end
     end
   end
 end

--- a/app/response_handlers/sipity/response_handlers/work_area_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_area_handler.rb
@@ -2,51 +2,10 @@ module Sipity
   module ResponseHandlers
     # This is an Experimental module and concept
     module WorkAreaHandler
-      # Responsible for handling a :success-ful action
-      class SuccessResponse
-        def self.respond(**keywords)
-          new(**keywords).respond
-        end
-
-        attr_reader :context, :handled_response, :template
-        def initialize(context:, handled_response:, template:)
-          self.context = context
-          self.handled_response = handled_response
-          self.template = template
-          prepare_context_for_response
-        end
-
-        def respond
-          # Consider yielding options for configuration
-          context.render(template: template)
-        end
-
-        private
-
-        attr_writer :template
-
-        def prepare_context_for_response
-          # Wouldn't it be great if we had proper View objects in Rails? Instead
-          # of this crazy copy instance variables from the controller to the
-          # template (aka 'ActionView') layer.
-          context.view_object = handled_response.object
-        end
-
-        def context=(input)
-          guard_interface_expectation!(input, :view_object=, :render)
-          @context = input
-        end
-
-        def handled_response=(input)
-          guard_interface_expectation!(input, :object)
-          @handled_response = input
-        end
-
-        # TODO: Extract this concept?
-        def guard_interface_expectation!(input, *expectations)
-          expectations.each do |expectation|
-            fail(Exceptions::InterfaceExpectationError, object: input, expectation: expectation) unless input.respond_to?(expectation)
-          end
+      # Huzzah! Success
+      module SuccessResponder
+        def self.call(handler:)
+          handler.render(template: handler.template)
         end
       end
     end

--- a/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
@@ -2,10 +2,18 @@ module Sipity
   module ResponseHandlers
     # This is an Experimental module and concept
     module WorkSubmissionHandler
-      # Responsible for handling a :success-ful action
-      #
-      # TODO: Extract a porper base class, if one exists
-      class SuccessResponse < ResponseHandlers::WorkAreaHandler::SuccessResponse
+      # It worked
+      module SuccessResponder
+        def self.call(handler:)
+          handler.render(template: handler.template)
+        end
+      end
+
+      # Forms that fail to submit may have different errors.
+      module SubmitFailureResponder
+        def self.call(handler:)
+          handler.render(template: handler.template, status: :unprocessable_entity)
+        end
       end
     end
   end

--- a/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
@@ -17,7 +17,7 @@ module Sipity
         before { controller.runner = runner }
         let(:processing_action_name) { 'fun_things' }
         it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::SubmissionWindowHandler::SuccessResponse).to receive(:respond).and_call_original
+          expect(Sipity::ResponseHandlers::SubmissionWindowHandler::SuccessResponder).to receive(:call).and_call_original
 
           # I don't want to mess around with all the possible actions
           expect do
@@ -46,7 +46,7 @@ module Sipity
         before { controller.runner = runner }
         let(:processing_action_name) { 'fun_things' }
         it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::SubmissionWindowHandler::SuccessResponse).to receive(:respond).and_call_original
+          expect(Sipity::ResponseHandlers::SubmissionWindowHandler::SuccessResponder).to receive(:call).and_call_original
 
           # I don't want to mess around with all the possible actions
           expect do

--- a/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
@@ -16,7 +16,7 @@ module Sipity
         before { controller.runner = runner }
         let(:processing_action_name) { 'fun_things' }
         it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
+          expect(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponder).to receive(:call).and_call_original
 
           # I don't want to mess around with all the possible actions
           expect do
@@ -41,7 +41,7 @@ module Sipity
         before { controller.runner = runner }
         let(:processing_action_name) { 'fun_things' }
         it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
+          expect(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponder).to receive(:call).and_call_original
 
           # I don't want to mess around with all the possible actions
           expect do

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -17,12 +17,12 @@ module Sipity
         before { controller.runner = runner }
         let(:processing_action_name) { 'fun_things' }
         it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
+          expect(Sipity::ResponseHandlers::WorkSubmissionHandler::SuccessResponder).to receive(:call).and_call_original
 
           # I don't want to mess around with all the possible actions
           expect do
             get 'query_action', work_id: work.id, processing_action_name: processing_action_name, work: { title: 'Hello' }
-          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/works/#{processing_action_name}})
+          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/work_submissions/#{processing_action_name}})
 
           expect(runner).to have_received(:run).with(
             described_class,
@@ -38,12 +38,12 @@ module Sipity
         before { controller.runner = runner }
         let(:processing_action_name) { 'fun_things' }
         it 'will pass along to the response handler' do
-          expect_any_instance_of(Sipity::ResponseHandlers::WorkAreaHandler::SuccessResponse).to receive(:respond).and_call_original
+          expect(Sipity::ResponseHandlers::WorkSubmissionHandler::SuccessResponder).to receive(:call).and_call_original
 
           # I don't want to mess around with all the possible actions
           expect do
             post 'command_action', work_id: work.id, processing_action_name: processing_action_name, work: { title: 'Hello' }
-          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/works/#{processing_action_name}})
+          end.to raise_error(ActionView::MissingTemplate, %r{sipity/controllers/work_submissions/#{processing_action_name}})
 
           expect(runner).to have_received(:run).with(
             described_class,

--- a/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
@@ -4,13 +4,16 @@ module Sipity
     RSpec.describe HandledResponseParameter do
       let(:status) { :success }
       let(:object) { double('Object') }
+      let(:template) { 'a/template' }
 
-      subject { described_class.new(status: status, object: object) }
+      subject { described_class.new(status: status, object: object, template: template) }
       its(:status) { should eq status }
       its(:object) { should eq object }
+      its(:template) { should eq template }
 
       it 'will fail to initialize if the status is not a symbol' do
-        expect { described_class.new(status: double, object: object) }.to raise_error(Exceptions::InvalidHandledResponseStatus)
+        expect { described_class.new(status: double, object: object, template: template) }.
+          to raise_error(Exceptions::InvalidHandledResponseStatus)
       end
     end
   end

--- a/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
@@ -4,104 +4,69 @@ require 'sipity/response_handlers/submission_window_handler'
 module Sipity
   module ResponseHandlers
     module SubmissionWindowHandler
-      RSpec.describe SuccessResponse do
-        let(:context) { double(render: 'rendered', :view_object= => true) }
-        let(:viewable_object) { double }
-        let(:handled_response) { double(object: viewable_object) }
-        subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
-        it 'will #respond by rendering the context' do
-          expect(subject.respond).to eq(context.render)
-        end
+      RSpec.describe SuccessResponder do
+        let(:handler) { double(render: 'rendered', template: 'show') }
 
-        it 'will .respond by rendering the context' do
-          expect(described_class.respond(context: context, handled_response: handled_response, template: 'show')).to eq(context.render)
-          expect(context).to have_received(:render).with(template: 'show')
-        end
-
-        context 'collaborating objects expected interface' do
-          it '#context must implement #view_object=' do
-            expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
-          it '#context must implement #render' do
-            expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
-          it '#handled_response must implement #object' do
-            expect { described_class.new(context: context, handled_response: double, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
+        it 'will coordinate the rendering of the template' do
+          described_class.call(handler: handler)
+          expect(handler).to have_received(:render).with(template: handler.template)
         end
       end
 
-      RSpec.describe SubmitSuccessResponse do
+      RSpec.describe SubmitSuccessResponder do
         let(:submission_window) { Models::SubmissionWindow.new(slug: 'a_slug', work_area: work_area) }
-        let(:viewable_object) { submission_window }
         let(:work_area) { Models::WorkArea.new(slug: 'area_slug') }
-        let(:context) { double(render: :rendered, redirect_to: :redirected_to, :view_object= => true) }
-        let(:handled_response) { double(object: viewable_object) }
-        subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
-
-        it 'will .respond by delegating to an instance' do
-          expect_any_instance_of(described_class).to receive(:respond)
-          described_class.respond(context: context, handled_response: handled_response, template: 'show')
-        end
+        let(:handler) { double(redirect_to: true, submission_window_path: true, work_submission_path: true) }
+        let(:work) { Models::Work.new(id: 'an_id') }
+        let(:path) { '/redirected_to/this/path' }
 
         context 'for a SubmissionWindow' do
           it "will #respond by redirecting to the submission window's path" do
-            path = '/path/to/submission_window'
-            expect(context).to receive(:submission_window_path).
+            allow(handler).to receive(:response_object).and_return(submission_window)
+            expect(handler).to receive(:submission_window_path).
               with(work_area_slug: work_area.slug, submission_window_slug: submission_window.slug).
               and_return(path)
-            expect(context).to receive(:redirect_to).with(path)
-            subject.respond
+            expect(handler).to receive(:redirect_to).with(path)
+            described_class.call(handler: handler)
           end
         end
 
         context 'for a Work' do
-          let(:viewable_object) { Models::Work.new(id: 'an_id') }
-
-          it "will #respond by redirecting to the submission window's path" do
-            path = '/path/to/work'
-            expect(context).to receive(:work_submission_path).with(work_id: viewable_object.id).and_return(path)
-            expect(context).to receive(:redirect_to).with(path)
-            subject.respond
+          it "will #respond by redirecting to the work's path" do
+            allow(handler).to receive(:response_object).and_return(work)
+            expect(handler).to receive(:work_submission_path).with(work_id: work.id).and_return(path)
+            expect(handler).to receive(:redirect_to).with(path)
+            described_class.call(handler: handler)
           end
         end
 
         context 'for something that can be converted to a submission window' do
           let(:viewable_object) { double(to_submission_window: submission_window) }
           it "will attempt to convert the object" do
-            path = '/path/to/submission_window'
-            expect(context).to receive(:submission_window_path).
+            allow(handler).to receive(:response_object).and_return(viewable_object)
+            expect(handler).to receive(:submission_window_path).
               with(work_area_slug: work_area.slug, submission_window_slug: submission_window.slug).
               and_return(path)
-            expect(context).to receive(:redirect_to).with(path)
-            subject.respond
+            expect(handler).to receive(:redirect_to).with(path)
+            described_class.call(handler: handler)
           end
         end
 
         context 'for something else' do
           let(:viewable_object) { double }
-          it "will attempt to convert the object" do
+          it "will attempt to convert the object but fail" do
+            allow(handler).to receive(:response_object).and_return(viewable_object)
             expect(PowerConverter).to receive(:convert).with(viewable_object, to: :submission_window).and_call_original
-            expect { subject.respond }.to raise_error(PowerConverter::ConversionError)
+            expect { described_class.call(handler: handler) }.to raise_error(PowerConverter::ConversionError)
           end
         end
+      end
 
-        context 'collaborating objects expected interface' do
-          it '#context must implement #view_object=' do
-            expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
-          it '#context must implement #render' do
-            expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
-          it '#handled_response must implement #object' do
-            expect { described_class.new(context: context, handled_response: double, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
+      RSpec.describe SubmitFailureResponder do
+        let(:handler) { double(render: 'rendered', template: 'show') }
+        it 'will coordinate the rendering of the template' do
+          described_class.call(handler: handler)
+          expect(handler).to have_received(:render).with(template: handler.template, status: :unprocessable_entity)
         end
       end
     end

--- a/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
@@ -12,6 +12,15 @@ module Sipity
           expect(handler).to have_received(:render).with(template: handler.template)
         end
       end
+
+      RSpec.describe SubmitFailureResponder do
+        let(:handler) { double(render: 'rendered', template: 'show') }
+
+        it 'will coordinate the rendering of the template' do
+          described_class.call(handler: handler)
+          expect(handler).to have_received(:render).with(template: handler.template, status: :unprocessable_entity)
+        end
+      end
     end
   end
 end

--- a/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
@@ -4,33 +4,12 @@ require 'sipity/response_handlers/work_area_handler'
 module Sipity
   module ResponseHandlers
     module WorkAreaHandler
-      RSpec.describe SuccessResponse do
-        let(:context) { double(render: 'rendered', :view_object= => true) }
-        let(:viewable_object) { double }
-        let(:handled_response) { double(object: viewable_object) }
-        subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
-        it 'will #respond by rendering the context' do
-          expect(subject.respond).to eq(context.render)
-        end
+      RSpec.describe SuccessResponder do
+        let(:handler) { double(render: 'rendered', template: 'show') }
 
-        it 'will .respond by rendering the context' do
-          expect(described_class.respond(context: context, handled_response: handled_response, template: 'show')).to eq(context.render)
-          expect(context).to have_received(:render).with(template: 'show')
-        end
-
-        context 'collaborating objects expected interface' do
-          it '#context must implement #view_object=' do
-            expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
-          it '#context must implement #render' do
-            expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
-          it '#handled_response must implement #object' do
-            expect { described_class.new(context: context, handled_response: double, template: 'show') }.
-              to raise_error(Exceptions::InterfaceExpectationError)
-          end
+        it 'will coordinate the rendering of the template' do
+          described_class.call(handler: handler)
+          expect(handler).to have_received(:render).with(template: handler.template)
         end
       end
     end

--- a/spec/response_handlers/sipity/response_handlers/work_submission_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/work_submission_handler_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'sipity/response_handlers/work_submission_handler'
+
+module Sipity
+  module ResponseHandlers
+    module WorkSubmissionHandler
+      RSpec.describe SuccessResponder do
+        let(:handler) { double(render: 'rendered', template: 'show') }
+
+        it 'will coordinate the rendering of the template' do
+          described_class.call(handler: handler)
+          expect(handler).to have_received(:render).with(template: handler.template)
+        end
+      end
+
+      RSpec.describe SubmitFailureResponder do
+        let(:handler) { double(render: 'rendered', template: 'show') }
+
+        it 'will coordinate the rendering of the template' do
+          described_class.call(handler: handler)
+          expect(handler).to have_received(:render).with(template: handler.template, status: :unprocessable_entity)
+        end
+      end
+    end
+  end
+end

--- a/spec/response_handlers/sipity/response_handlers_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers_spec.rb
@@ -30,4 +30,36 @@ module Sipity
       end
     end
   end
+
+  module ResponseHandlers
+    RSpec.describe DefaultHandler do
+      let(:context) { double(render: 'rendered', :view_object= => true, redirect_to: 'redirected_to') }
+      let(:viewable_object) { double }
+      let(:handled_response) { double(object: viewable_object) }
+      subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
+      it 'will #respond by rendering the context' do
+        expect(subject.respond).to eq(context.render)
+      end
+
+      it 'will .respond by rendering the context' do
+        expect(described_class.respond(context: context, handled_response: handled_response, template: 'show')).to eq(context.render)
+        expect(context).to have_received(:render).with(template: 'show')
+      end
+
+      context 'collaborating objects expected interface' do
+        it '#context must implement #view_object=' do
+          expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
+            to raise_error(Exceptions::InterfaceExpectationError)
+        end
+        it '#context must implement #render' do
+          expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
+            to raise_error(Exceptions::InterfaceExpectationError)
+        end
+        it '#handled_response must implement #object' do
+          expect { described_class.new(context: context, handled_response: double, template: 'show') }.
+            to raise_error(Exceptions::InterfaceExpectationError)
+        end
+      end
+    end
+  end
 end

--- a/spec/response_handlers/sipity/response_handlers_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers_spec.rb
@@ -15,14 +15,13 @@ module Sipity
     end
     after { Sipity.send(:remove_const, :MockContainer) }
     let(:context) { double(render: true, redirect_to: true, :view_object= => true) }
-    let(:handled_response) { double(status: :success, object: double) }
-    let(:template) { double }
+    let(:handled_response) { double(status: :success, object: double, template: double) }
 
     context '.handle_response' do
       it 'will build a handler then respond with that handler' do
         expect(MockContainer::SuccessResponder).to receive(:call).with(handler: kind_of(described_class::DefaultHandler))
         described_class.handle_response(
-          container: MockContainer, context: context, handled_response: handled_response, template: template
+          container: MockContainer, context: context, handled_response: handled_response
         )
       end
     end
@@ -39,35 +38,39 @@ module Sipity
     RSpec.describe DefaultHandler do
       let(:context) { double(render: 'rendered', :view_object= => true, redirect_to: 'redirected_to') }
       let(:viewable_object) { double }
-      let(:handled_response) { double(object: viewable_object) }
-      subject { described_class.new(context: context, handled_response: handled_response, template: 'show') }
+      let(:handled_response) { double(object: viewable_object, template: 'show') }
+      subject { described_class.new(context: context, handled_response: handled_response) }
       it 'will #respond by rendering the context' do
         expect(subject.respond).to eq(context.render)
       end
 
       it 'will .respond by rendering the context' do
-        expect(described_class.respond(context: context, handled_response: handled_response, template: 'show')).to eq(context.render)
+        expect(described_class.respond(context: context, handled_response: handled_response)).to eq(context.render)
         expect(context).to have_received(:render).with(template: 'show')
       end
 
       it 'accepts a custom responder' do
         responder = double(call: true)
-        subject = described_class.new(context: context, handled_response: handled_response, template: 'show', responder: responder)
+        subject = described_class.new(context: context, handled_response: handled_response, responder: responder)
         subject.respond
         expect(responder).to have_received(:call).with(handler: subject)
       end
 
       context 'collaborating objects expected interface' do
         it '#context must implement #view_object=' do
-          expect { described_class.new(context: double(render: true), handled_response: handled_response, template: 'show') }.
+          expect { described_class.new(context: double(render: true), handled_response: handled_response) }.
             to raise_error(Exceptions::InterfaceExpectationError)
         end
         it '#context must implement #render' do
-          expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response, template: 'show') }.
+          expect { described_class.new(context: double(:view_object= => true), handled_response: handled_response) }.
             to raise_error(Exceptions::InterfaceExpectationError)
         end
         it '#handled_response must implement #object' do
-          expect { described_class.new(context: context, handled_response: double, template: 'show') }.
+          expect { described_class.new(context: context, handled_response: double(template: 'show')) }.
+            to raise_error(Exceptions::InterfaceExpectationError)
+        end
+        it '#handled_response must implement #template' do
+          expect { described_class.new(context: context, handled_response: double(object: double)) }.
             to raise_error(Exceptions::InterfaceExpectationError)
         end
       end

--- a/spec/response_handlers/sipity/response_handlers_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers_spec.rb
@@ -56,6 +56,27 @@ module Sipity
         expect(responder).to have_received(:call).with(handler: subject)
       end
 
+      context '#method_missing' do
+        it 'will delegate all *_path methods to the context' do
+          expect(context).to receive(:submission_window_path).with(key: 'value')
+          subject.submission_window_path(key: 'value')
+        end
+        it 'will pass through if the method_name is not *_path' do
+          expect { subject.obviously_missing }.to raise_error(NoMethodError)
+        end
+      end
+
+      context '#respond_to?' do
+        it 'will respond to all *_path methods (if the context does)' do
+          context = double(render: 'rendered', :view_object= => true, redirect_to: 'redirected_to', submission_window_path: true)
+          subject = described_class.new(context: context, handled_response: handled_response)
+          expect(subject.respond_to?(:submission_window_path)).to eq(true)
+        end
+        it 'will pass through if the method_name is not *_path' do
+          expect(subject.respond_to?(:obviously_missing)).to be_falsey
+        end
+      end
+
       context 'collaborating objects expected interface' do
         it '#context must implement #view_object=' do
           expect { described_class.new(context: double(render: true), handled_response: handled_response) }.


### PR DESCRIPTION
## Teasing apart the Handler and Responder

@2c2ede07740ec9422640bbd4054cd1295eac0de6

I was leveraging lots of inheritance. So instead I'm opting for
composition.

## Changing response handler for composition

@ff3892d612a119955206a476a9a80c178da1ed47


## Reworking WorkArea response handling

@01a612bd9fe982f8b863ad73aa09abdd56cd8325

Removing lots of cruft as the coordination is handled at a higher
level.

## Adding SubmissionWindow responders

@fcbdff0258fdf26161275bbb197302d7525535f1

Composition is much more favorable than inheritance

Yes the responder is a nosy neighbor, but the logic is encoded there.

## Adding WorkAreaHandler::SubmitFailureResponder

@62339b1dd3f4d49994801f42dcecefa8534d7519


## Normalizing WorkSubmission responders

@5ab291c8654b024536cfa0679e211366651fdd1d


## Reworking response handler interface

@e2f4a9b8d99aff11156601954ab86bc3197fa8e1

Based on the changes to remove a parameter in the response handling,
I needed to tidy up how the response handling occurred.
