### PR TITLE
Freeing up RAM by not requiring all mime types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
+# Free 20% RAM by not loading ALL mime-types
+gem 'mime-types', '~> 2.6.1', require: 'mime/types/columnar'
 gem 'rails', '~> 4.2'
 
 gem 'airbrake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,7 @@ GEM
       rack-contrib (~> 1.1)
       railties (>= 3.0.0, < 5.0.0)
     method_source (0.8.2)
-    mime-types (2.5)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
     multi_json (1.11.0)
@@ -573,6 +573,7 @@ DEPENDENCIES
   launchy
   letter_opener
   meta_request
+  mime-types (~> 2.6.1)
   mysql2
   noids_client!
   poltergeist


### PR DESCRIPTION
Yes, twitter as a source for this action:

https://twitter.com/schneems/status/603227060199272448

However, the underlying Issues can be found:

* https://github.com/mime-types/ruby-mime-types/issues/83
* https://github.com/mikel/mail/pull/829