### PR TITLE
Adding explicit require

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 require 'hesburgh/lib/controller_with_runner'
 
 # The foundational controller for this application

--- a/app/controllers/sipity/controllers/processing_action_composer.rb
+++ b/app/controllers/sipity/controllers/processing_action_composer.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Controllers
     # Responsible for composing collaborating behavior on the base controller.

--- a/app/data_generators/sipity/data_generators/permission_generator.rb
+++ b/app/data_generators/sipity/data_generators/permission_generator.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   # :nodoc:
   module DataGenerators

--- a/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module DataGenerators
     module WorkTypes

--- a/app/data_generators/sipity/data_generators/work_types/self_deposit_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/self_deposit_generator.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module DataGenerators
     module WorkTypes

--- a/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module DataGenerators
     module WorkTypes

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   # The logical container for all things Exceptional in Sipity! And by
   # Exceptional, I mean custom exceptions that can and will be raised by Sipity.

--- a/app/forms/sipity/forms/base_form.rb
+++ b/app/forms/sipity/forms/base_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     # A Form data structure for validation and submission.

--- a/app/forms/sipity/forms/composable_elements/on_behalf_of_collaborator.rb
+++ b/app/forms/sipity/forms/composable_elements/on_behalf_of_collaborator.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Forms
     module ComposableElements

--- a/app/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension.rb
+++ b/app/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module ComposableElements

--- a/app/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension.rb
+++ b/app/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension.rb
@@ -1,3 +1,4 @@
+require 'sipity/guard_interface_expectation'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/processing_form.rb
+++ b/app/forms/sipity/forms/processing_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     # This class is responsible for handling much of the form composition

--- a/app/forms/sipity/forms/processing_form.rb
+++ b/app/forms/sipity/forms/processing_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/guard_interface_expectation'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/submission_windows/etd/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/submission_windows/etd/start_a_submission_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/submission_windows/etd/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/submission_windows/etd/start_a_submission_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module SubmissionWindows

--- a/app/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module SubmissionWindows

--- a/app/forms/sipity/forms/submission_windows/ulra/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/submission_windows/ulra/start_a_submission_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/submission_windows/ulra/start_a_submission_form.rb
+++ b/app/forms/sipity/forms/submission_windows/ulra/start_a_submission_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module SubmissionWindows

--- a/app/forms/sipity/forms/work_areas/core/show_form.rb
+++ b/app/forms/sipity/forms/work_areas/core/show_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'sipity/guard_interface_expectation'
 

--- a/app/forms/sipity/forms/work_areas/core/show_form.rb
+++ b/app/forms/sipity/forms/work_areas/core/show_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'sipity/guard_interface_expectation'
 
 module Sipity

--- a/app/forms/sipity/forms/work_areas/core/show_form.rb
+++ b/app/forms/sipity/forms/work_areas/core/show_form.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Forms
     module WorkAreas

--- a/app/forms/sipity/forms/work_submissions/core/destroy_form.rb
+++ b/app/forms/sipity/forms/work_submissions/core/destroy_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/core/destroy_form.rb
+++ b/app/forms/sipity/forms/work_submissions/core/destroy_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/access_policy_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/access_policy_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity
   module Forms

--- a/app/forms/sipity/forms/work_submissions/etd/advisor_signoff_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/advisor_signoff_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/advisor_signoff_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/advisor_signoff_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity
   module Forms

--- a/app/forms/sipity/forms/work_submissions/etd/attach_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/attach_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/attach_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/attach_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/collaborator_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/etd/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/collaborator_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/collaborator_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/defense_date_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/defense_date_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/etd/defense_date_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/defense_date_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/defense_date_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/defense_date_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/degree_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/degree_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/etd/degree_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/degree_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/degree_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/degree_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/describe_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/describe_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/describe_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/describe_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 

--- a/app/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 

--- a/app/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 

--- a/app/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 

--- a/app/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 

--- a/app/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/search_term_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/search_term_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/etd/search_term_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/search_term_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 

--- a/app/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/submit_for_review_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/etd/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/submit_for_review_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity
   module Forms

--- a/app/forms/sipity/forms/work_submissions/self_deposit/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/access_policy_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/self_deposit/access_policy_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/access_policy_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/affiliation_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/affiliation_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/self_deposit/affiliation_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/affiliation_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/self_deposit/affiliation_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/affiliation_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/attach_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/attach_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/self_deposit/attach_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/attach_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/collaborator_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/self_deposit/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/collaborator_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/self_deposit/collaborator_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/collaborator_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/describe_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/describe_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/self_deposit/describe_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/describe_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/search_term_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/search_term_form.rb
@@ -1,3 +1,5 @@
+require 'active_model/validations'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/self_deposit/search_term_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/search_term_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form.rb
+++ b/app/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require_relative '../../../forms'
 module Sipity
   module Forms

--- a/app/forms/sipity/forms/work_submissions/ulra/faculty_response_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/faculty_response_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/ulra/faculty_response_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/faculty_response_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/ulra/faculty_response_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/faculty_response_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/ulra/plan_of_study_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/plan_of_study_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/ulra/plan_of_study_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/plan_of_study_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/ulra/plan_of_study_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/plan_of_study_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/ulra/publisher_information_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/publisher_information_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/ulra/publisher_information_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/publisher_information_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/ulra/publisher_information_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/publisher_information_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/forms/sipity/forms/work_submissions/ulra/research_process_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/research_process_form.rb
@@ -1,3 +1,4 @@
+require 'sipity/forms/processing_form'
 require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 

--- a/app/forms/sipity/forms/work_submissions/ulra/research_process_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/research_process_form.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/app/forms/sipity/forms/work_submissions/ulra/research_process_form.rb
+++ b/app/forms/sipity/forms/work_submissions/ulra/research_process_form.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/inputs/multi_value_input.rb
+++ b/app/inputs/multi_value_input.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 require 'simple_form'
 # Customization for multi-valued input field
 class MultiValueInput < SimpleForm::Inputs::CollectionInput

--- a/app/inputs/multi_value_input.rb
+++ b/app/inputs/multi_value_input.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/array/wrap'
+require 'simple_form/inputs/collection_input'
 
 require 'simple_form'
 # Customization for multi-valued input field

