### PR TITLE
Housekeeping

### DIFF
--- a/app/policies/sipity/policies/work_policy.rb
+++ b/app/policies/sipity/policies/work_policy.rb
@@ -19,45 +19,6 @@ module Sipity
       def method_missing(method_name, *)
         Processing::ProcessingEntityPolicy.call(user: user, entity: entity, action_to_authorize: method_name)
       end
-
-      # Responsible for building a scoped query to find a collection of
-      # Model::Work objects for the given user.
-      #
-      # Responsible for answering the following:
-      #
-      # Given a user and an array of how the user could be acting, what are all the entities
-      # within the scope that I can "see"
-      #
-      # @see [Pundit gem scopes](https://github.com/elabs/pundit#scopes) for
-      #   more information regarding the Scope interface.
-      class Scope
-        def self.resolve(options = {})
-          user = options.fetch(:user)
-          scope = options.fetch(:scope) { Models::Work }
-          new(user, scope, options.slice(:acting_as, :repository)).resolve(options)
-        end
-
-        def initialize(user, scope, options = {})
-          self.user = user
-          self.scope = scope
-          self.repository = options.fetch(:repository) { default_repository }
-        end
-
-        def resolve(options = {})
-          repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
-            user: user,
-            proxy_for_type: scope, filter: { processing_state: options[:processing_state] }
-          )
-        end
-
-        private
-
-        attr_accessor :user, :scope, :repository
-
-        def default_repository
-          QueryRepository.new
-        end
-      end
     end
   end
 end

--- a/app/repositories/sipity/commands/additional_attribute_commands.rb
+++ b/app/repositories/sipity/commands/additional_attribute_commands.rb
@@ -9,25 +9,18 @@ module Sipity
         create_work_attribute_values!(work: work, key: key, values: (input_values - existing_values))
         destroy_work_attribute_values!(work: work, key: key, values: (existing_values - input_values))
       end
-      module_function :update_work_attribute_values!
-      public :update_work_attribute_values!
 
       def create_work_attribute_values!(work:, key:, values:)
         Array.wrap(values).each do |value|
           Models::AdditionalAttribute.create!(work: work, key: key, value: value) if value.present?
         end
       end
-      module_function :create_work_attribute_values!
-      public :create_work_attribute_values!
 
       def destroy_work_attribute_values!(work:, key:, values:)
         values_to_destroy = Array.wrap(values)
         return true unless values_to_destroy.present?
         Models::AdditionalAttribute.where(work: work, key: key, value: values_to_destroy).destroy_all
       end
-
-      module_function :destroy_work_attribute_values!
-      public :destroy_work_attribute_values!
     end
   end
 end

--- a/app/repositories/sipity/commands/additional_attribute_commands.rb
+++ b/app/repositories/sipity/commands/additional_attribute_commands.rb
@@ -3,15 +3,6 @@ module Sipity
   module Commands
     # Commands
     module AdditionalAttributeCommands
-      def update_work_publication_date!(work:, publication_date:)
-        return true unless publication_date.present?
-        update_work_attribute_values!(
-          work: work, key: Models::AdditionalAttribute::PUBLICATION_DATE_PREDICATE_NAME, values: publication_date
-        )
-      end
-      module_function :update_work_publication_date!
-      public :update_work_publication_date!
-
       def update_work_attribute_values!(work:, key:, values:)
         input_values = Array.wrap(values)
         existing_values = Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: key)

--- a/app/repositories/sipity/commands/additional_attribute_commands.rb
+++ b/app/repositories/sipity/commands/additional_attribute_commands.rb
@@ -3,9 +3,9 @@ module Sipity
   module Commands
     # Commands
     module AdditionalAttributeCommands
-      def update_work_attribute_values!(work:, key:, values:)
+      def update_work_attribute_values!(work:, key:, values:, repository: self)
         input_values = Array.wrap(values)
-        existing_values = Queries::AdditionalAttributeQueries.work_attribute_values_for(work: work, key: key)
+        existing_values = repository.work_attribute_values_for(work: work, key: key)
         create_work_attribute_values!(work: work, key: key, values: (input_values - existing_values))
         destroy_work_attribute_values!(work: work, key: key, values: (existing_values - input_values))
       end

--- a/app/repositories/sipity/commands/notification_commands.rb
+++ b/app/repositories/sipity/commands/notification_commands.rb
@@ -11,9 +11,9 @@ module Sipity
       #
       # @see Parameters::NotificationContextParameter
       # @see Services::DeliverFormSubmissionNotificationsService
