### PR TITLE
UX improvments

### DIFF
--- a/app/assets/javascripts/sipity/redactor_field.js.coffee
+++ b/app/assets/javascripts/sipity/redactor_field.js.coffee
@@ -1,4 +1,16 @@
-class RedactorField
+class RedactorTextInput
+  constructor: (@fieldElement) ->
+    if @fieldElement.length > 0
+      @setupField()
+
+  setupField: ->
+    @fieldElement.redactor({
+      buttonSource: true
+      focus: true
+      buttons: ['bold', 'italic']
+    })
+
+class RedactorTextArea
   constructor: (@fieldElement) ->
     if @fieldElement.length > 0
       @setupField()
@@ -13,13 +25,19 @@ class RedactorField
 
 jQuery ($) ->
 
-  setupRedactor = () ->
-    field = $(".sipity_redactor")
+  setupRedactorTextInputs = () ->
+    field = $(".redactor-input")
     if field.size() > 0
-      new RedactorField(field)
+      new RedactorTextInput(field)
+
+  setupRedactorTextAreas = () ->
+    field = $(".redactor-area")
+    if field.size() > 0
+      new RedactorTextArea(field)
 
   ready = ->
-    setupRedactor()
+    setupRedactorTextInputs()
+    setupRedactorTextAreas()
 
   $(document).ready(ready)
   $(document).on('page:load', ready)

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -116,6 +116,9 @@ section {
 .btn-primary strong,
 .panel-primary .panel-title b {
   color: $text-highlight-color;
+  font-variant: small-caps;
+  letter-spacing: .08em;
+  text-transform: lowercase;
 }
 
 .work-show.page-header {

--- a/app/assets/stylesheets/modules/_panel.css.scss
+++ b/app/assets/stylesheets/modules/_panel.css.scss
@@ -16,7 +16,6 @@
     }
   }
 
-
   .panel-body {
     overflow: auto;
     width: 100%;
@@ -36,22 +35,18 @@
 }
 
 // Grid of panels
+.panel-tiles .panel {
+  border: none;
+  box-shadow: none;
+  //box-shadow: 0 0 0 transparent;
+
+  .panel-body {
+    padding: 2px 2px 30px;
+  }
+}
+
 @media only screen and (min-width: 550px) {
-  .panel-tiles {
-    align-items: stretch;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    margin: 0 auto;
-    max-width: 100%;
-  }
-
   .panel-tiles .panel {
-    display: flex;
-    flex: 0 0 49%;
-  }
-
-  .panel-tiles .panel:nth-child(odd) {
-    margin-right: 2%;
+    max-width: 60%;
   }
 }

--- a/app/assets/stylesheets/modules/_panel.css.scss
+++ b/app/assets/stylesheets/modules/_panel.css.scss
@@ -36,7 +36,7 @@
 
 // Grid of panels
 .panel-tiles .panel {
-  border: none;
+  border: 0;
   box-shadow: none;
   //box-shadow: 0 0 0 transparent;
 

--- a/app/assets/stylesheets/modules/_panel.css.scss
+++ b/app/assets/stylesheets/modules/_panel.css.scss
@@ -41,7 +41,7 @@
   //box-shadow: 0 0 0 transparent;
 
   .panel-body {
-    padding: 2px 2px 30px;
+    padding: 6px 2px 10px;
   }
 }
 

