### PR TITLE
Ensuring update to date data migrations of app

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -132,6 +132,7 @@ end
 
 before 'deploy:db_migrate', 'configuration:copy_secrets'
 after 'deploy', 'deploy:db_migrate'
+after 'deploy:db_migrate', 'deploy:data_migrate'
 after 'deploy:db_migrate', 'deploy:precompile_assets'
 after 'deploy', 'deploy:cleanup'
 after 'deploy', 'deploy:restart'


### PR DESCRIPTION
Why:

* Because Sipity is a data driven application and its schema as well
  as data are equally important.

This change addresses the need by:

* Adding an `after 'deploy:db_migrate'` hook to ensure
  `deploy:data_migrate` is run

[skip ci]