### PR TITLE
Adding primary key to sipity_work_submissions

### DIFF
--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -13,7 +13,7 @@ module Sipity
       has_many :access_rights, as: :entity, dependent: :destroy
       has_many :transient_answers, as: :entity, dependent: :destroy
       has_many :event_logs, as: :entity, class_name: 'Sipity::Models::EventLog'
-      has_one :work_submission
+      has_one :work_submission, dependent: :destroy
 
       delegate :submission_window, :work_area, to: :work_submission, allow_nil: true
 

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -60,9 +60,6 @@ module Sipity
       # This may look ridiculous, but I'd like to isolate the destruction so
       # that I can associate any other actions with it (i.e. logging, emails, etc.)
       def destroy_a_work(work:)
-        # Because I could not get the dependent: :destroy imperative working
-        # on the has_one relationship.
-        Models::WorkSubmission.where(work: work).destroy
         work.destroy
       end
 

--- a/db/migrate/20150610170005_adding_primary_key_to_work_submissions.rb
+++ b/db/migrate/20150610170005_adding_primary_key_to_work_submissions.rb
@@ -1,0 +1,5 @@
+class AddingPrimaryKeyToWorkSubmissions < ActiveRecord::Migration
+  def change
+    add_column :sipity_work_submissions, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150528195849) do
+ActiveRecord::Schema.define(version: 20150610170005) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.string   "entity_id",         limit: 32,  null: false
@@ -404,7 +404,7 @@ ActiveRecord::Schema.define(version: 20150528195849) do
   add_index "sipity_work_areas", ["name"], name: "index_sipity_work_areas_on_name", unique: true, using: :btree
   add_index "sipity_work_areas", ["slug"], name: "index_sipity_work_areas_on_slug", unique: true, using: :btree
 
-  create_table "sipity_work_submissions", id: false, force: :cascade do |t|
+  create_table "sipity_work_submissions", force: :cascade do |t|
     t.integer  "work_area_id",         limit: 4,   null: false
     t.integer  "submission_window_id", limit: 4,   null: false
     t.string   "work_id",              limit: 255, null: false

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -12,7 +12,6 @@ module Sipity
         let(:work) { Models::Work.new(id: '1') }
         it 'will destroy the work in question' do
           work.save! # so it is persisted
-          expect(Models::WorkSubmission).to receive_message_chain(:where, :destroy)
           expect { test_repository.destroy_a_work(work: work) }.
             to change { Models::Work.count }.by(-1)
           expect { work.reload }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
Prior to this commit the following Ruby code threw an exception:

```ruby
> Sipity::Models::WorkSubmission.where(work: work).destroy_all
=> !! #<ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column
   'sipity_work_submissions.' in 'where clause': DELETE FROM
   `sipity_work_submissions` WHERE `sipity_work_submissions`.`` =
   NULL>
```

This is because I didn't have a primary key associated with the table.
I could've opted to use the more appropriate composite_primary_keys
gem, however that adds lots of additional code for a very small gain.
Yes, it would be better to have this be a composite key, but I don't
need to add hundreds of lines of code for this edge case.

https://github.com/composite-primary-keys/composite_primary_keys