-      def deliver_notification_for(scope:, the_thing:, **keywords)
+      def deliver_notification_for(scope:, the_thing:, repository: self, **keywords)
         notification_context = Parameters::NotificationContextParameter.new(scope: scope, the_thing: the_thing, **keywords)
-        Services::DeliverFormSubmissionNotificationsService.call(notification_context: notification_context, repository: self)
+        Services::DeliverFormSubmissionNotificationsService.call(notification_context: notification_context, repository: repository)
       end
 
       alias_method :deliver_form_submission_notifications_for, :deliver_notification_for
@@ -27,21 +27,21 @@ module Sipity
       # @option roles_for_recipients [Array<String>] :cc role (names) to use to find associated emails to send as :cc
       # @option roles_for_recipients [Array<String>] :bcc role (names) to use to find associated emails to send as :to
       # @return [void]
-      def send_notification_for_entity_trigger(notification:, entity:, **roles_for_recipients)
+      def send_notification_for_entity_trigger(notification:, entity:, repository: self, **roles_for_recipients)
         Services::Notifier.deliver(
           notification: notification,
           entity: entity,
-          to: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:acting_as]),
-          cc: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:cc]),
-          bcc: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:bcc])
+          to: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:acting_as], repository: repository),
+          cc: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:cc], repository: repository),
+          bcc: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:bcc], repository: repository)
         )
       end
 
       private
 
-      def convert_recipient_roles_to_email(entity:, roles:)
+      def convert_recipient_roles_to_email(entity:, roles:, repository: self)
         return [] unless roles.present?
-        Queries::ProcessingQueries.user_emails_for_entity_and_roles(entity: entity, roles: roles)
+        repository.user_emails_for_entity_and_roles(entity: entity, roles: roles)
       end
     end
   end

--- a/app/repositories/sipity/commands/notification_commands.rb
+++ b/app/repositories/sipity/commands/notification_commands.rb
@@ -15,31 +15,6 @@ module Sipity
         notification_context = Parameters::NotificationContextParameter.new(scope: scope, the_thing: the_thing, **keywords)
         Services::DeliverFormSubmissionNotificationsService.call(notification_context: notification_context, repository: repository)
       end
-
-      # Responsible for delivering notifications (i.e., email)
-      # @param notification [String] Name of the notification
-      # @param roles_for_recipients [Hash]
-      # @param entity [String] The entity that is the "subject" of the notification
-      # @option roles_for_recipients [Array<String>] :acting_as
-      # @option roles_for_recipients [Array<String>] :cc role (names) to use to find associated emails to send as :cc
-      # @option roles_for_recipients [Array<String>] :bcc role (names) to use to find associated emails to send as :to
-      # @return [void]
-      def send_notification_for_entity_trigger(notification:, entity:, repository: self, **roles_for_recipients)
-        Services::Notifier.deliver(
-          notification: notification,
-          entity: entity,
-          to: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:acting_as], repository: repository),
-          cc: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:cc], repository: repository),
-          bcc: convert_recipient_roles_to_email(entity: entity, roles: roles_for_recipients[:bcc], repository: repository)
-        )
-      end
-
-      private
-
-      def convert_recipient_roles_to_email(entity:, roles:, repository: self)
-        return [] unless roles.present?
-        repository.user_emails_for_entity_and_roles(entity: entity, roles: roles)
-      end
     end
   end
 end

--- a/app/repositories/sipity/commands/notification_commands.rb
+++ b/app/repositories/sipity/commands/notification_commands.rb
@@ -16,9 +16,6 @@ module Sipity
         Services::DeliverFormSubmissionNotificationsService.call(notification_context: notification_context, repository: repository)
       end
 
-      alias_method :deliver_form_submission_notifications_for, :deliver_notification_for
-      deprecate :deliver_form_submission_notifications_for
-
       # Responsible for delivering notifications (i.e., email)
       # @param notification [String] Name of the notification
       # @param roles_for_recipients [Hash]

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -24,14 +24,10 @@ module Sipity
           grant_processing_permission_for!(entity: entity, actor: an_actor, role: acting_as)
         end
       end
-      module_function :grant_permission_for!
-      public :grant_permission_for!
 
       def grant_processing_permission_for!(entity:, actor:, role:)
         Services::GrantProcessingPermission.call(entity: entity, actor: actor, role: role)
       end
