### PR TITLE
Removing etd_reviewer permission to action

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
@@ -204,7 +204,7 @@ module Sipity
                 ],[
                   ['under_advisor_review'],
                   ['advisor_requests_change'],
-                  ['etd_reviewer', 'advisor']
+                  ['advisor']
                 ],[
                   ['under_grad_school_review'],
                   ['grad_school_requests_change', 'grad_school_signoff'],


### PR DESCRIPTION
Given that the etd_review can request change on behalf of someone,
we no longer need to give the ETD Reviewer permission to submit an
Advisor Requests Change form.

Verified via the graph generated from the state machine.