--- a/app/parameters/sipity/parameters/action_set_parameter.rb
+++ b/app/parameters/sipity/parameters/action_set_parameter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 require 'sipity/guard_interface_expectation'
 
 module Sipity

--- a/app/parameters/sipity/parameters/action_set_parameter.rb
+++ b/app/parameters/sipity/parameters/action_set_parameter.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/array/wrap'
-
 require 'sipity/guard_interface_expectation'
 
 module Sipity

--- a/app/parameters/sipity/parameters/action_set_parameter.rb
+++ b/app/parameters/sipity/parameters/action_set_parameter.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Parameters
     # Responsible for providing an identified collection of actions.

--- a/app/parameters/sipity/parameters/entity_with_additional_attributes_parameter.rb
+++ b/app/parameters/sipity/parameters/entity_with_additional_attributes_parameter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Parameters
     # A coordination parameter for gathering collecting an entity and its

--- a/app/parameters/sipity/parameters/handled_response_parameter.rb
+++ b/app/parameters/sipity/parameters/handled_response_parameter.rb
@@ -1,3 +1,6 @@
+require 'power_converter'
+require 'sipity/exceptions'
+
 module Sipity
   module Parameters
     # Responsible for defining the mapping interface between the Runners

--- a/app/policies/sipity/policies.rb
+++ b/app/policies/sipity/policies.rb
@@ -1,3 +1,5 @@
+require 'sipity/exceptions'
+
 module Sipity
   # Contains the various Policies associated with Sipity.
   #

--- a/app/policies/sipity/policies/processing/processing_entity_policy.rb
+++ b/app/policies/sipity/policies/processing/processing_entity_policy.rb
@@ -55,6 +55,7 @@ module Sipity
         end
 
         def default_repository
+          require 'sipity/query_repository' unless defined?(Sipity::QueryRepository)
           QueryRepository.new
         end
       end

--- a/app/policies/sipity/policies/submission_window_policy.rb
+++ b/app/policies/sipity/policies/submission_window_policy.rb
@@ -1,3 +1,4 @@
+require 'sipity/policies/processing/processing_entity_policy'
 module Sipity
   module Policies
     # Responsible for enforcing access to a given Sipity::Models::WorkArea.

--- a/app/policies/sipity/policies/work_area_policy.rb
+++ b/app/policies/sipity/policies/work_area_policy.rb
@@ -1,3 +1,5 @@
+require 'sipity/policies/processing/processing_entity_policy'
+
 module Sipity
   module Policies
     # Responsible for enforcing access to a given Sipity::Models::WorkArea.

--- a/app/policies/sipity/policies/work_policy.rb
+++ b/app/policies/sipity/policies/work_policy.rb
@@ -1,3 +1,4 @@
+require 'sipity/policies/processing/processing_entity_policy'
 module Sipity
   module Policies
     # Responsible for enforcing access to a given Sipity::Work.

--- a/app/presenters/sipity/controllers/additional_attribute_presenter.rb
+++ b/app/presenters/sipity/controllers/additional_attribute_presenter.rb
@@ -1,3 +1,4 @@
+require 'sipity/guard_interface_expectation'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/presenters/sipity/controllers/additional_attribute_presenter.rb
+++ b/app/presenters/sipity/controllers/additional_attribute_presenter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Controllers
     # Responsible for presenting a comment.

--- a/app/presenters/sipity/controllers/composable_elements/processing_actions_composer.rb
+++ b/app/presenters/sipity/controllers/composable_elements/processing_actions_composer.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Controllers
     module ComposableElements

--- a/app/presenters/sipity/controllers/debug_actor_presenter.rb
+++ b/app/presenters/sipity/controllers/debug_actor_presenter.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Controllers
     # Responsible for exposing an Actor to a debug style view.

--- a/app/presenters/sipity/controllers/debug_presenter.rb
+++ b/app/presenters/sipity/controllers/debug_presenter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Controllers
     # Because we are dealing with a complex state driven engine, I want to

--- a/app/presenters/sipity/controllers/debug_role_presenter.rb
+++ b/app/presenters/sipity/controllers/debug_role_presenter.rb
@@ -1,3 +1,4 @@
+require 'sipity/guard_interface_expectation'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/presenters/sipity/controllers/debug_role_presenter.rb
+++ b/app/presenters/sipity/controllers/debug_role_presenter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Controllers
     # Responsible for presenting the debug view of a Role

--- a/app/presenters/sipity/controllers/enrichment_action_presenter.rb
+++ b/app/presenters/sipity/controllers/enrichment_action_presenter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Controllers
     # Responsible for presenting an enrichment action

--- a/app/presenters/sipity/controllers/enrichment_action_presenter.rb
+++ b/app/presenters/sipity/controllers/enrichment_action_presenter.rb
@@ -1,3 +1,4 @@
+require 'sipity/guard_interface_expectation'
 require 'active_support/core_ext/array/wrap'
 
 module Sipity

--- a/app/presenters/sipity/controllers/state_advancing_action_presenter.rb
+++ b/app/presenters/sipity/controllers/state_advancing_action_presenter.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Controllers
     # Responsible for presenting an state advancing action

--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Controllers
     module WorkAreas

--- a/app/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff.rb
+++ b/app/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff.rb
@@ -1,3 +1,6 @@
+require 'sipity/models/additional_attribute'
+require 'active_support/core_ext/numeric/time'
+
 module Sipity
   module ProcessingHooks
     module Etd
@@ -22,11 +25,13 @@ module Sipity
           end
 
           def default_repository
+            require 'sipity/command_repository' unless defined?(Sipity::CommandRepository)
             CommandRepository.new
           end
           private_class_method :default_repository
 
           def default_as_of_date
+            require 'active_support/core_ext/numeric/time' unless Time.respond_to?(:zone)
             Time.zone.today
           end
           private_class_method :default_as_of_date

--- a/app/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook.rb
+++ b/app/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook.rb
@@ -22,11 +22,13 @@ module Sipity
           end
 
           def default_repository
+            require 'sipity/command_repository' unless defined?(Sipity::CommandRepository)
             CommandRepository.new
           end
           private_class_method :default_repository
 
           def default_as_of_date