-      module_function :grant_processing_permission_for!
-      public :grant_processing_permission_for!
     end
   end
 end

--- a/app/repositories/sipity/queries/additional_attribute_queries.rb
+++ b/app/repositories/sipity/queries/additional_attribute_queries.rb
@@ -7,16 +7,12 @@ module Sipity
       def work_attribute_values_for(work:, key:)
         Models::AdditionalAttribute.where(work: work, key: key).pluck(:value)
       end
-      module_function :work_attribute_values_for
-      public :work_attribute_values_for
 
       def work_attribute_key_value_pairs(work:, keys: [])
         query = Models::AdditionalAttribute.where(work: work).order(:work_id, :key)
         query = query.where(key: keys) if keys.present?
         query.pluck(:key, :value)
       end
-      module_function :work_attribute_key_value_pairs
-      public :work_attribute_key_value_pairs
     end
   end
 end

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -614,14 +614,10 @@ module Sipity
           or(user_table[:id].in(sub_query_for_user_via_group))
         )
       end
-      module_function :scope_users_for_entity_and_roles
-      public :scope_users_for_entity_and_roles
 
       def user_emails_for_entity_and_roles(entity:, roles:)
         scope_users_for_entity_and_roles(entity: entity, roles: roles).pluck(:email)
       end
-      module_function :user_emails_for_entity_and_roles
-      public :user_emails_for_entity_and_roles
 
       # @api public
       #

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -10,24 +10,27 @@ module Sipity
         Models::Work.includes(:processing_entity, work_submission: [:work_area, :submission_window]).find(id)
       end
 
-      def build_dashboard_view(user:, filter: {})
-        Decorators::DashboardView.new(repository: self, user: user, filter: filter)
+      def build_dashboard_view(user:, filter: {}, repository: self)
+        Decorators::DashboardView.new(repository: repository, user: user, filter: filter)
       end
 
       # TODO: Rename this method; Keeping it separate for now.
-      def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {})
+      def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {}, repository: self)
         # Leveraging an obvious inflection point, namely each work area may well
         # have its own form module.
         Forms::WorkSubmissions.build_the_form(
           work: work,
           processing_action_name: processing_action_name,
           attributes: attributes,
-          repository: self
+          repository: repository
         )
       end
 
-      def find_works_for(user:, processing_state: nil)
-        Policies::WorkPolicy::Scope.resolve(user: user, scope: Models::Work, processing_state: processing_state)
+      # @todo: Is there a Parameter Object that makes more sense?
+      def find_works_for(user:, processing_state: nil, repository: self)
+        repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
+          user: user, proxy_for_type: Models::Work, filter: { processing_state: processing_state }
+        )
       end
 
       def work_access_right_codes(work:)

--- a/lib/tasks/sipity.rake
+++ b/lib/tasks/sipity.rake
@@ -94,6 +94,7 @@ namespace :sipity do
       name = type.pluralize.capitalize
       ::STATS_DIRECTORIES << [name, dir] unless ::STATS_DIRECTORIES.find { |array| array[0] == name }
     end
+    ::STATS_DIRECTORIES.reject! { |name, dir| dir =~ /javascripts\/?/ }
     ::STATS_DIRECTORIES.sort!
   end
 end

--- a/spec/policies/sipity/policies/work_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_policy_spec.rb
@@ -30,23 +30,5 @@ module Sipity
         end
       end
     end
-
-    RSpec.describe WorkPolicy::Scope do
-      let(:user) { User.new(id: 1234) }
-      let(:entity) { Models::Work.new(id: 5678) }
-      let(:repository) { QueryRepository.new }
-      subject { described_class.new(user, entity.class) }
-      its(:default_repository) { should respond_to :scope_proxied_objects_for_the_user_and_proxy_for_type }
-      context '.resolve' do
-        it 'will use the #scope_proxied_objects_for_the_user_and_proxy_for_type' do
-          expect(repository).to receive(:scope_proxied_objects_for_the_user_and_proxy_for_type).and_call_original
-          described_class.resolve(user: user, repository: repository)
-        end
-
-        it 'will handle a processing_state' do
-          described_class.resolve(user: user, repository: repository, processing_state: 'new').first
-        end
-      end
-    end
   end
 end

