### PR TITLE
Reworking data generator organization to match

### DIFF
--- a/app/data_generators/sipity/data_generators/find_or_create_submission_window.rb
+++ b/app/data_generators/sipity/data_generators/find_or_create_submission_window.rb
@@ -44,11 +44,11 @@ module Sipity
       end
 
       def work_area_specific_submission_window_generator
-        "Sipity::DataGenerators::#{work_area.demodulized_class_prefix_name}::SubmissionWindowProcessingGenerator".constantize
+        "Sipity::DataGenerators::SubmissionWindows::#{work_area.demodulized_class_prefix_name}Generator".constantize
       end
 
       def work_area_specific_work_types_generator
-        "Sipity::DataGenerators::#{work_area.demodulized_class_prefix_name}::WorkTypesProcessingGenerator".constantize
+        "Sipity::DataGenerators::WorkTypes::#{work_area.demodulized_class_prefix_name}Generator".constantize
       end
     end
   end

--- a/app/data_generators/sipity/data_generators/find_or_create_work_area.rb
+++ b/app/data_generators/sipity/data_generators/find_or_create_work_area.rb
@@ -76,7 +76,7 @@ module Sipity
       end
 
       def work_area_specific_generator
-        "Sipity::DataGenerators::#{work_area.demodulized_class_prefix_name}::WorkAreaProcessingGenerator".constantize
+        "Sipity::DataGenerators::WorkAreas::#{work_area.demodulized_class_prefix_name}Generator".constantize
       rescue NameError
         # Return a null generator
         ->(**_) {}

--- a/app/data_generators/sipity/data_generators/submission_windows/base_generator.rb
+++ b/app/data_generators/sipity/data_generators/submission_windows/base_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Base
+    module SubmissionWindows
       # Responsible for generating the submission window for the ETD work area.
-      class SubmissionWindowProcessingGenerator
+      class BaseGenerator
         def self.call(**keywords)
           new(**keywords).call
         end

--- a/app/data_generators/sipity/data_generators/submission_windows/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/submission_windows/etd_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Ulra
+    module SubmissionWindows
       # Responsible for generating the submission window for the ETD work area.
-      class SubmissionWindowProcessingGenerator < DataGenerators::Base::SubmissionWindowProcessingGenerator
+      class EtdGenerator < BaseGenerator
       end
     end
   end

--- a/app/data_generators/sipity/data_generators/submission_windows/ulra_generator.rb
+++ b/app/data_generators/sipity/data_generators/submission_windows/ulra_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Etd
+    module SubmissionWindows
       # Responsible for generating the submission window for the ETD work area.
-      class SubmissionWindowProcessingGenerator < DataGenerators::Base::SubmissionWindowProcessingGenerator
+      class UlraGenerator < BaseGenerator
       end
     end
   end

--- a/app/data_generators/sipity/data_generators/work_areas/base_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_areas/base_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Base
+    module WorkAreas
       # Responsible for generating the work types within the ETD.
-      class WorkAreaProcessingGenerator
+      class BaseGenerator
         def self.call(**keywords)
           new(**keywords).call
         end

--- a/app/data_generators/sipity/data_generators/work_areas/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_areas/etd_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Ulra
+    module WorkAreas
       # Responsible for generating the work types within the ETD.
-      class WorkAreaProcessingGenerator < DataGenerators::Base::WorkAreaProcessingGenerator
+      class EtdGenerator < BaseGenerator
       end
     end
   end

--- a/app/data_generators/sipity/data_generators/work_areas/ulra_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_areas/ulra_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Etd
+    module WorkAreas
       # Responsible for generating the work types within the ETD.
-      class WorkAreaProcessingGenerator < DataGenerators::Base::WorkAreaProcessingGenerator
+      class UlraGenerator < BaseGenerator
       end
     end
   end

--- a/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Etd
+    module WorkTypes
       # Responsible for generating the work types within the ETD.