+            require 'active_support/core_ext/numeric/time' unless Time.respond_to?(:zone)
             Time.zone.today
           end
           private_class_method :default_as_of_date

--- a/app/repositories/sipity/commands/additional_attribute_commands.rb
+++ b/app/repositories/sipity/commands/additional_attribute_commands.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   # :nodoc:
   module Commands

--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   # :nodoc:
   module Commands

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   # :nodoc:
   module Commands

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Queries
     # Welcome intrepid developer. You have stumbled into some complex data

--- a/app/response_handlers/sipity/response_handlers.rb
+++ b/app/response_handlers/sipity/response_handlers.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   # ResponseHandlers are a means of encapsulating how we respond to an action's
   # response. Action responses should implement the interface of the

--- a/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
@@ -1,3 +1,5 @@
+require 'power_converter'
+
 module Sipity
   module ResponseHandlers
     # This is an Experimental module and concept

--- a/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
@@ -1,3 +1,5 @@
+require 'power_converter'
+
 module Sipity
   module ResponseHandlers
     # These handlers are very nosy; In object perlance they are doing little on

--- a/app/runners/sipity/runners/account_profile_runners.rb
+++ b/app/runners/sipity/runners/account_profile_runners.rb
@@ -1,3 +1,5 @@
+require 'sipity/runners/base_runner'
+
 module Sipity
   module Runners
     # Container for account profile related actions.

--- a/app/runners/sipity/runners/base_runner.rb
+++ b/app/runners/sipity/runners/base_runner.rb
@@ -1,4 +1,6 @@
 require 'hesburgh/lib/runner'
+require 'sipity/exceptions'
+require 'sipity/services/authorization_layer'
 
 module Sipity
   module Runners

--- a/app/runners/sipity/runners/comment_runners.rb
+++ b/app/runners/sipity/runners/comment_runners.rb
@@ -1,3 +1,5 @@
+require 'sipity/runners/base_runner'
+
 module Sipity
   module Runners
     module CommentRunners

--- a/app/runners/sipity/runners/dashboard_runners.rb
+++ b/app/runners/sipity/runners/dashboard_runners.rb
@@ -1,3 +1,5 @@
+require 'sipity/runners/base_runner'
+
 module Sipity
   module Runners
     # Container for Dashboard related actions.

--- a/app/runners/sipity/runners/submission_window_runners.rb
+++ b/app/runners/sipity/runners/submission_window_runners.rb
@@ -1,3 +1,5 @@
+require 'sipity/runners/base_runner'
+
 module Sipity
   module Runners
     # Responsible for being a collection of SubmissionWindow runners

--- a/app/runners/sipity/runners/visitors_runner.rb
+++ b/app/runners/sipity/runners/visitors_runner.rb
@@ -1,3 +1,6 @@
+require 'sipity/runners/base_runner'
+require 'sipity/controllers/work_areas/etd/show_presenter'
+
 module Sipity
   module Runners
     module VisitorsRunner

--- a/app/runners/sipity/runners/work_area_runners.rb
+++ b/app/runners/sipity/runners/work_area_runners.rb
@@ -1,3 +1,6 @@
+require 'sipity/runners/base_runner'
+require 'active_record/base'
+
 module Sipity
   module Runners
     # Container for WorkArea related "action" runners

--- a/app/runners/sipity/runners/work_submissions_runners.rb
+++ b/app/runners/sipity/runners/work_submissions_runners.rb
@@ -1,3 +1,6 @@
+require 'sipity/runners/base_runner'
+require 'active_record/base'
+
 module Sipity
   module Runners
     # Container for WorkSubmission's "action" runners

--- a/app/services/sipity/guard_interface_expectation.rb
+++ b/app/services/sipity/guard_interface_expectation.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   # A mixin to expose a quick means of guarding an interface.
   module GuardInterfaceExpectation

--- a/app/services/sipity/services/action_taken_on_entity.rb
+++ b/app/services/sipity/services/action_taken_on_entity.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Services
     # Service object that handles the business logic of granting permission.

--- a/app/services/sipity/services/advisor_signs_off.rb
+++ b/app/services/sipity/services/advisor_signs_off.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Services
     # This is what happens when the advisor signs off on a given form.

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Services
     # Responsible for rebuilding access policies for accessible objects

--- a/app/services/sipity/services/deliver_form_submission_notifications_service.rb
+++ b/app/services/sipity/services/deliver_form_submission_notifications_service.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Services
     # Responsible for taking a notification context, building out the emails

--- a/app/services/sipity/services/request_changes_via_comment_service.rb
+++ b/app/services/sipity/services/request_changes_via_comment_service.rb
@@ -1,3 +1,5 @@
+require 'sipity/guard_interface_expectation'
+
 module Sipity
   module Services
     # When someone has requested changes via a comment, this is the service that

--- a/app/validators/net_id_validator.rb
+++ b/app/validators/net_id_validator.rb
@@ -1,3 +1,5 @@
+require 'active_model/validator'
+
 # Responsible for validating netid
 class NetIdValidator < ActiveModel::EachValidator
   def initialize(options = {})

--- a/spec/constraints/sipity/constraints/unauthenticated_constraint_spec.rb
+++ b/spec/constraints/sipity/constraints/unauthenticated_constraint_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/constraints/unauthenticated_constraint'
 
 module Sipity
   module Constraints

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'application_controller'
 
 RSpec.describe ApplicationController do
   context '#repository' do

--- a/spec/controllers/sipity/controllers/account_profiles_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/account_profiles_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/account_profiles_controller'
 require 'hesburgh/lib/mock_runner'
 
 module Sipity

--- a/spec/controllers/sipity/controllers/comments_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/comments_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/comments_controller'
 require 'hesburgh/lib/mock_runner'
 
 module Sipity

--- a/spec/controllers/sipity/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/dashboards_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/dashboards_controller'
 require 'hesburgh/lib/mock_runner'
 
 module Sipity

--- a/spec/controllers/sipity/controllers/processing_action_composer_spec.rb
+++ b/spec/controllers/sipity/controllers/processing_action_composer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/processing_action_composer'
 
 module Sipity
   module Controllers

--- a/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/submission_windows_controller'
 
 module Sipity
   module Controllers

--- a/spec/controllers/sipity/controllers/visitors_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/visitors_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/visitors_controller'
 
 module Sipity
   module Controllers