--- a/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
+++ b/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
@@ -12,20 +12,6 @@ module Sipity
 
       subject { test_repository }
 
-      context '#update_work_publication_date!' do
-        it 'will not attempt an update if a nil value is given' do
-          expect(test_repository).to_not receive(:update_work_attribute_values!)
-          test_repository.update_work_publication_date!(work: work, publication_date: nil)
-        end
-
-        it 'will update if a non-nil value is given' do
-          publication_date = double
-          expect(test_repository).to receive(:update_work_attribute_values!).
-            with(work: work, values: publication_date, key: Models::AdditionalAttribute::PUBLICATION_DATE_PREDICATE_NAME)
-          test_repository.update_work_publication_date!(work: work, publication_date: publication_date)
-        end
-      end
-
       it 'will create a key/value pair if the value does not exist' do
         expect { subject.update_work_attribute_values!(work: work, key: key, values: 'abc') }.
           to change { subject.work_attribute_values_for(work: work, key: key) }.from([]).to(['abc'])

--- a/spec/repositories/sipity/commands/notification_commands_spec.rb
+++ b/spec/repositories/sipity/commands/notification_commands_spec.rb
@@ -10,21 +10,6 @@ module Sipity
           test_repository.deliver_notification_for(parameters)
         end
       end
-      context '#send_notification_for_entity_trigger' do
-        let(:entity) { double }
-        let(:notification) { double }
-        let(:acting_as) { double }
-        let(:emails) { ['test@hello.com'] }
-        let(:repository) { QueryRepositoryInterface.new }
-
-        it 'is a placeholder' do
-          expect(repository).to receive(:user_emails_for_entity_and_roles).and_return(emails)
-          allow(Services::Notifier).to receive(:deliver).with(notification: notification, to: emails, entity: entity, bcc: [], cc: [])
-          test_repository.send_notification_for_entity_trigger(
-            notification: notification, entity: entity, repository: repository, acting_as: acting_as
-          )
-        end
-      end
     end
   end
 end

--- a/spec/repositories/sipity/commands/notification_commands_spec.rb
+++ b/spec/repositories/sipity/commands/notification_commands_spec.rb
@@ -15,11 +15,14 @@ module Sipity
         let(:notification) { double }
         let(:acting_as) { double }
         let(:emails) { ['test@hello.com'] }
+        let(:repository) { QueryRepositoryInterface.new }
 
         it 'is a placeholder' do
-          allow(Queries::ProcessingQueries).to receive(:user_emails_for_entity_and_roles).and_return(emails)
+          expect(repository).to receive(:user_emails_for_entity_and_roles).and_return(emails)
           allow(Services::Notifier).to receive(:deliver).with(notification: notification, to: emails, entity: entity, bcc: [], cc: [])
-          test_repository.send_notification_for_entity_trigger(notification: notification, entity: entity, acting_as: acting_as)
+          test_repository.send_notification_for_entity_trigger(
+            notification: notification, entity: entity, repository: repository, acting_as: acting_as
+          )
         end
       end
     end

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -4,10 +4,15 @@ module Sipity
   module Queries
     RSpec.describe WorkQueries, type: :isolated_repository_module do
       context '#find_works_for' do
-        it 'will delegate to Policies::WorkPolicy::Scope' do
-          user = double
-          expect(Policies::WorkPolicy::Scope).to receive(:resolve)
-          test_repository.find_works_for(user: user)
+        let(:repository) { QueryRepositoryInterface.new }
+        let(:user) { double }
+        let(:processing_state) { double }
+
+        it 'will leverage the underlying scope_proxied_objects_for_the_user_and_proxy_for_type method' do
+          expect(repository).to receive(:scope_proxied_objects_for_the_user_and_proxy_for_type).
+            with(user: user, proxy_for_type: Models::Work, filter: { processing_state: processing_state }).
+            and_call_original
+          test_repository.find_works_for(user: user, processing_state: processing_state, repository: repository)
         end
       end
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -26,7 +26,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def assign_collaborators_to(work:, collaborators:)
+    def assign_collaborators_to(work:, collaborators:, repository: self)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -70,7 +70,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/notification_commands.rb
-    def convert_recipient_roles_to_email(entity:, roles:)
+    def convert_recipient_roles_to_email(entity:, roles:, repository: self)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -94,7 +94,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/notification_commands.rb
-    def deliver_notification_for(scope:, the_thing:, **keywords)
+    def deliver_notification_for(scope:, the_thing:, repository: self, **keywords)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -186,7 +186,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def manage_collaborators_for(work:, collaborators:)
+    def manage_collaborators_for(work:, collaborators:, repository: self)
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb
@@ -294,7 +294,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/notification_commands.rb
-    def send_notification_for_entity_trigger(notification:, entity:, **roles_for_recipients)
+    def send_notification_for_entity_trigger(notification:, entity:, repository: self, **roles_for_recipients)
     end
 
     # @see ./app/repositories/sipity/queries/event_log_queries.rb
