### PR TITLE
Adding html scrubbing for data

### DIFF
--- a/app/models/sipity/models/additional_attribute.rb
+++ b/app/models/sipity/models/additional_attribute.rb
@@ -1,3 +1,5 @@
+require 'hesburgh/lib/html_scrubber'
+
 module Sipity
   module Models
     # A rudimentary container for all (as of now string based) attributes
@@ -72,6 +74,13 @@ module Sipity
           OCLC_NUMBER => OCLC_NUMBER
         }
       )
+
+      # The predicate definitions are nearby, so that is why I'm providing the
+      # lookup container.
+      def self.scrubber_for(predicate_name:, container: Hesburgh::Lib::HtmlScrubber)
+        return container.build_inline_scrubber if predicate_name.to_s =~ /title\Z/
+        container.build_block_scrubber
+      end
     end
   end
 end

--- a/app/models/sipity/models/work.rb
+++ b/app/models/sipity/models/work.rb
@@ -1,3 +1,5 @@
+require 'hesburgh/lib/html_scrubber'
+
 module Sipity
   module Models
     # The most basic of information required for generating a valid work.
@@ -27,6 +29,10 @@ module Sipity
       enum(work_type: WorkType.all_for_enum_configuration)
 
       after_initialize :set_default_work_type, if: :new_record?
+
+      def title=(input, scrubber: Hesburgh::Lib::HtmlScrubber.build_inline_scrubber)
+        super(scrubber.sanitize(input))
+      end
 
       private
 

--- a/app/repositories/sipity/commands/additional_attribute_commands.rb
+++ b/app/repositories/sipity/commands/additional_attribute_commands.rb
@@ -13,7 +13,9 @@ module Sipity
       end
 
       def create_work_attribute_values!(work:, key:, values:)
-        Array.wrap(values).each do |value|
+        scrubber = Models::AdditionalAttribute.scrubber_for(predicate_name: key)
+        Array.wrap(values).each do |raw_value|
+          value = scrubber.sanitize(raw_value)
           Models::AdditionalAttribute.create!(work: work, key: key, value: value) if value.present?
         end
       end

--- a/db/data/20151106140726_remediate_html_entities.rb
+++ b/db/data/20151106140726_remediate_html_entities.rb
@@ -1,0 +1,20 @@
+class RemediateHtmlEntities < ActiveRecord::Migration
+  def self.up
+    model = Sipity::Models::AdditionalAttribute
+    model.find_each do |additional_attribute|
+      scrubber = model.scrubber_for(predicate_name: additional_attribute.key)
+      scrubbed_value = scrubber.sanitize(additional_attribute.value)
+      additional_attribute.update_column(:value, scrubbed_value)
+    end
+
+    inline_scrubber = Hesburgh::Lib::HtmlScrubber.build_inline_scrubber
+    Sipity::Models::Work.find_each do |work|
+      scrubbed_title = inline_scrubber.sanitize(work.title)
+      work.update_column(:title, scrubbed_title)
+    end
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/hesburgh/lib/html_scrubber.rb
+++ b/lib/hesburgh/lib/html_scrubber.rb
@@ -1,0 +1,112 @@
+require 'loofah/scrubber'
+
+module Hesburgh
+  module Lib
+    # Exposes a consistent means of scrubbing HTML
+    #
+    # @see Rails `sanitize` method
+    # @todo Extract to the Hesburgh::Lib gem
+    module HtmlScrubber
+      ALLOWED_INLINE_TAGS = %w(a abbr acronym b big cit cite code dfn em i mark samp small strong sub sup time tt var).freeze
+      ALLOWED_INLINE_ATTRIBUTES = %w(datetime title href rel dir).freeze
+      ALLOWED_BLOCK_ATTRIBUTES = ALLOWED_INLINE_ATTRIBUTES
+
+      # We want to render this information as part of the metadata of a page. Examples include the `html head title` attribute
+      def self.build_meta_tag_scrubber(tags: [], attributes: :fallback)
+        AllowedTagsScrubber.new(tags: tags, attributes: attributes)
+      end
+
+      # We expect a single line of content. Examples include a "title" of an item
+      def self.build_inline_scrubber(tags: ALLOWED_INLINE_TAGS, attributes: ALLOWED_INLINE_ATTRIBUTES)
+        AllowedTagsScrubber.new(tags: tags, attributes: attributes)
+      end
+
+      # We are allowing multiple lines of content. Examples include an "abstract" of an item
+      def self.build_block_scrubber
+        AllowedTagsScrubber.new(tags: AllowedTagsScrubber::FALLBACK, attributes: ALLOWED_BLOCK_ATTRIBUTES)
+      end
+
+      # place this file to app/scrubbers/ directory
+      #
+      # This scrubber is analog of :strip build-in scrubber
+      #  (http://rubydoc.info/github/flavorjones/loofah/master/Loofah/Scrubbers/Strip)
+      # with allowed @tags and @attributes lists.
+      # Fallback to default :strip behavior included.
+      class AllowedTagsScrubber < Loofah::Scrubber
+        FALLBACK = :fallback
+        def initialize(tags: FALLBACK, attributes: FALLBACK, direction: :bottom_up)
+          self.direction = direction
+          self.tags = tags
+          self.attributes = attributes
+        end
+
+        # A convenience method for sanitiziation
+        def sanitize(input)
+          Loofah.fragment(input).scrub!(self).to_s
+        end
+        alias_method :call, :sanitize
+
+        def scrub(node)
+          return node.remove if script_node?(node)
+          if node_allowed?(node)
+            scrub_node_attributes(node)
+            return CONTINUE
+          else
+            node.before node.children
+            node.remove
+          end
+        end
+
+        private
+
+        attr_reader :tags, :attributes
+        attr_accessor :direction
+
+        def tags=(input)
+          @tags = extract_with_fallback_consideration(input)
+        end
+
+        def attributes=(input)
+          @attributes = extract_with_fallback_consideration(input)
+        end
+
+        def extract_with_fallback_consideration(input)
+          return FALLBACK if input == FALLBACK
+          Array.wrap(input)
+        end
+
+        def script_node?(node)
+          node.name == 'script'
+        end
+
+        def scrub_node_attributes(node)
+          return fallback_scrub_node_attributes(node) if attributes == FALLBACK
+          node.attribute_nodes.each do |attr_node|
+            attr_node.remove unless attributes.include?(attr_node.name)
+          end
+        end
+
+        def allowed_not_element_node_types
+          [Nokogiri::XML::Node::TEXT_NODE, Nokogiri::XML::Node::CDATA_SECTION_NODE]
+        end
+
+        def fallback_scrub_node_attributes(node)
+          Loofah::HTML5::Scrub.scrub_attributes(node)
+          true
+        end
+
+        def fallback_allowed_element_detection(node)
+          Loofah::HTML5::Scrub.allowed_element?(node.name)
+        end
+
+        def node_allowed?(node)
+          return fallback_allowed_element_detection(node) if tags == FALLBACK
+          return true if allowed_not_element_node_types.include?(node.type)
+          return false unless node.type == Nokogiri::XML::Node::ELEMENT_NODE
+          tags.include?(node.name)
+        end
+      end
+      private_constant :AllowedTagsScrubber
+    end
+  end
+end