--- a/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/work_areas_controller'
 
 module Sipity
   module Controllers

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/work_submissions_controller'
 
 module Sipity
   module Controllers

--- a/spec/conversions/sipity/conversions/convert_to_date_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_date_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_date'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_permanent_uri_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_permanent_uri_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_permanent_uri'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_polymorphic_type_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_polymorphic_type_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_polymorphic_type'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_processing_action_name_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_action_name_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_processing_action_name'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_processing_action_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_action_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_processing_action'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_processing_actor_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_actor_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_processing_actor'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_processing_entity_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_entity_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_processing_entity'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_processing_strategy_id_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_processing_strategy_id_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_processing_strategy_id'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_registered_action_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_registered_action_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_registered_action'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_role_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_role_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_role'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_work_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_work_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_work'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/convert_to_year_spec.rb
+++ b/spec/conversions/sipity/conversions/convert_to_year_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/convert_to_year'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/extract_input_date_from_input_spec.rb
+++ b/spec/conversions/sipity/conversions/extract_input_date_from_input_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/extract_input_date_from_input'
 
 module Sipity
   module Conversions

--- a/spec/conversions/sipity/conversions/sanitize_html_spec.rb
+++ b/spec/conversions/sipity/conversions/sanitize_html_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/conversions/sanitize_html'
 
 module Sipity
   module Conversions

--- a/spec/data_generators/sipity/data_generators/find_or_create_submission_window_spec.rb
+++ b/spec/data_generators/sipity/data_generators/find_or_create_submission_window_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/find_or_create_submission_window'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/find_or_create_work_area_spec.rb
+++ b/spec/data_generators/sipity/data_generators/find_or_create_work_area_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/find_or_create_work_area'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/find_or_create_work_type_spec.rb
+++ b/spec/data_generators/sipity/data_generators/find_or_create_work_type_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/find_or_create_work_type'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/on_user_create_spec.rb
+++ b/spec/data_generators/sipity/data_generators/on_user_create_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/on_user_create'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/permission_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/permission_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/permission_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/submission_windows/base_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/base_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/submission_windows/base_generator'
+require 'sipity/data_generators/submission_windows/base_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/submission_windows/etd_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/etd_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/submission_windows/etd_generator'
+require 'sipity/data_generators/submission_windows/etd_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/submission_windows/self_deposit_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/self_deposit_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/submission_windows/self_deposit_generator'
+require 'sipity/data_generators/submission_windows/self_deposit_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/submission_windows/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_windows/ulra_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/submission_windows/ulra_generator'
+require 'sipity/data_generators/submission_windows/ulra_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_areas/base_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/base_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/work_areas/base_generator'
+require 'sipity/data_generators/work_areas/base_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_areas/etd_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/etd_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/work_areas/etd_generator'
+require 'sipity/data_generators/work_areas/etd_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_areas/self_deposit_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/self_deposit_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/work_areas/self_deposit_generator'
+require 'sipity/data_generators/work_areas/self_deposit_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_areas/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_areas/ulra_generator_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'sipity/data_generators/work_areas/ulra_generator'
+require 'sipity/data_generators/work_areas/ulra_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_types/etd_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_types/etd_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/work_types/etd_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_types/self_deposit_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_types/self_deposit_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/work_types/self_deposit_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/data_generators/sipity/data_generators/work_types/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_types/ulra_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/data_generators/work_types/ulra_generator'
 
 module Sipity
   module DataGenerators

--- a/spec/decorators/sipity/decorators/application_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/application_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/application_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/attachment_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/attachment_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/attachment_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/base_object_with_composed_attributes_delegator_spec.rb
+++ b/spec/decorators/sipity/decorators/base_object_with_composed_attributes_delegator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/base_object_with_composed_attributes_delegator'
 module Sipity
   module Decorators
     RSpec.describe BaseObjectWithComposedAttributesDelegator do

--- a/spec/decorators/sipity/decorators/collaborator_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/collaborator_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/collaborator_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/comparable_simple_delegator_spec.rb
+++ b/spec/decorators/sipity/decorators/comparable_simple_delegator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/comparable_simple_delegator'
 module Sipity
   module Decorators
     RSpec.describe ComparableSimpleDelegator do

--- a/spec/decorators/sipity/decorators/emails/processing_comment_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/processing_comment_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/emails/processing_comment_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/emails/registered_action_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/registered_action_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/emails/registered_action_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/emails/work_email_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/processing/processing_comment_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/processing_comment_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/processing/processing_comment_decorator'
 
 module Sipity
   module Decorators

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/decorators/work_decorator'
 
 module Sipity
   module Decorators

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/exceptions'
+require 'sipity/exceptions'
 
 module Sipity
   module Exceptions

--- a/spec/exporters/sipity/exporters/etd_exporter_spec.rb
+++ b/spec/exporters/sipity/exporters/etd_exporter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/exporters/etd_exporter'
 
 module Sipity
   module Exporters

--- a/spec/forms/sipity/forms/base_form_spec.rb
+++ b/spec/forms/sipity/forms/base_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/base_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/composable_elements/attachments_extension'
 
 module Sipity

--- a/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/composable_elements/attachments_extension'
 
 module Sipity

--- a/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/composable_elements/attachments_extension'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension_spec.rb
@@ -1,3 +1,6 @@
+require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
+
 module Sipity
   module Forms
     module ComposableElements

--- a/spec/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
+++ b/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/core/manage_account_profile_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
+++ b/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/core/manage_account_profile_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
+++ b/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/core/manage_account_profile_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/processing_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_form_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'active_model/validations'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/processing_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/processing_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_form_spec.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'spec_helper'
 require 'sipity/forms/processing_form'
 

--- a/spec/forms/sipity/forms/processing_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_form_spec.rb
@@ -1,5 +1,6 @@
-require 'active_model/validations'
 require 'spec_helper'
