### PR TITLE
Reducing chance of Airbrake swallowing exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,10 @@ source 'https://rubygems.org'
 gem 'mime-types', '~> 2.6.1', require: 'mime/types/columnar'
 gem 'rails', '~> 4.2'
 
-gem 'airbrake'
+# This is part of the v4.3.0 API
+# Once the following pull request is merged (or similar solution), then we
+# can hopefully use the Airbrake maintained gem. https://github.com/airbrake/airbrake/pull/397
+gem 'airbrake', github: 'jeremyf/airbrake'
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass'
 gem 'coffee-rails', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
     ezid-client (1.1.1)
 
 GIT
+  remote: git://github.com/jeremyf/airbrake.git
+  revision: 1e3c1c7c8ee9b2f7195243ac3e012f639b090171
+  specs:
+    airbrake (4.3.0)
+      builder
+      multi_json
+
+GIT
   remote: git://github.com/jeremyf/curly.git
   revision: 7209cb9e932f7cbd0839508b96cc979d61b19277
   branch: sipity-hack
@@ -90,9 +98,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.0)
-      builder
-      multi_json
     arel (6.0.0)
     ast (2.0.0)
     astrolabe (1.3.0)
@@ -529,7 +534,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake
+  airbrake!
   autoprefixer-rails
   better_errors
   binding_of_caller


### PR DESCRIPTION
For a POST request that included an Attachment, processed by dragonfly,
an exception was encountered in our application logic. That exception
was in turn caught and handled via Airbrake. As part of Airbrake's
cleanup, it attempted to send #collect to the attachment. The
attachment, however, was already closed so #collect failed and threw
an exception.

This thrown exception, IOError, in turn obliterated the original
exception that was thrown by our application. It should be noted
that the current work around is a fork of the v4.3.0..master work
of Airbrake. Once issue 396 is resolved and released in a gem, we
can go back to using the default Airbrake gem.

Related to markevans/dragonfly#271
Related to markevans/dragonfly#271
Related to airbrake/airbrake#397
Related to airbrake/airbrake#396