### PR TITLE
Updating according to reek

### DIFF
--- a/.reek.config
+++ b/.reek.config
@@ -1,0 +1,19 @@
+# Use the following configuration when running the reek command
+#
+# ```console
+# $ bundle exec reek -c .reek.config app/
+# ```
+#
+# See https://github.com/troessner/reek for more details
+---
+LongParameterList:
+  enabled: true
+  exclude: []
+  max_params: 4
+  overrides:
+    initialize:
+      max_params: 5
+UtilityFunction:
+  enabled: false
+PrimaDonnaMethod:
+  enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :doc do
   gem 'railroady', require: false, github: 'jeremyf/railroady', branch: 'allowing-namespaced-models'
   gem 'yard', require: false
   gem 'yard-activerecord', require: false
+  gem 'reek', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
   specs:
+    abstract_type (0.0.7)
     actionmailer (4.2.4)
       actionpack (= 4.2.4)
       actionview (= 4.2.4)
@@ -111,6 +112,9 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    adamantium (0.2.0)
+      ice_nine (~> 0.11.0)
+      memoizable (~> 0.4.0)
     addressable (2.3.8)
     arel (6.0.3)
     ast (2.1.0)
@@ -190,6 +194,9 @@ GEM
       rubocop
       scss-lint
       simplecov
+    concord (0.1.5)
+      adamantium (~> 0.2.0)
+      equalizer (~> 0.0.9)
     crass (1.0.2)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
@@ -221,6 +228,7 @@ GEM
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       request_store (~> 1.0)
+    equalizer (0.0.11)
     erubis (2.7.0)
     excon (0.45.4)
     execjs (2.6.0)
@@ -290,6 +298,7 @@ GEM
     i18n (0.7.0)
     i18n-debug (1.1.0)
       i18n (< 1)
+    ice_nine (0.11.1)
     inch (0.7.0)
       pry
       sparkr (>= 0.2.0)