+require 'active_model/validations'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/processing_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/processing_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/processing_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/submission_windows/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/core/show_form_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/forms/submission_windows/core/show_form'
+require 'sipity/forms/submission_windows/core/show_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/submission_windows/etd/start_a_submission_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/submission_windows/etd/start_a_submission_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/submission_windows/etd/start_a_submission_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/submission_windows/self_deposit/start_a_submission_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/submission_windows/self_deposit/start_a_submission_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/self_deposit/start_a_submission_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/submission_windows/self_deposit/start_a_submission_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/submission_windows/ulra/start_a_submission_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/submission_windows/ulra/start_a_submission_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/submission_windows/ulra/start_a_submission_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/submission_windows_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/submission_windows'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_areas/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/work_areas/core/show_form_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/forms/work_areas/core/show_form'
+require 'sipity/forms/work_areas/core/show_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_areas_spec.rb
+++ b/spec/forms/sipity/forms/work_areas_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_areas'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/core/destroy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/destroy_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/core/destroy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/destroy_form_spec.rb
@@ -1,3 +1,6 @@
+require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/spec/forms/sipity/forms/work_submissions/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/show_form_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/forms/work_submissions/core/show_form'
+require 'sipity/forms/work_submissions/core/show_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/access_policy_form_spec.rb
@@ -1,3 +1,8 @@
+require 'spec_helper'
+require 'sipity/models/work'
+require 'sipity/models/attachment'
+require 'spec/support/sipity/command_repository_interface'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/spec/forms/sipity/forms/work_submissions/etd/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/access_policy_form_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'sipity/models/work'
 require 'sipity/models/attachment'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/advisor_requests_change_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/advisor_requests_change_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/advisor_requests_change_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/advisor_signoff_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/advisor_signoff_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/advisor_signoff_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/attach_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/attach_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/attach_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/attach_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/attach_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/attach_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/collaborator_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/collaborator_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/collaborator_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/defense_date_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/defense_date_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/defense_date_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/degree_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/degree_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/degree_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/describe_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/describe_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/describe_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/grad_school_requests_change_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/grad_school_requests_change_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/grad_school_requests_change_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/grad_school_signoff_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/grad_school_signoff_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/grad_school_signoff_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form'
 module Sipity
   module Forms
     module WorkSubmissions

--- a/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form'
+require 'sipity/models/work'
+require 'sipity/policies/work_policy'
+require 'sipity/models/work_area'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form'
 require 'sipity/models/work'
 require 'sipity/policies/work_policy'

--- a/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/request_change_on_behalf_of_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/request_change_on_behalf_of_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/request_change_on_behalf_of_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/respond_to_advisor_request_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/respond_to_advisor_request_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/respond_to_advisor_request_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/respond_to_grad_school_request_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/respond_to_grad_school_request_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/respond_to_grad_school_request_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/search_term_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/search_term_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/search_term_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/signoff_on_behalf_of_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/signoff_on_behalf_of_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/signoff_on_behalf_of_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/submit_for_review_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/etd/submit_for_review_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/submit_for_review_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/access_policy_form_spec.rb
@@ -1,3 +1,8 @@
+require 'spec_helper'
+require 'sipity/models/work'
+require 'sipity/models/attachment'
+require 'spec/support/sipity/command_repository_interface'
+
 module Sipity
   module Forms
     module WorkSubmissions

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/access_policy_form_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'sipity/models/work'
 require 'sipity/models/attachment'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/affiliation_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/affiliation_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/affiliation_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/affiliation_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/affiliation_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/affiliation_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/affiliation_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/affiliation_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/self_deposit/affiliation_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/attach_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/attach_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/attach_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/self_deposit/attach_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/attach_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/attach_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/collaborator_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/collaborator_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/collaborator_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/collaborator_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/collaborator_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/self_deposit/collaborator_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/describe_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/describe_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/describe_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/self_deposit/describe_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/describe_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/describe_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/search_term_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/search_term_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/search_term_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/search_term_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/search_term_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/self_deposit/search_term_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/submit_for_review_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/self_deposit/submit_for_review_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/self_deposit/submit_for_review_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/self_deposit/submit_for_review_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/ulra/faculty_response_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/faculty_response_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/faculty_response_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/plan_of_study_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/plan_of_study_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/ulra/plan_of_study_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/ulra/publisher_information_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/publisher_information_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/publisher_information_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/research_process_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/forms/work_submissions/ulra/research_process_form'
 
 module Sipity

--- a/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions/ulra/research_process_form'
 
 module Sipity
   module Forms

--- a/spec/forms/sipity/forms/work_submissions_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/forms/work_submissions'
 
 module Sipity
   module Forms

--- a/spec/inputs/multi_value_input_spec.rb
+++ b/spec/inputs/multi_value_input_spec.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'spec_helper'
 require 'multi_value_input'
 

--- a/spec/inputs/multi_value_input_spec.rb
+++ b/spec/inputs/multi_value_input_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'multi_value_input'
 
 describe 'MultiValueInput', type: :input do
 

--- a/spec/jobs/sipity/jobs_spec.rb
+++ b/spec/jobs/sipity/jobs_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/jobs'
+require 'sipity/jobs'
 
 module Sipity
   RSpec.describe Jobs do

--- a/spec/lib/devise/strategies/cas_authenticatable_with_service_agreement_spec.rb
+++ b/spec/lib/devise/strategies/cas_authenticatable_with_service_agreement_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'devise/strategies/cas_authenticatable_with_service_agreement'
 
 module Devise
   module Strategies

--- a/spec/mailers/sipity/mailers/email_notifier_spec.rb
+++ b/spec/mailers/sipity/mailers/email_notifier_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/mailers/email_notifier'
 module Sipity
   module Mailers
     describe EmailNotifier do

--- a/spec/mappers/sipity/mappers/etd_mapper_spec.rb
+++ b/spec/mappers/sipity/mappers/etd_mapper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/mappers/etd_mapper'
 
 module Sipity
   module Mappers

--- a/spec/mappers/sipity/mappers/generic_file_mapper_spec.rb
+++ b/spec/mappers/sipity/mappers/generic_file_mapper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/mappers/generic_file_mapper'
 
 module Sipity
   module Mappers