--- a/spec/lib/hesburgh/lib/html_scrubber_spec.rb
+++ b/spec/lib/hesburgh/lib/html_scrubber_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
     subject { described_class.build_inline_scrubber }
     it { should respond_to(:call) }
     {
+      nil => '',
       %(<p>Hello</p>) => %(Hello),
       %(Hello) => %(Hello),
       %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
@@ -21,6 +22,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
     context 'with tags: :fallback' do
       subject { described_class.build_inline_scrubber(tags: :fallback) }
       {
+        nil => '',
         %(<p>Hello</p>) => %(<p>Hello</p>),
         %(Hello) => %(Hello),
         %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
@@ -37,6 +39,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
     context 'with attributes: :fallback' do
       subject { described_class.build_inline_scrubber(attributes: :fallback) }
       {
+        nil => '',
         %(<p>Hello</p>) => %(Hello),
         %(Hello) => %(Hello),
         %(<script><i>Hello</i></script>) => %(),
@@ -54,6 +57,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
     subject { described_class.build_block_scrubber }
     it { should respond_to(:call) }
     {
+      nil => '',
       %(<p>Hello</p>) => %(<p>Hello</p>),
       %(Hello) => %(Hello),
       %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
@@ -71,6 +75,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
     subject { described_class.build_meta_tag_scrubber }
     it { should respond_to(:call) }
     {
+      nil => '',
       %(<p>Hello</p>) => %(Hello),
       %(Hello) => %(Hello),
       %(<i>Hello<script><i>World</i></script></i>) => %(Hello),

--- a/spec/lib/hesburgh/lib/html_scrubber_spec.rb
+++ b/spec/lib/hesburgh/lib/html_scrubber_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'hesburgh/lib/html_scrubber'
+
+RSpec.describe Hesburgh::Lib::HtmlScrubber do
+  context '.build_inline_scrubber' do
+    subject { described_class.build_inline_scrubber }
+    it { should respond_to(:call) }
+    {
+      %(<p>Hello</p>) => %(Hello),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(Hello <a href="http://world.com">World</a>),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World <i>Are we there yet?</i>)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+
+    context 'with tags: :fallback' do
+      subject { described_class.build_inline_scrubber(tags: :fallback) }
+      {
+        %(<p>Hello</p>) => %(<p>Hello</p>),
+        %(Hello) => %(Hello),
+        %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+        %(<script><i>Hello</i></script>) => %(),
+        %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(<p>Hello <a href="http://world.com">World</a></p>),
+        %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello <p>World <i>Are we there yet?</i></p>)
+      }.each do |input, expected|
+        it "will scrub #{input.inspect} into #{expected.inspect}" do
+          expect(subject.sanitize(input)).to eq(expected)
+        end
+      end
+    end
+
+    context 'with attributes: :fallback' do
+      subject { described_class.build_inline_scrubber(attributes: :fallback) }
+      {
+        %(<p>Hello</p>) => %(Hello),
+        %(Hello) => %(Hello),
+        %(<script><i>Hello</i></script>) => %(),
+        %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+        %(<p>Hello <a href="http://world.com" bad_attr="_blank">World</a></p>) => %(Hello <a href="http://world.com">World</a>),
+        %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World <i>Are we there yet?</i>)
+      }.each do |input, expected|
+        it "will scrub #{input.inspect} into #{expected.inspect}" do
+          expect(subject.sanitize(input)).to eq(expected)
+        end
+      end
+    end
+  end
+  context '.build_block_scrubber' do
+    subject { described_class.build_block_scrubber }
+    it { should respond_to(:call) }
+    {
+      %(<p>Hello</p>) => %(<p>Hello</p>),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(<i>Hello</i>),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(<p>Hello <a href="http://world.com">World</a></p>),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello <p>World <i>Are we there yet?</i></p>)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+  end
+
+  context '.build_meta_tag_scrubber' do
+    subject { described_class.build_meta_tag_scrubber }
+    it { should respond_to(:call) }
+    {
+      %(<p>Hello</p>) => %(Hello),
+      %(Hello) => %(Hello),
+      %(<i>Hello<script><i>World</i></script></i>) => %(Hello),
+      %(<script><i>Hello</i></script>) => %(),
+      %(<p>Hello <a href="http://world.com" target="_blank">World</a></p>) => %(Hello World),
+      %(Hello <p>World <i>Are we there yet?</i></p>) => %(Hello World Are we there yet?)
+    }.each do |input, expected|
+      it "will scrub #{input.inspect} into #{expected.inspect}" do
+        expect(subject.sanitize(input)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/models/sipity/models/additional_attribute_spec.rb
+++ b/spec/models/sipity/models/additional_attribute_spec.rb
@@ -13,6 +13,13 @@ module Sipity
         expect { subject.key = '__incorrect_strategy__' }.to raise_error(ArgumentError)
       end
 
+      context '.scrubber_for' do
+        described_class.keys.each do |predicate_name, _|
+          it "will have exist for the #{predicate_name.inspect} predicate" do
+            expect(described_class.scrubber_for(predicate_name: predicate_name)).to respond_to(:sanitize)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/sipity/models/work_spec.rb
+++ b/spec/models/sipity/models/work_spec.rb
@@ -13,6 +13,11 @@ module Sipity
         its(:column_names) { should include('title') }
       end
 
+      it 'will sanitize its title' do
+        subject = Work.new(title: '<p>Hello<script>World</script></p>')
+        expect(subject.title).to eq('Hello')
+      end
+
       its(:to_s) { should eq(subject.title) }
 
       it { should respond_to :processing_strategy }

--- a/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
+++ b/spec/repositories/sipity/commands/additional_attribute_commands_spec.rb
@@ -23,6 +23,11 @@ module Sipity
           to_not change { subject.work_attribute_values_for(work: work, key: key) }
       end
 
+      it 'will not create nodes for script tags' do
+        expect { subject.update_work_attribute_values!(work: work, key: key, values: '<script>L337</script>') }.
+          to_not change { subject.work_attribute_values_for(work: work, key: key) }
+      end
+
       it 'will destroy_work_attribute_values a key/value pair if the value exists but is not part of the update' do
         subject.create_work_attribute_values!(work: work, key: key, values: 'abc')
         subject.update_work_attribute_values!(work: work, key: key, values: 'new_value')


### PR DESCRIPTION
## Adding Hesburgh::Lib::HtmlScrubber module

@861efbf013b7666ab19087dcd31d7fda54b3b026

Why:

* Because there are different strategies for scrubbing/sanitizing HTML
  data.

## Adding sanitization of HTML tags on input

@654941d119cef5eeaa1d29ee8a44e2e4a0036828

Why:

* Because we are getting all kinds of outrageous tags that have been
  pasted from Word (and the RTE).

This change addresses the need by:

* Catching all "additional attributes" and the title of the work.

## Adding a sanitization scenario for verification

@91c993882855a2491b404c4a66a6471c8f8b2a33

Though I had a feeling the scrubber would behave this way, I wanted to
be certain.

## Adding data scrubbing data migration

@640ae7e2e93e29f08e795c325bacc8430ee2bf5e

Why:

* Because we have overly chatty HTML in our database. Prior commits
  handle scrubbing at the point of persistence; However it does not
  account for the data that has already been persisted.
