### PR TITLE
Adding a CommandLineContext for running tasks

### DIFF
--- a/app/runners/sipity/command_line_context.rb
+++ b/app/runners/sipity/command_line_context.rb
@@ -1,0 +1,42 @@
+require 'user'
+
+module Sipity
+  # Responsible for being a valid context for running a Sipity::Runner
+  #
+  #
+  # @example
+  #   context = Sipity::CommandLineContext.new(requested_by: a_user)
+  #   runner = Sipity::Runners::WorkSubmissionsRunner.new(context)
+  #   runner.run(work_id: 123)
+  #
+  # @param username [String]
+  # @param repository_strategy [#to_s] :query and :command are the two likely repositories
+  #
+  # @see Sipity::Runners
+  class CommandLineContext
+    def initialize(requested_by:, repository_strategy: default_repository_strategy)
+      self.requested_by = requested_by
+      self.repository_strategy = repository_strategy
+    end
+
+    attr_reader :repository, :requested_by
+    alias_method :current_user, :requested_by
+
+    private
+
+    # @todo When Cogitate is deployed switch from ConvertToProcessingActor
+    def requested_by=(input)
+      @requested_by = Conversions::ConvertToProcessingActor.call(input)
+    end
+
+    def repository_strategy=(input)
+      filename = "#{input.to_s.underscore}_repository"
+      require "sipity/#{filename}" unless defined?(Sipity.const_get(filename.classify))
+      @repository = Sipity.const_get(filename.classify).new
+    end
+
+    def default_repository_strategy
+      :command
+    end
+  end
+end

--- a/spec/runners/sipity/command_line_context_spec.rb
+++ b/spec/runners/sipity/command_line_context_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe Sipity::CommandLineContext do
+  let(:requested_by) { Sipity::Models::Processing::Actor.new }
+
+  subject { described_class.new(requested_by: requested_by, repository_strategy: :query) }
+
+  its(:default_repository_strategy) { should eq(:command) }
+  its(:current_user) { should eq(requested_by) }
+  its(:repository) { should be_a(Sipity::QueryRepository) }
+
+  it 'will fail to initialize with a :bogus repository strategy' do
+    expect { described_class.new(username: username, repository_strategy: :bogus) }.to raise_error(NameError)
+  end
+
+end


### PR DESCRIPTION
The Sipity::CommandLineContext is analogue to a Rails controller.
It implements the interface necessary for the require context of
a Sipity::Runners object. This is a work in progress in that there
might be an methods on the context that should be implemented.