--- a/spec/models/sipity/models/access_right_facade_spec.rb
+++ b/spec/models/sipity/models/access_right_facade_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/models/access_right_facade'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/access_right_spec.rb
+++ b/spec/models/sipity/models/access_right_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/access_right'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/additional_attribute_spec.rb
+++ b/spec/models/sipity/models/additional_attribute_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/additional_attribute'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/agent_spec.rb
+++ b/spec/models/sipity/models/agent_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/agent'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/attachment_spec.rb
+++ b/spec/models/sipity/models/attachment_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/attachment'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/collaborator_spec.rb
+++ b/spec/models/sipity/models/collaborator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/models/collaborator'
 module Sipity
   module Models
     RSpec.describe Collaborator, type: :model do

--- a/spec/models/sipity/models/event_log_spec.rb
+++ b/spec/models/sipity/models/event_log_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/event_log'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/group_membership_spec.rb
+++ b/spec/models/sipity/models/group_membership_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/models/group_membership'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/group_spec.rb
+++ b/spec/models/sipity/models/group_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/group'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/notification/email_recipient_spec.rb
+++ b/spec/models/sipity/models/notification/email_recipient_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/notification/email_recipient'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/notification/email_spec.rb
+++ b/spec/models/sipity/models/notification/email_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/notification/email'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/notification/notifiable_context_spec.rb
+++ b/spec/models/sipity/models/notification/notifiable_context_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/notification/notifiable_context'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/notification_spec.rb
+++ b/spec/models/sipity/models/notification_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/models/notification'
+require 'sipity/models/notification'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/actor_spec.rb
+++ b/spec/models/sipity/models/processing/actor_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/actor'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/comment_spec.rb
+++ b/spec/models/sipity/models/processing/comment_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/comment'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/entity_action_register_spec.rb
+++ b/spec/models/sipity/models/processing/entity_action_register_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/entity_action_register'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/entity_spec.rb
+++ b/spec/models/sipity/models/processing/entity_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/entity'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/entity_specific_responsibility_spec.rb
+++ b/spec/models/sipity/models/processing/entity_specific_responsibility_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/entity_specific_responsibility'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_action_analogue_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_analogue_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_action_analogue'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_action_prerequisite_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_prerequisite_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_action_prerequisite'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_action_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_action'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_responsibility_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_responsibility_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_responsibility'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_role_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_role_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_role'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_state_action_permission_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_action_permission_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_state_action_permission'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_state_action_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_action_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_state_action'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_state_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_state'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/processing/strategy_usage_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_usage_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/processing/strategy_usage'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/role_spec.rb
+++ b/spec/models/sipity/models/role_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/role'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/submission_window_spec.rb
+++ b/spec/models/sipity/models/submission_window_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/submission_window'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/submission_window_work_type_spec.rb
+++ b/spec/models/sipity/models/submission_window_work_type_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/submission_window_work_type'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/work_area_spec.rb
+++ b/spec/models/sipity/models/work_area_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/work_area'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/work_spec.rb
+++ b/spec/models/sipity/models/work_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/models/work'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/work_submission_spec.rb
+++ b/spec/models/sipity/models/work_submission_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/work_submission'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models/work_type_spec.rb
+++ b/spec/models/sipity/models/work_type_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/models/work_type'
 
 module Sipity
   module Models

--- a/spec/models/sipity/models_spec.rb
+++ b/spec/models/sipity/models_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/models'
 
 module Sipity
   RSpec.describe Models do

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity'
+require 'sipity'
 
 RSpec.describe Sipity do
   subject { described_class }

--- a/spec/parameters/sipity/parameters/action_set_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/action_set_parameter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/parameters/action_set_parameter'
 
 module Sipity
   module Parameters

--- a/spec/parameters/sipity/parameters/entity_with_additional_attributes_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/entity_with_additional_attributes_parameter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/parameters/entity_with_additional_attributes_parameter'
 
 module Sipity
   module Parameters

--- a/spec/parameters/sipity/parameters/entity_with_comments_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/entity_with_comments_parameter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/parameters/entity_with_comments_parameter'
 
 module Sipity
   module Parameters

--- a/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/parameters/handled_response_parameter'
 module Sipity
   module Parameters
     RSpec.describe HandledResponseParameter do

--- a/spec/parameters/sipity/parameters/notification_context_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/notification_context_parameter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/parameters/notification_context_parameter'
 module Sipity
   module Parameters
     RSpec.describe NotificationContextParameter do

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/parameters/search_criteria_for_works_parameter'
 
 module Sipity
   module Parameters

--- a/spec/policies/sipity/policies/base_policy_spec.rb
+++ b/spec/policies/sipity/policies/base_policy_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/policies/base_policy'
 
 module Sipity
   module Policies

--- a/spec/policies/sipity/policies/processing/processing_entity_policy_spec.rb
+++ b/spec/policies/sipity/policies/processing/processing_entity_policy_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/policies/processing/processing_entity_policy'
 
 module Sipity
   module Policies

--- a/spec/policies/sipity/policies/work_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_policy_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/policies/work_policy'
 
 module Sipity
   module Policies

--- a/spec/policies/sipity/policies_spec.rb
+++ b/spec/policies/sipity/policies_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/policies'
+require 'sipity/policies'
 
 module Sipity
   RSpec.describe Policies do

--- a/spec/presenters/sipity/controllers/additional_attribute_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/additional_attribute_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/additional_attribute_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/additional_attribute_set_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/additional_attribute_set_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/additional_attribute_set_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/collaborator_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/collaborator_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/collaborator_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/current_comments_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/current_comments_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/current_comments_presenter'
 require 'sipity/parameters/entity_with_comments_parameter'
 
 module Sipity

--- a/spec/presenters/sipity/controllers/debug_actor_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_actor_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/debug_actor_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/debug_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/debug_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/debug_role_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_role_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/debug_role_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/enrichment_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/enrichment_action_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/enrichment_action_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/enrichment_action_presenter'
 

--- a/spec/presenters/sipity/controllers/enrichment_action_set_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/enrichment_action_set_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/enrichment_action_set_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/enrichment_action_set_presenter'
 

--- a/spec/presenters/sipity/controllers/processing_state_notice_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/processing_state_notice_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/processing_state_notice_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/processing_state_notice_presenter'
 

--- a/spec/presenters/sipity/controllers/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/resourceful_action_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/resourceful_action_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/resourceful_action_presenter'
 

--- a/spec/presenters/sipity/controllers/state_advancing_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/state_advancing_action_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/state_advancing_action_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/state_advancing_action_presenter'
 