-      class WorkTypesProcessingGenerator
+      class EtdGenerator
         WORK_TYPE_NAMES = [
           Models::WorkType::DOCTORAL_DISSERTATION,
           Models::WorkType::MASTER_THESIS

--- a/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
@@ -1,8 +1,8 @@
 module Sipity
   module DataGenerators
-    module Ulra
+    module WorkTypes
       # Responsible for generating the work types within the ETD.
-      class WorkTypesProcessingGenerator
+      class UlraGenerator
         WORK_TYPE_NAMES = [
           Models::WorkType::ULRA_SUBMISSION
         ]

--- a/app/forms/sipity/forms/etd/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/etd/start_a_submission_form.rb
@@ -81,7 +81,8 @@ module Sipity
         end
 
         def possible_work_types
-          DataGenerators::Etd::WorkTypesProcessingGenerator::WORK_TYPE_NAMES
+          # Yikes?
+          DataGenerators::WorkTypes::EtdGenerator::WORK_TYPE_NAMES
         end
 
         def possible_work_publication_strategies

--- a/db/seeds/groups_and_roles_seeds.rb
+++ b/db/seeds/groups_and_roles_seeds.rb
@@ -1,5 +1,5 @@
 $stdout.puts 'Creating Groups...'
-graduate_school_reviewers = Sipity::DataGenerators::Etd::WorkTypesProcessingGenerator::GRADUATE_SCHOOL_REVIEWERS
+graduate_school_reviewers = Sipity::DataGenerators::WorkTypes::EtdGenerator::GRADUATE_SCHOOL_REVIEWERS
 Sipity::Conversions::ConvertToProcessingActor.call(
   Sipity::Models::Group.find_or_create_by!(name: graduate_school_reviewers)
 )

--- a/spec/data_generators/sipity/data_generators/find_or_create_submission_window_spec.rb
+++ b/spec/data_generators/sipity/data_generators/find_or_create_submission_window_spec.rb
@@ -8,8 +8,8 @@ module Sipity
       let(:strategy_id) { 888_999_111 }
       let(:slug) { 'start' }
       before do
-        allow(Sipity::DataGenerators::Etd::SubmissionWindowProcessingGenerator).to receive(:call)
-        allow(Sipity::DataGenerators::Etd::WorkTypesProcessingGenerator).to receive(:call)
+        allow(Sipity::DataGenerators::SubmissionWindows::EtdGenerator).to receive(:call)
+        allow(Sipity::DataGenerators::WorkTypes::EtdGenerator).to receive(:call)
       end
       it 'will create a submission window for the given work area' do
         expect { subject.call(slug: slug, work_area: work_area) }.
@@ -29,9 +29,9 @@ module Sipity
       end
 
       it 'will leverage the custom etd processing generator' do
-        expect(Sipity::DataGenerators::Etd::SubmissionWindowProcessingGenerator).
+        expect(Sipity::DataGenerators::SubmissionWindows::EtdGenerator).
           to receive(:call).with(work_area: work_area, submission_window: be_persisted)
-        expect(Sipity::DataGenerators::Etd::WorkTypesProcessingGenerator).
+        expect(Sipity::DataGenerators::WorkTypes::EtdGenerator).
           to receive(:call).with(work_area: work_area, submission_window: be_persisted)
         subject.call(slug: slug, work_area: work_area)
       end

--- a/spec/data_generators/sipity/data_generators/find_or_create_work_area_spec.rb
+++ b/spec/data_generators/sipity/data_generators/find_or_create_work_area_spec.rb
@@ -5,7 +5,7 @@ module Sipity
     RSpec.describe FindOrCreateWorkArea do
       let(:user) { Sipity::Factories.create_user }
       before do
-        allow(Etd::WorkAreaProcessingGenerator).to receive(:call)
+        allow(WorkAreas::EtdGenerator).to receive(:call)
       end
       it 'will create a processing strategy if none exists for work areas otherwise reuse it' do
         expect { described_class.call(name: 'Worm', slug: 'worm') }.
@@ -24,7 +24,7 @@ module Sipity
       end
 
       it 'will call the custom work area processing generator' do
-        expect(Etd::WorkAreaProcessingGenerator).to receive(:call)
+        expect(WorkAreas::EtdGenerator).to receive(:call)
         described_class.call(name: 'ETD', slug: 'etd')
       end
 

--- a/spec/data_generators/sipity/data_generators/submission_windows/base_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/base_generator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'sipity/data_generators/base/submission_window_processing_generator'
+require 'sipity/data_generators/submission_windows/base_generator'
 
 module Sipity
   module DataGenerators
-    module Base
+    module SubmissionWindows
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe SubmissionWindowProcessingGenerator do
+      RSpec.describe BaseGenerator do
         let(:work_area) { Models::WorkArea.new(id: 1, slug: 'etd') }
         let(:submission_window) { Models::SubmissionWindow.new(slug: 'start', work_area_id: work_area.id) }
         subject { described_class }

--- a/spec/data_generators/sipity/data_generators/submission_windows/etd_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/etd_generator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'sipity/data_generators/etd/submission_window_processing_generator'
+require 'sipity/data_generators/submission_windows/etd_generator'
 
 module Sipity
   module DataGenerators
-    module Etd
+    module SubmissionWindows
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe SubmissionWindowProcessingGenerator do
+      RSpec.describe EtdGenerator do
         it 'does not deviate from the base implementation' do
           expect(described_class.methods(false)).to be_empty
           expect(described_class.instance_methods(false)).to be_empty

--- a/spec/data_generators/sipity/data_generators/submission_windows/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/ulra_generator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'sipity/data_generators/etd/work_area_processing_generator'
+require 'sipity/data_generators/submission_windows/ulra_generator'
 
 module Sipity
   module DataGenerators
-    module Etd
+    module SubmissionWindows
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe WorkAreaProcessingGenerator do
+      RSpec.describe UlraGenerator do
         it 'does not deviate from the base implementation' do
           expect(described_class.methods(false)).to be_empty
           expect(described_class.instance_methods(false)).to be_empty

--- a/spec/data_generators/sipity/data_generators/work_areas/base_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/base_generator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'sipity/data_generators/base/work_area_processing_generator'
+require 'sipity/data_generators/work_areas/base_generator'
 
 module Sipity
   module DataGenerators
-    module Base
+    module WorkAreas
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe WorkAreaProcessingGenerator do
+      RSpec.describe BaseGenerator do
         let(:work_area) { Models::WorkArea.new(id: 1, slug: 'etd') }
         let(:processing_strategy) { Models::Processing::Strategy.create!(id: 2, name: 'etd processing') }
         subject { described_class }

--- a/spec/data_generators/sipity/data_generators/work_areas/etd_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/etd_generator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'sipity/data_generators/ulra/submission_window_processing_generator'
+require 'sipity/data_generators/work_areas/etd_generator'
 
 module Sipity
   module DataGenerators
-    module Ulra
+    module WorkAreas
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe SubmissionWindowProcessingGenerator do
+      RSpec.describe EtdGenerator do
         it 'does not deviate from the base implementation' do
           expect(described_class.methods(false)).to be_empty
           expect(described_class.instance_methods(false)).to be_empty

--- a/spec/data_generators/sipity/data_generators/work_areas/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/ulra_generator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
-require 'sipity/data_generators/ulra/work_area_processing_generator'
+require 'sipity/data_generators/work_areas/ulra_generator'
 
 module Sipity
   module DataGenerators
-    module Ulra
+    module WorkAreas
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe WorkAreaProcessingGenerator do
+      RSpec.describe UlraGenerator do
         it 'does not deviate from the base implementation' do
           expect(described_class.methods(false)).to be_empty
           expect(described_class.instance_methods(false)).to be_empty

--- a/spec/data_generators/sipity/data_generators/work_types/etd_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_types/etd_generator_spec.rb
@@ -2,27 +2,27 @@ require 'rails_helper'
 
 module Sipity
   module DataGenerators
-    module Ulra
+    module WorkTypes
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe WorkTypesProcessingGenerator do
-        let(:work_area) { Models::WorkArea.new(id: 1, slug: 'ulra') }
+      RSpec.describe EtdGenerator do
+        let(:work_area) { Models::WorkArea.new(id: 1, slug: 'etd') }
         let(:submission_window) { Models::SubmissionWindow.new(id: 2, slug: 'start', work_area_id: work_area.id) }
         subject { described_class }
 
-        it "will generate the state diagram for a ULRA submission" do
+        it "will generate the state diagram for the master thesis and doctoral dissertation" do
           # Consider running this code and checking against the output state machine
           # This was how I visually validated the changes.
           #
           # However this test is much more of a bare-bones sanity check.
           expect do
             expect do
-              expect do
-                subject.call(work_area: work_area, submission_window: submission_window)
-              end.to change { Models::WorkType.count }.by(described_class::WORK_TYPE_NAMES.count)
-            end.to change { Models::Processing::Strategy.count }.by(described_class::WORK_TYPE_NAMES.count)
-          end.to change { Models::Processing::StrategyResponsibility.count }.by(described_class::WORK_TYPE_NAMES.count)
+              subject.call(work_area: work_area, submission_window: submission_window)
+            end.to change { Models::WorkType.count }.by(described_class::WORK_TYPE_NAMES.count)
+          end.to change { Models::Processing::Strategy.count }.by(described_class::WORK_TYPE_NAMES.count)
+        end
 
-          # It can be called repeatedly without updating things
+        it 'can be called repeatedly without updating things' do
+          subject.call(submission_window: submission_window, work_area: work_area)
           [:update_attribute, :update_attributes, :update_attributes!, :save, :save!, :update, :update!].each do |method_names|
             expect_any_instance_of(ActiveRecord::Base).to_not receive(method_names)
           end

--- a/spec/data_generators/sipity/data_generators/work_types/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_types/ulra_generator_spec.rb
@@ -2,27 +2,27 @@ require 'rails_helper'
 
 module Sipity
   module DataGenerators
-    module Etd
+    module WorkTypes
       # Responsible for generating the submission window for the ETD work area.
-      RSpec.describe WorkTypesProcessingGenerator do
-        let(:work_area) { Models::WorkArea.new(id: 1, slug: 'etd') }
+      RSpec.describe UlraGenerator do
+        let(:work_area) { Models::WorkArea.new(id: 1, slug: 'ulra') }
         let(:submission_window) { Models::SubmissionWindow.new(id: 2, slug: 'start', work_area_id: work_area.id) }
         subject { described_class }
 
-        it "will generate the state diagram for the master thesis and doctoral dissertation" do
+        it "will generate the state diagram for a ULRA submission" do
           # Consider running this code and checking against the output state machine
           # This was how I visually validated the changes.
           #
           # However this test is much more of a bare-bones sanity check.
           expect do
             expect do
-              subject.call(work_area: work_area, submission_window: submission_window)
-            end.to change { Models::WorkType.count }.by(described_class::WORK_TYPE_NAMES.count)
-          end.to change { Models::Processing::Strategy.count }.by(described_class::WORK_TYPE_NAMES.count)
-        end
+              expect do
+                subject.call(work_area: work_area, submission_window: submission_window)
+              end.to change { Models::WorkType.count }.by(described_class::WORK_TYPE_NAMES.count)
+            end.to change { Models::Processing::Strategy.count }.by(described_class::WORK_TYPE_NAMES.count)
+          end.to change { Models::Processing::StrategyResponsibility.count }.by(described_class::WORK_TYPE_NAMES.count)
 
-        it 'can be called repeatedly without updating things' do
-          subject.call(submission_window: submission_window, work_area: work_area)
+          # It can be called repeatedly without updating things
           [:update_attribute, :update_attributes, :update_attributes!, :save, :save!, :update, :update!].each do |method_names|
             expect_any_instance_of(ActiveRecord::Base).to_not receive(method_names)
           end


### PR DESCRIPTION
Instead of work area level modules sitting above application concepts
in the module namespace, I'm switching that.

It keeps similar application concerns closer together.