@@ -318,7 +318,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
-    def update_work_attribute_values!(work:, key:, values:)
+    def update_work_attribute_values!(work:, key:, values:, repository: self)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -69,10 +69,6 @@ module Sipity
     def collaborators_that_have_taken_the_action_on_the_entity(entity:, actions:)
     end
 
-    # @see ./app/repositories/sipity/commands/notification_commands.rb
-    def convert_recipient_roles_to_email(entity:, roles:, repository: self)
-    end
-
     # @see ./app/repositories/sipity/commands/work_commands.rb
     def create_sipity_user_from(netid:, email: nil)
     end
@@ -291,10 +287,6 @@ module Sipity
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb
     def scope_users_for_entity_and_roles(entity:, roles:)
-    end
-
-    # @see ./app/repositories/sipity/commands/notification_commands.rb
-    def send_notification_for_entity_trigger(notification:, entity:, repository: self, **roles_for_recipients)
     end
 
     # @see ./app/repositories/sipity/queries/event_log_queries.rb

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -42,7 +42,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def build_dashboard_view(user:, filter: {})
+    def build_dashboard_view(user:, filter: {}, repository: self)
     end
 
     # @see ./app/repositories/sipity/queries/submission_window_queries.rb
@@ -54,7 +54,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {})
+    def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {}, repository: self)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -150,7 +150,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def find_works_for(user:, processing_state: nil)
+    def find_works_for(user:, processing_state: nil, repository: self)
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb
@@ -319,10 +319,6 @@ module Sipity
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def update_work_attribute_values!(work:, key:, values:)
-    end
-
-    # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
-    def update_work_publication_date!(work:, publication_date:)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -26,7 +26,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def build_dashboard_view(user:, filter: {})
+    def build_dashboard_view(user:, filter: {}, repository: self)
     end
 
     # @see ./app/repositories/sipity/queries/submission_window_queries.rb
@@ -38,7 +38,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {})
+    def build_work_submission_processing_action_form(work:, processing_action_name:, attributes: {}, repository: self)
     end
 
     # @see ./app/repositories/sipity/queries/collaborator_queries.rb
@@ -86,7 +86,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def find_works_for(user:, processing_state: nil)
+    def find_works_for(user:, processing_state: nil, repository: self)
     end
 
     # @see ./app/repositories/sipity/queries/simple_controlled_vocabulary_queries.rb


### PR DESCRIPTION
## Refactoring to allow repository injection

@426646c1947b1aaf7562f0b2393ca14299fc77a0

By removing a direct reference to a constant, I'm able to have a more
robust composition.

Also, in looking at Policies::WorkPolicy::Scope.resolve, it was only
used via this single method. That means, I am able to remove a layer
of indirection (and ultimately remove a class).

## Removing unused Scope class

@484e3aa12f2306ec9dded5b0b26501b3a87fead3

By leveraging dependency injection of a repository parameter for a
repository module, I'm able to get around the indirection of the Scope
object.

This methodology will also enable a removal of a long-standing module
function in a repository method.

## Removing unused method

@0a64b2059a5e66d2efa5efb48d44c82dc36aada8


## Removing module function declarations

@d860fc251dce42334da541043a7bc29d2044807f

These are not needed and create undue points of potention chaos.

## Removing usage of module function

@ea02b382a7696485459b837befee4878d66b153c

By using dependency injection, this works. It looks a bit funny in
that the repository object looks to not implement the method. However
it does (via composition of the repository).

## Removing Repository module_function usage

@ef6e4c90d255638c5da398f6000d29348babb9eb

These were crossing boundaries and creating harder coupling than was
necessary.

## Removing deprecated method

@a2677fe0fd4baa75e52f891c1504afb381570669

This was no longer needed so out the door it goes.

## Removing unused method

@56dad6b7bc0cbf82ce54afaaba39ca8339b0e44b