--- a/spec/presenters/sipity/controllers/state_advancing_action_set_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/state_advancing_action_set_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/state_advancing_action_set_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/state_advancing_action_set_presenter'
 

--- a/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/controllers/submission_window_presenter'
+require 'sipity/controllers/submission_window_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/submission_windows/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_windows/resourceful_action_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/submission_windows/resourceful_action_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/submission_windows/resourceful_action_presenter'
 

--- a/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/controllers/submission_windows/show_presenter'
+require 'sipity/controllers/submission_windows/show_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/translation_assistant_for_polymorphic_type_spec.rb
+++ b/spec/presenters/sipity/controllers/translation_assistant_for_polymorphic_type_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/translation_assistant_for_polymorphic_type'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/translation_assistant_spec.rb
+++ b/spec/presenters/sipity/controllers/translation_assistant_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/translation_assistant'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/controllers/work_areas/core/show_presenter'
+require 'sipity/controllers/work_areas/core/show_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/controllers/work_areas/etd/show_presenter'
+require 'sipity/controllers/work_areas/etd/show_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/work_areas/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/resourceful_action_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/work_areas/resourceful_action_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/work_areas/resourceful_action_presenter'
 

--- a/spec/presenters/sipity/controllers/work_areas/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/show_presenter_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/controllers/work_areas/show_presenter'
+require 'sipity/controllers/work_areas/show_presenter'
 
 module Sipity
   module Controllers

--- a/spec/presenters/sipity/controllers/work_submissions/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_submissions/resourceful_action_presenter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/controllers/work_submissions/resourceful_action_presenter'
 # Because RSpec's described_class is getting confused
 require 'sipity/controllers/work_submissions/resourceful_action_presenter'
 

--- a/spec/presenters/sipity/controllers/work_submissions/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_submissions/show_presenter_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/controllers/work_submissions/show_presenter'
+require 'sipity/controllers/work_submissions/show_presenter'
 
 module Sipity
   module Controllers

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/processing_hooks/etd/works/grad_school_signoff'
 
 module Sipity
   module ProcessingHooks

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/processing_hooks/etd/works/grad_school_signoff'
 
 module Sipity

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/processing_hooks/etd/works/grad_school_signoff'
 
 module Sipity

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/processing_hooks/etd/works/submit_for_review_processing_hook'
 
 module Sipity

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/processing_hooks/etd/works/submit_for_review_processing_hook'
 
 module Sipity
   module ProcessingHooks

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/processing_hooks/etd/works/submit_for_review_processing_hook'
 
 module Sipity

--- a/spec/processing_hooks/sipity/processing_hooks_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/processing_hooks'
 
 module Sipity
   # A container module for functions that are called as part of

--- a/spec/repositories/sipity/command_repository_spec.rb
+++ b/spec/repositories/sipity/command_repository_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/command_repository'
 
 module Sipity
   RSpec.describe CommandRepository, type: :repository do

--- a/spec/repositories/sipity/commands/account_profile_commands_spec.rb
+++ b/spec/repositories/sipity/commands/account_profile_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/account_profile_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
+++ b/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/additional_attribute_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/event_log_commands_spec.rb
+++ b/spec/repositories/sipity/commands/event_log_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/event_log_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/notification_commands_spec.rb
+++ b/spec/repositories/sipity/commands/notification_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/notification_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/permission_commands_spec.rb
+++ b/spec/repositories/sipity/commands/permission_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/permission_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/todo_list_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/transient_answer_commands_spec.rb
+++ b/spec/repositories/sipity/commands/transient_answer_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/commands/transient_answer_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/commands/work_commands'
 
 module Sipity

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/commands/work_commands'
 
 module Sipity

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/commands/work_commands'
 
 module Sipity
   module Commands

--- a/spec/repositories/sipity/queries/account_profile_queries_spec.rb
+++ b/spec/repositories/sipity/queries/account_profile_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/queries/account_profile_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/queries/attachment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/attachment_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/queries/attachment_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/queries/collaborator_queries_spec.rb
+++ b/spec/repositories/sipity/queries/collaborator_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/queries/collaborator_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/queries/event_log_queries_spec.rb
+++ b/spec/repositories/sipity/queries/event_log_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/queries/event_log_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/queries/notification_queries_spec.rb
+++ b/spec/repositories/sipity/queries/notification_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/queries/notification_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/queries/processing_queries'
 
 # Welcome intrepid developer. You have stumbled into some complex data
 # interactions. There are a lot of data collaborators regarding these tests.

--- a/spec/repositories/sipity/queries/simple_controlled_vocabulary_queries_spec.rb
+++ b/spec/repositories/sipity/queries/simple_controlled_vocabulary_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/queries/simple_controlled_vocabulary_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/queries/work_queries'
 
 module Sipity
   module Queries

--- a/spec/repositories/sipity/query_repository_spec.rb
+++ b/spec/repositories/sipity/query_repository_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/query_repository'
 
 module Sipity
   RSpec.describe QueryRepository, type: :repository do

--- a/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/response_handlers/submission_window_handler'
+require 'sipity/response_handlers/submission_window_handler'
 
 module Sipity
   module ResponseHandlers

--- a/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/response_handlers/work_area_handler'
+require 'sipity/response_handlers/work_area_handler'
 
 module Sipity
   module ResponseHandlers

--- a/spec/response_handlers/sipity/response_handlers/work_submission_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/work_submission_handler_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/response_handlers/work_submission_handler'
+require 'sipity/response_handlers/work_submission_handler'
 
 module Sipity
   module ResponseHandlers

--- a/spec/response_handlers/sipity/response_handlers_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/response_handlers'
 
 module Sipity
   RSpec.describe ResponseHandlers do

