### PR TITLE
Adding documentation on ETD bulk ingest testing

### DIFF
--- a/app/jobs/sipity/jobs.rb
+++ b/app/jobs/sipity/jobs.rb
@@ -3,6 +3,8 @@ module Sipity
   # That means we are only passing primatives to the Jobs and it is
   # the Jobs responsibility to reify the correct objects.
   #
+  # @note As a matter of procedure, the steps for testing the various jobs against live data can be found in each of the jobs.
+  #
   # @see https://github.com/resque/resque Resque gem
   module Jobs
     # Herein lies the inflection point. If you want to run things

--- a/app/jobs/sipity/jobs/etd/bulk_ingest_job.rb
+++ b/app/jobs/sipity/jobs/etd/bulk_ingest_job.rb
@@ -4,7 +4,29 @@ module Sipity
       # Responsible for managing the ingest of each and every work in the :work_area that is in the :initial_processing_state_name.
       #
       # As these are jobs, I believe that I want the parameters to all be primatives (i.e. a String, an Integer). This way they can
-      # be serialized without holding too much state.
+      # be serialized without holding too much state. The BulkIngestJob makes use of the [curatend-batch](https://github.com/ndlib/curatend-batch)
+      # process.
+      #
+      # @note Run the Bulk Ingest Job from development; As with all how to documentation, your mileage may vary
+      #   1. Mount the curatend-batch directory (smb://library.corpfs.nd.edu/DCNS/Library/Departmental/curatend-batch)
+      #      * In OS X, go to Finder, Connect to Server… [Cmd+K] and paste the above URL
+      #   2. Update the ./config/application.yml entries for :curate_batch_data_mount_path and :curate_batch_queue_mount_path.
+      #      The following is the examples for the libvirt6 environment.
+      #
+      #        curate_batch_data_mount_path: /Volumes/curatend-batch/data/sipity/libvirt6
+      #        curate_batch_queue_mount_path: /Volumes/curatend-batch/test/libvirt6/queue
+      #
+      #      * *Please review the directory structure of the mounted drive as that may have changed*
+      #   3. Open up a Terminal window
+      #      1. Change directory (cd) into the root of this Rails project
+      #      2. Run the following command `rails runner 'Sipity::Jobs::Etd::BulkIngestJob.call'`
+      #   4. Review the mounted queue subdirectories (i.e. `/Volumes/curatend-batch/test/libvirt6/queue`) for successes and failures
+      #
+      #   In some cases you may need to make changes to address that you don't have a copy of the attachments, see
+      #   Sipity::Models::Attachment for more information on how to do this.
+      #
+      # @see Sipity::Models::Attachment for information on faking attached files.
+      # @see https://github.com/ndlib/curatend-batch curatend-batch
       class BulkIngestJob
         def self.call(**keywords)
           new(**keywords).call

--- a/app/models/sipity/models/attachment.rb
+++ b/app/models/sipity/models/attachment.rb
@@ -1,6 +1,15 @@
 module Sipity
   module Models
     # Represents a single file attached to a given work.
+    #
+    # If you want to always fake having an attachment (i.e. you copied the production database to your local machine but did not copy
+    # the production attachments from their filesystem) add the following to the class definition:
+    #
+    #      if Rails.env.development?
+    #        after_initialize do |obj|
+    #          obj.file = File.new(__FILE__)
+    #        end
+    #      end
     class Attachment < ActiveRecord::Base
       extend Dragonfly::Model
       self.table_name = 'sipity_attachments'


### PR DESCRIPTION
I went through a handful of simple yet not entirely obvious steps for
testing the ETD production data for bulk ingest. This commit adds the
information needed to run those tests.

[skip ci]