### PR TITLE
Working on general view and template organization

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -26,6 +26,19 @@ ModuleLength:
   Exclude:
     - '**/*'
 
+CaseEquality:
+  Exclude:
+    - app/decorators/sipity/decorators.rb
+    - spec/decorators/sipity/decorators_spec.rb
+
+MethodName:
+  Exclude:
+    - app/decorators/sipity/decorators.rb
+
+Style/PredicateName:
+  Exclude:
+    - app/decorators/sipity/decorators.rb
+
 MethodLength:
   Max: 10
   Description: 'Avoid methods longer than 10 lines of code.'

--- a/app/decorators/sipity/decorators.rb
+++ b/app/decorators/sipity/decorators.rb
@@ -7,5 +7,40 @@ module Sipity
   #   It does a great job of explaining their importance.
   # @note Establishing module name
   module Decorators
+    module_function
+
+    # A function to help you build a ComparableDecoratorClass
+    #
+    # @example
+    #   class DecoratorBook < Decorators::ComparableDelegateClass(Book)
+    #     # Further details of your class
+    #   end
+    #
+    # @todo Extract this to the hesburgh-lib
+    def ComparableDelegateClass(base_class)
+      klass = Class.new(ComparableSimpleDelegator)
+      klass.base_class = base_class
+      klass
+    end
+
+    # Provides a convenience wrapper of an object to assist in equality testing.
+    # This is key as it relates to PowerConverter and how it is used.
+    class ComparableSimpleDelegator < SimpleDelegator
+      class_attribute :base_class, instance_writer: false
+
+      class << self
+        def ===(other)
+          super || base_class === other
+        end
+      end
+
+      def is_a?(classification)
+        # REVIEW: Is base_class == classification a reasonable assumption?
+        #   Thinking in terms of Liskov's Substitution this may be necessary.
+        super || __getobj__.is_a?(classification) || base_class == classification
+      end
+
+      alias_method :kind_of?, :is_a?
+    end
   end
 end

--- a/app/forms/sipity/forms/core/submission_windows/show_form.rb
+++ b/app/forms/sipity/forms/core/submission_windows/show_form.rb
@@ -6,7 +6,7 @@ module Sipity
         #
         # @note This is the result of changing the SubmissionsWindows controller
         #   to be two actions.
-        class ShowForm < SimpleDelegator
+        class ShowForm < Decorators::ComparableDelegateClass(Models::SubmissionWindow)
           class_attribute :policy_enforcer
           self.policy_enforcer = Sipity::Policies::SubmissionWindowPolicy
 

--- a/app/forms/sipity/forms/core/work_areas/show_form.rb
+++ b/app/forms/sipity/forms/core/work_areas/show_form.rb
@@ -6,7 +6,7 @@ module Sipity
         #
         # @note This is the result of changing the WorkAreas controller
         #   to be two actions.
-        class ShowForm < SimpleDelegator
+        class ShowForm < Decorators::ComparableDelegateClass(Models::WorkArea)
           class_attribute :policy_enforcer
           self.policy_enforcer = Sipity::Policies::WorkAreaPolicy
 

--- a/app/forms/sipity/forms/core/work_submissions/show_form.rb
+++ b/app/forms/sipity/forms/core/work_submissions/show_form.rb
@@ -6,7 +6,7 @@ module Sipity
         #
         # @note This is the result of changing the Work controller
         #   to be two actions.
-        class ShowForm < SimpleDelegator
+        class ShowForm < Decorators::ComparableDelegateClass(Models::Work)
           class_attribute :policy_enforcer
           self.policy_enforcer = Sipity::Policies::WorkPolicy
 