@@ -324,6 +333,8 @@ GEM
     lumberjack (1.0.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
     meta_request (0.3.4)
       callsite (~> 0.0, >= 0.0.11)
       rack-contrib (~> 1.1)
@@ -356,6 +367,7 @@ GEM
       websocket-driver (>= 0.2.0)
     power_converter (0.0.5)
     powerpack (0.1.1)
+    procto (0.0.2)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -416,6 +428,10 @@ GEM
       ffi (>= 0.5.0)
     rb-readline (0.5.3)
     rdiscount (2.1.8)
+    reek (2.2.1)
+      parser (~> 2.2)
+      rainbow (~> 2.0)
+      unparser (~> 0.2.2)
     request_store (1.2.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
@@ -547,6 +563,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    unparser (0.2.4)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      concord (~> 0.1.5)
+      diff-lcs (~> 1.2.5)
+      equalizer (~> 0.0.9)
+      parser (~> 2.2.2)
+      procto (~> 0.0.2)
     warden (1.2.3)
       rack (>= 1.0)
     websocket (1.2.2)
@@ -629,6 +653,7 @@ DEPENDENCIES
   rb-inotify
   rb-readline
   rdiscount
+  reek
   responders (~> 2.0)
   rspec-given
   rspec-html-matchers (~> 0.6)

--- a/app/controllers/sipity/controllers/work_areas_controller.rb
+++ b/app/controllers/sipity/controllers/work_areas_controller.rb
@@ -41,8 +41,9 @@ module Sipity
       def query_or_command_attributes
         # Munging pagination into the work area attributes. This is a concession
         # for having a common handler for the query_action.
+        page_param_key_name = Kaminari.config.param_name
         params.fetch(:work_area) { HashWithIndifferentAccess.new }.tap do |work_area|
-          work_area[:page] = params[Kaminari.config.param_name] if params.key?(Kaminari.config.param_name) && !work_area.key?(:page)
+          work_area[:page] = params[page_param_key_name] if params.key?(page_param_key_name) && !work_area.key?(:page)
         end
       end
     end

--- a/app/services/sipity/services/apply_access_policies_to.rb
+++ b/app/services/sipity/services/apply_access_policies_to.rb
@@ -14,8 +14,8 @@ module Sipity
         self.work = work
         self.access_policies = Array.wrap(access_policies)
       end
-      attr_accessor :user, :work, :access_policies
-      private(:user=, :work=, :access_policies=)
+
+      attr_reader :user, :work, :access_policies
 
       def call
         access_policies.each do |attributes|
@@ -24,6 +24,8 @@ module Sipity
       end
 
       private
+
+      attr_writer :user, :work, :access_policies
 
       include Conversions::ConvertToDate
 

--- a/app/services/sipity/services/netid_query_service.rb
+++ b/app/services/sipity/services/netid_query_service.rb
@@ -59,10 +59,10 @@ module Sipity
         JSON.parse(response).fetch('people').first
       end
 
-      def url
-        base_uri = URI.parse(Figaro.env.hesburgh_api_host!)
+      def url(env: Figaro.env)
+        base_uri = URI.parse(env.hesburgh_api_host!)
         base_uri.path = "/1.0/people/by_netid/#{netid}.json"
-        base_uri.query = "auth_token=#{Figaro.env.hesburgh_api_auth_token!}"
+        base_uri.query = "auth_token=#{env.hesburgh_api_auth_token!}"
         base_uri.to_s
       end
     end

--- a/app/services/sipity/services/noid_minter.rb
+++ b/app/services/sipity/services/noid_minter.rb
@@ -8,11 +8,11 @@ module Sipity
         connection.mint.first
       end
 
-      def connection
+      def connection(env: Figaro.env)
         return @connection if @connection.present?
-        server = Figaro.env.noid_server!
-        port = Figaro.env.noid_port!.to_i
-        pool = Figaro.env.noid_pool!
+        server = env.noid_server!
+        port = env.noid_port!.to_i
+        pool = env.noid_pool!
         @connection = ::NoidsClient::Connection.new("#{server}:#{port}").get_pool(pool)
       end
     end


### PR DESCRIPTION
## Adding reek for finding code smells

@887cd145504e20ca2c7cd5aa5370063f48e94f7f

Why:

* Because we want to avoid smelly code.

This change addresses the need by:

* `$ reek app/` to see what Reek identifies as possible code smells.

## Adding a .reek.config file

@0a2a11c29a5189f540fa2525ba160155e315179f

In addition to leveraging Rubocop, I want to explore the automation
and analysis provided by [reek](https://github.com/troessner/reek).

There is some overlap between what Rubocop detects and checks for,
versus what reek looks for.

```console
$ bundle exec reek -c .reek.config app/
```

## Updating code based on Reek

@c88e862215e5d8f557a759174514426aa29affc0

Responding to the following message:

```console
Sipity::Controllers::WorkAreasController#query_or_command_attributes
calls Kaminari.config 2 times (DuplicateMethodCall)
```

## Fixing a code smell found by Reek

@bd03772fa55a5a57372d6dfd10f5827ae48aa6ea

```console
[17]:Sipity::Services::ApplyAccessPoliciesTo#access_policies is a
     writable attribute (Attribute)
[17]:Sipity::Services::ApplyAccessPoliciesTo#user is a writable
     attribute (Attribute)
[17]:Sipity::Services::ApplyAccessPoliciesTo#work is a writable
     attribute (Attribute)
```

## Removing duplicate method call

@ff2d6c7d086effe0b79fecbf408ca67b629a692a

```console
[13, 14, 15]:Sipity::Services::NoidMinter#connection calls Figaro.env 3
             times (DuplicateMethodCall)
```

## Updating method as per Reek

@39579c35a110707e1ddae94be674d4fc4fda733d

```console
[63, 65]:Sipity::Services::NetidQueryService#url calls Figaro.env 2
         times (DuplicateMethodCall)
```
