### PR TITLE
Updating how interfaces are guarded

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -31,8 +31,19 @@ module Sipity
 
     # The object did not implement the expected interface.
     class InterfaceExpectationError < RuntimeError
-      def initialize(object:, expectation:)
-        super("Expected #{object} to implement ##{expectation}")
+      def initialize(object:, expectations:)
+        self.expectations = expectations
+        super("Expected #{object} to implement #{expected_methods}")
+      end
+
+      private
+
+      def expected_methods
+        @expectations.map { |e| "##{e}" }.inspect
+      end
+
+      def expectations=(input)
+        @expectations = Array.wrap(input)
       end
     end
 

--- a/app/services/sipity/guard_interface_expectation.rb
+++ b/app/services/sipity/guard_interface_expectation.rb
@@ -4,10 +4,12 @@ module Sipity
     private
 
     def guard_interface_expectation!(input, *expectations, include_all: false)
+      missing_methods = []
       expectations.each do |expectation|
         next if input.respond_to?(expectation, include_all)
-        fail(Exceptions::InterfaceExpectationError, object: input, expectation: expectation)
+        missing_methods << expectation
       end
+      fail(Exceptions::InterfaceExpectationError, object: input, expectations: missing_methods) if missing_methods.present?
     end
   end
 end

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -30,7 +30,7 @@ module Sipity
     end
 
     RSpec.describe InterfaceExpectationError do
-      subject { described_class.new(object: 'hello', expectation: :fly) }
+      subject { described_class.new(object: 'hello', expectations: :fly) }
       its(:message) { should be_a(String) }
     end
 


### PR DESCRIPTION
Instead of failing early, I'm collecting all of the interface methods
that the object did not respond to then raising an exception that
includes all of that information.