--- a/spec/decorators/sipity/decorators_spec.rb
+++ b/spec/decorators/sipity/decorators_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'sipity/decorators'
+
+module Sipity
+  RSpec.describe Decorators do
+    context '.ComparableDelegateClass' do
+      let(:underlying_object) { double }
+      subject { described_class.ComparableDelegateClass(underlying_object.class) }
+      its(:base_class) { should eq(double.class) }
+      it { should be_a Class }
+      it { should respond_to :new }
+
+      context 'instantiating an instance of the class' do
+        subject { described_class.ComparableDelegateClass(underlying_object.class).new(underlying_object) }
+        context '.===' do
+          it 'Decorators::ComparableSimpleDelegator will "claim" the subject' do
+            expect(Decorators::ComparableSimpleDelegator === subject).to be_truthy
+          end
+
+          it 'Decorators::ComparableSimpleDelegator will not "claim" the underlying object' do
+            expect(Decorators::ComparableSimpleDelegator === subject.__getobj__).to be_falsey
+          end
+
+          it 'SimpleDelegator will "claim" the subject' do
+            expect(SimpleDelegator === subject).to be_truthy
+          end
+
+          it 'SimpleDelegator will not "claim" the underlying object' do
+            expect(SimpleDelegator === subject.__getobj__).to be_falsey
+          end
+
+          it 'The underlying object\'s class will not claim the subject' do
+            expect(underlying_object.class === subject).to be_falsey
+          end
+
+          it 'The underlying object\'s class will not claim the subject' do
+            expect(underlying_object.class === subject.__getobj__).to be_truthy
+          end
+        end
+
+        [:kind_of?, :is_a?].each do |method_name|
+          context "##{method_name}" do
+            it 'will be a Decorators::ComparableSimpleDelegator' do
+              expect(subject.send(method_name, Decorators::ComparableSimpleDelegator)).to be_truthy
+            end
+            it 'will be a SimpleDelegator' do
+              expect(subject.send(method_name, SimpleDelegator)).to be_truthy
+            end
+            it 'will be a underlying class' do
+              expect(subject.send(method_name, underlying_object.class)).to be_truthy
+            end
+            it 'will be a base class even if its not the same as the underlying object' do
+              subject = described_class.ComparableDelegateClass(Integer).new(underlying_object)
+              expect(subject.send(method_name, Integer)).to be_truthy
+            end
+            it 'will not be another class' do
+              expect(subject.send(method_name, Class.new)).to be_falsey
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/sipity/forms/core/submission_windows/show_form_spec.rb
+++ b/spec/forms/sipity/forms/core/submission_windows/show_form_spec.rb
@@ -12,6 +12,8 @@ module Sipity
 
           its(:policy_enforcer) { should eq Sipity::Policies::SubmissionWindowPolicy }
           its(:processing_action_name) { should eq processing_action_name }
+
+          it { should be_a(Models::SubmissionWindow) }
         end
       end
     end

--- a/spec/forms/sipity/forms/core/work_areas/show_form_spec.rb
+++ b/spec/forms/sipity/forms/core/work_areas/show_form_spec.rb
@@ -12,6 +12,8 @@ module Sipity
 
           its(:policy_enforcer) { should eq Sipity::Policies::WorkAreaPolicy }
           its(:processing_action_name) { should eq processing_action_name }
+
+          it { expect(subject.is_a?(Models::WorkArea)).to be_truthy }
         end
       end
     end

--- a/spec/forms/sipity/forms/core/work_submissions/show_form_spec.rb
+++ b/spec/forms/sipity/forms/core/work_submissions/show_form_spec.rb
@@ -14,6 +14,7 @@ module Sipity
           its(:processing_action_name) { should eq processing_action_name }
           its(:work_id) { should eq work.id }
           it { should be_decorated }
+          it { should be_a(Models::Work) }
         end
       end
     end


### PR DESCRIPTION
## Adding ComparableDelegateClass function

@fcb192108aaa74cffec3e7254144fbd5f27b640c

The rubocop settings were adjusted because these comparison operators
are not-advised by default Rubocop. However, with PowerConverter and
case statements, I need to leverage these behaviors.

## Leveraging ComparableDelegateClass for show forms

@422e02db0c1d9a63d30f18e2d20815fe0319f324

I was running into the case in which PowerConverter could not convert
a ShowForm to the requisite WorkArea or ProcessingEntity.

This now works around that.