--- a/spec/runners/sipity/runners/account_profile_runners_spec.rb
+++ b/spec/runners/sipity/runners/account_profile_runners_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/account_profile_runners'
+require 'sipity/runners/account_profile_runners'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/base_runner_spec.rb
+++ b/spec/runners/sipity/runners/base_runner_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/runners/base_runner'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/comment_runners_spec.rb
+++ b/spec/runners/sipity/runners/comment_runners_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/comment_runners'
+require 'sipity/runners/comment_runners'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/dashboard_runners_spec.rb
+++ b/spec/runners/sipity/runners/dashboard_runners_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/dashboard_runners'
+require 'sipity/runners/dashboard_runners'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/submission_window_runners_spec.rb
+++ b/spec/runners/sipity/runners/submission_window_runners_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/submission_window_runners'
+require 'sipity/runners/submission_window_runners'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/visitors_runner_spec.rb
+++ b/spec/runners/sipity/runners/visitors_runner_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/visitors_runner'
+require 'sipity/runners/visitors_runner'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/work_area_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_area_runners_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/work_area_runners'
+require 'sipity/runners/work_area_runners'
 
 module Sipity
   module Runners

--- a/spec/runners/sipity/runners/work_submissions_runners_spec.rb
+++ b/spec/runners/sipity/runners/work_submissions_runners_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'sipity/runners/work_submissions_runners'
+require 'sipity/runners/work_submissions_runners'
 
 module Sipity
   module Runners

--- a/spec/services/sipity/guard_interface_expectation_spec.rb
+++ b/spec/services/sipity/guard_interface_expectation_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/guard_interface_expectation'
 
 module Sipity
   RSpec.describe GuardInterfaceExpectation do

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/services/action_taken_on_entity'
 
 module Sipity

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/action_taken_on_entity'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/services/action_taken_on_entity'
 
 module Sipity

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -1,3 +1,6 @@
+require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
+
 module Sipity
   module Services
     RSpec.describe AdvisorSignsOff do

--- a/spec/services/sipity/services/apply_access_policies_to_spec.rb
+++ b/spec/services/sipity/services/apply_access_policies_to_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/apply_access_policies_to'
 module Sipity
   module Services
     RSpec.describe ApplyAccessPoliciesTo do

--- a/spec/services/sipity/services/authorization_layer_spec.rb
+++ b/spec/services/sipity/services/authorization_layer_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/authorization_layer'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/create_work_service_spec.rb
+++ b/spec/services/sipity/services/create_work_service_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sipity/services/create_work_service'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/deliver_form_submission_notifications_service_spec.rb
+++ b/spec/services/sipity/services/deliver_form_submission_notifications_service_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/deliver_form_submission_notifications_service'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/grant_processing_permission_spec.rb
+++ b/spec/services/sipity/services/grant_processing_permission_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/grant_processing_permission'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/netid_query_service_spec.rb
+++ b/spec/services/sipity/services/netid_query_service_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/netid_query_service'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/noid_minter_spec.rb
+++ b/spec/services/sipity/services/noid_minter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/noid_minter'
 module Sipity
   module Services
     describe NoidMinter do

--- a/spec/services/sipity/services/notifier_spec.rb
+++ b/spec/services/sipity/services/notifier_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/notifier'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/request_changes_via_comment_service_spec.rb
+++ b/spec/services/sipity/services/request_changes_via_comment_service_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/request_changes_via_comment_service_spec.rb
+++ b/spec/services/sipity/services/request_changes_via_comment_service_spec.rb
@@ -1,3 +1,6 @@
+require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
+
 module Sipity
   module Services
     RSpec.describe RequestChangesViaCommentService do

--- a/spec/services/sipity/services/update_entity_processing_state_spec.rb
+++ b/spec/services/sipity/services/update_entity_processing_state_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sipity/services/update_entity_processing_state'
 
 module Sipity
   module Services

--- a/spec/services/sipity/services/update_entity_processing_state_spec.rb
+++ b/spec/services/sipity/services/update_entity_processing_state_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'spec/support/sipity/command_repository_interface'
+require 'support/sipity/command_repository_interface'
 require 'sipity/services/update_entity_processing_state'
 
 module Sipity

--- a/spec/services/sipity/services/update_entity_processing_state_spec.rb
+++ b/spec/services/sipity/services/update_entity_processing_state_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spec/support/sipity/command_repository_interface'
 require 'sipity/services/update_entity_processing_state'
 
 module Sipity

--- a/spec/validators/net_id_validator_spec.rb
+++ b/spec/validators/net_id_validator_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe NetIdValidator do
   let(:validatable) do

--- a/spec/validators/net_id_validator_spec.rb
+++ b/spec/validators/net_id_validator_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'net_id_validator'
 
 describe NetIdValidator do
   let(:validatable) do

--- a/spec/validators/net_id_validator_spec.rb
+++ b/spec/validators/net_id_validator_spec.rb
@@ -1,3 +1,4 @@
+require 'active_model/validations'
 require 'rails_helper'
 require 'net_id_validator'
 


### PR DESCRIPTION
## Adding explicit requires to Runners

@ac1145d2ee0a045ab21ca239eff2b67e0fb3ca42

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit requires to ResponseHandlers

@6c21fdf8c51db697021eb669f84d0416411be2af

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit requires to ProcessingHooks

@84b5e0b29a7e3356a1f225126cc7dee3d037becd

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit requires to Validators

@b2a7e34f26424cd6123a2fd7d8f876d917fb34c5

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit requires to Policies

@cbaa82c12e12b95ecfc19883c51d02d7798792be

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit requires to Parameters

@7bf41e73601bce69c2d3ec60da94505eec8627a1

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit require for Array.wrap

@c2ed942c9b70f2d1b74594beebd2ae431d10ccc5

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit require for Inputs

@3f822b38562252326b6721d0871d7d56ca6aafb2

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit require for corresponding file

@fd9fc22a3287bb2de5723a4819a2def4ad2dea12

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit require for guard interface

@427241699f9aeeebb5ec5396dd227e8ffdd8bd7b

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Requiring explicit ActiveModel::Validations

@7a6a23eae04fc0cbad84a44c2915e0525bbaa929

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit require for corresponding file

@0f4a46db3664ce59e5182168fb0c2c76331fef1a

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Adding explicit require for corresponding file

@1ac41847163a1a91829586272e48ce31a1d57675

At present the .rsepc requires the Sipity's spec/rails_helper. In doing
so, all tests now load the entire Rails ecosystem. This results in very
slow tests for many of the unit tests. The problem remains hidden if
something like Spring is running; But Spring is a nasty kludge of a fix
that introduces all kinds of problems.

## Attempting to fix broken travis build.

@e42833c06ffe8251a1cd8ff40149f1e39a707372