--- a/app/assets/stylesheets/redactor.css
+++ b/app/assets/stylesheets/redactor.css
@@ -102,7 +102,7 @@ body .redactor-box-fullscreen {
   position: relative;
   overflow: auto;
   margin: 0 !important;
-  padding: 20px;
+  padding: 10px 20px 5px;
   outline: none;
   white-space: normal;
   border: 1px solid #eee;

--- a/app/views/sipity/_form_panel.html.erb
+++ b/app/views/sipity/_form_panel.html.erb
@@ -3,7 +3,7 @@
 <fieldset class="<%= dom_class(object, name) %> panel <%= "panel-#{theme}" %>">
   <legend class="panel-heading">
     <%# TODO: make the translation generic e.g. based on the action %>
-    <%= content_tag :h3, object.translate(name, scope: 'panel_heading'), class: 'panel-title' %>
+    <%= content_tag :h3, object.translate(name, scope: 'panel_headings'), class: 'panel-title' %>
   </legend>
   <div class="panel-body">
     <%= yield %>

--- a/app/views/sipity/controllers/submission_windows/etd/start_a_submission.html.erb
+++ b/app/views/sipity/controllers/submission_windows/etd/start_a_submission.html.erb
@@ -3,7 +3,7 @@
   <%= f.error :base, error_method: :to_sentence %>
   <div class="panel-tiles">
     <%= render(layout: 'sipity/form_panel', locals: { name: 'title', theme: :primary, object: view_object }) do %>
-      <%= f.input :title, as: :text, input_html: { class: 'sipity_redactor form-control' }, label: false %>
+      <%= f.input :title, as: :text, input_html: { class: 'redactor-input form-control' }, label: false %>
     <% end %>
     <%= render(layout: 'sipity/form_panel', locals: { name: 'work_type', theme: :primary, object: view_object }) do %>
       <%= f.input :work_type, as: :select, collection: view_object.work_types_for_select, input_html: { class: 'form-control' }, label: false %>

--- a/app/views/sipity/controllers/submission_windows/etd/start_a_submission.html.erb
+++ b/app/views/sipity/controllers/submission_windows/etd/start_a_submission.html.erb
@@ -2,20 +2,20 @@
   <%= f.error_notification %>
   <%= f.error :base, error_method: :to_sentence %>
   <div class="panel-tiles">
-    <%= render(layout: 'sipity/form_panel', locals: { name: 'attributes', theme: :primary, object: view_object }) do %>
-      <%= f.input :title, as: :text, input_html: { class: 'sipity_redactor form-control' } %>
+    <%= render(layout: 'sipity/form_panel', locals: { name: 'title', theme: :primary, object: view_object }) do %>
+      <%= f.input :title, as: :text, input_html: { class: 'sipity_redactor form-control' }, label: false %>
     <% end %>
     <%= render(layout: 'sipity/form_panel', locals: { name: 'work_type', theme: :primary, object: view_object }) do %>
-      <%= f.input :work_type, as: :select, collection: view_object.work_types_for_select, input_html: { class: 'form-control' } %>
+      <%= f.input :work_type, as: :select, collection: view_object.work_types_for_select, input_html: { class: 'form-control' }, label: false %>
     <% end %>
     <%= render(layout: 'sipity/form_panel', locals: { name: 'work_publication_strategy', theme: :primary, object: view_object }) do %>
-      <%= f.input :work_publication_strategy, as: :radio_buttons, collection: view_object.work_publication_strategies_for_select %>
+      <%= f.input :work_publication_strategy, as: :radio_buttons, collection: view_object.work_publication_strategies_for_select, label: false %>
     <% end %>
     <%= render(layout: 'sipity/form_panel', locals: { name: 'work_patent_strategy', theme: :primary, object: view_object }) do %>
-      <%= f.input :work_patent_strategy, as: :radio_buttons, collection: view_object.work_patent_strategies_for_select %>
+      <%= f.input :work_patent_strategy, as: :radio_buttons, collection: view_object.work_patent_strategies_for_select, label: false %>
     <% end %>
     <%= render(layout: 'sipity/form_panel', locals: { name: 'access_rights_answer', theme: :primary, object: view_object }) do %>
-      <%= f.input :access_rights_answer, as: :radio_buttons, collection: view_object.access_rights_answer_for_select %>
+      <%= f.input :access_rights_answer, as: :radio_buttons, collection: view_object.access_rights_answer_for_select, label: false %>
     <% end %>
   </div>
   <div class="action-pane">

--- a/app/views/sipity/controllers/submission_windows/ulra/start_a_submission.html.erb
+++ b/app/views/sipity/controllers/submission_windows/ulra/start_a_submission.html.erb
@@ -3,7 +3,7 @@
   <%= f.error :base, error_method: :to_sentence %>
   <div class="panel-tiles">
     <%= render(layout: 'sipity/form_panel', locals: { name: 'attributes', theme: :info, object: view_object }) do %>
-      <%= f.input :title, as: :text, input_html: { class: 'sipity_redactor form-control' } %>
+      <%= f.input :title, as: :text, input_html: { class: 'redactor-input form-control' } %>
     <% end %>
     <%= render(layout: 'sipity/form_panel', locals: { name: 'work_publication_strategy', theme: :info, object: view_object }) do %>
       <%= f.input :work_publication_strategy, as: :radio_buttons, collection: view_object.work_publication_strategies_for_select %>

--- a/app/views/sipity/controllers/work_submissions/etd/describe.html.erb
+++ b/app/views/sipity/controllers/work_submissions/etd/describe.html.erb
@@ -19,9 +19,9 @@
       <%= content_tag :p, t("sipity/decorators/entitiy_enrichments.panels.abstract.hint"), class: 'panel-hint' %>
       <%= f.error_notification %>
       <%= f.error :base, error_method: :to_sentence %>
-      <%= f.input :title, as: :text, input_html: { class: 'sipity_redactor form-control' }  %>
-      <%= f.input :abstract, as: :text, input_html: { class: 'sipity_redactor form-control', rows: 5 } %>
-      <%= f.input :alternate_title, as: :text, input_html: { class: 'sipity_redactor form-control' }  %>
+      <%= f.input :title, as: :text, input_html: { class: 'redactor-input form-control' }  %>
+      <%= f.input :abstract, as: :text, input_html: { class: 'redactor-area form-control', rows: 5 } %>
+      <%= f.input :alternate_title, as: :text, input_html: { class: 'redactor-input form-control' }  %>
     </fieldset>
 
     <div class="panel-footer action-pane">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,15 +210,15 @@ en:
         title_html: "Project Evaluation"
   panel_headings:
     access_rights_answer:
-      label: 'Who can <b>see</b> the completed submission?'
-    attributes:
+      label: 'Who should have <b>access</b> to this work after it is deposited?'
+    title:
       label: 'What is the <b>title</b> of your work?'
     work_publication_strategy:
-      label: 'Do you have <b>publishing</b> plans?'
+      label: 'Do you plan to <b>publish</b> this work?'
     work_patent_strategy:
-      label: 'Are there plans to <b>patent</b>?'
+      label: 'Do you plan to <b>patent</b> this work?'
     work_type:
-      label: 'What <b>kind</b> of work is this?'
+      label: 'What <b>type</b> of work is this?'
   processing_actions:
     publishing_and_patenting_intent:
       label: "Tell us about your <b>publishing</b> and <b>patenting</b> intent for this %{work_type}"
@@ -326,28 +326,28 @@ en:
       defaults:
         new:
           access_rights_answer:
-            open_access_html: '<b>Open Access:</b> freely viewable to the world'
-            restricted_access_html: '<b>Restricted:</b> only specific groups or people can see it'
-            private_access_html: '<b>Private:</b> Only viewable to the depositor and content reviewers'
-            access_changes_over_time_html: 'It will <b>change over time</b> e.g. <i>Private</i> now and <i>Open Access</i> in 3 years.'
+            open_access_html: '<b>Public</b> — Freely viewable to the world'
+            restricted_access_html: '<b>Restricted</b> — Only groups you specifiy have access'
+            private_access_html: '<b>Private</b> — Only you and the reviewers you designate'
+            access_changes_over_time_html: '<b>Embargoed</b> — will <i>Private</i> now but <i>Public</i> after 3 years'
         work_publication_strategy:
-          will_not_publish_html: 'I have <i>no plans to publish</i> this work in the future.'
-          already_published_html: 'I have <i>already published</i> portions of this work.'
-          going_to_publish_html: 'I am <i>planning on publishing</i> this work in the future.'
-          do_not_know: 'I don’t know.'
+          going_to_publish: 'Yes'
+          will_not_publish: 'No'
+          already_published_html: 'I have <i>already published</i> portions of this work'
+          do_not_know: 'Undecided'
         work_patent_strategy:
-          will_not_patent_html: 'There are <i>no plans to patent</i> this work.'
-          already_patented_html: 'Portions of this work have <i>already been patented</i>.'
-          going_to_patent_html: 'There are <i>plans to patent</i> this work in the future.'
-          do_not_know: 'I don’t know.'
+          going_to_patent: 'Yes'
+          will_not_patent: 'No'
+          already_patented_html: 'Portions of this work have <i>already been patented</i>'
+          do_not_know: 'Undecided'
         work_type:
           doctoral_dissertation: 'Doctoral Dissertation'
           master_thesis: "Master’s Thesis"
         access_rights_answer:
-          open_access_html: '<b>Open Access:</b> freely viewable to the world'
-          restricted_access_html: '<b>Restricted:</b> only specific groups or people can see it'
-          private_access_html: '<b>Private:</b> Only viewable to the depositor and content reviewers'
-          access_changes_over_time_html: 'It will <b>change over time</b> e.g. <i>Private</i> now and <i>Open Access</i> in 3 years.'
+          open_access_html: '<b>Public</b> — Freely viewable to the world'
+          restricted_access_html: '<b>Restricted</b> — Only groups you specifiy have access'
+          private_access_html: '<b>Private</b> — Only you and the reviewers you designate'
+          access_changes_over_time_html: '<b>Embargoed</b> — <i>Private</i> now but <i>Public</i> after 3 years'
     labels:
       doi:
         identifier: 'Existing DOI'

--- a/db/seeds/controlled_vocabularies_seeds.rb
+++ b/db/seeds/controlled_vocabularies_seeds.rb
@@ -21,13 +21,13 @@ $stdout.puts 'Creating controlled vocabularies'
   ['award_category', 'Senior/Honors Thesis'],
   ['award_category', '2000–4000 Level Papers'],
   ['award_category', '10000 Level Papers'],
-  [Sipity::Models::AdditionalAttribute::WORK_PATENT_STRATEGY, 'already_patented'],
-  [Sipity::Models::AdditionalAttribute::WORK_PATENT_STRATEGY, 'will_not_patent'],
   [Sipity::Models::AdditionalAttribute::WORK_PATENT_STRATEGY, 'going_to_patent'],
+  [Sipity::Models::AdditionalAttribute::WORK_PATENT_STRATEGY, 'will_not_patent'],
+  [Sipity::Models::AdditionalAttribute::WORK_PATENT_STRATEGY, 'already_patented'],
   [Sipity::Models::AdditionalAttribute::WORK_PATENT_STRATEGY, 'do_not_know'],
-  [Sipity::Models::AdditionalAttribute::WORK_PUBLICATION_STRATEGY, 'already_published'],
-  [Sipity::Models::AdditionalAttribute::WORK_PUBLICATION_STRATEGY, 'will_not_publish'],
   [Sipity::Models::AdditionalAttribute::WORK_PUBLICATION_STRATEGY, 'going_to_publish'],
+  [Sipity::Models::AdditionalAttribute::WORK_PUBLICATION_STRATEGY, 'will_not_publish'],
+  [Sipity::Models::AdditionalAttribute::WORK_PUBLICATION_STRATEGY, 'already_published'],
   [Sipity::Models::AdditionalAttribute::WORK_PUBLICATION_STRATEGY, 'do_not_know']
 ].each do |predicate_name, term_label, term_uri|
   Sipity::Models::SimpleControlledVocabulary.find_or_create_by!(


### PR DESCRIPTION
Implementing some of the feedback from [Randy](http://www.randalseanharrison.com/) on how best to clean up the initial submission page.

- Increased consistency of field labels; changed case of emphasised words to increase contrast
- Option text has been simplified for publishing and patent concerns
- Redundant labeling has been removed
- Grid of panels has been abandoned to improve eye-tracking and content flow
- Removed Redactor controls that should not apply to simple text fields

NOTE: I attempted to change the _order_ of the WORK_PATENT_STRATEGY and WORK_PUBLICATION_STRATEGY options by editing the seeds. I assume we will need to do something extra to make this work in production.