### PR TITLE
Adding intermediary state for etd catalogin

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
@@ -94,6 +94,7 @@ module Sipity
                 'advisor_changes_requested',
                 'under_grad_school_review',
                 'grad_school_changes_requested',
+                'grad_school_approved_but_waiting_for_routing',
                 'ready_for_ingest',
                 'ready_for_cataloging',
                 'back_from_cataloging',
@@ -210,7 +211,7 @@ module Sipity
                   ['respond_to_grad_school_request'],
                   ['creating_user']
                 ],[
-                  ['new', 'under_advisor_review', 'advisor_changes_requested', 'under_grad_school_review', 'grad_school_changes_requested', 'ready_for_cataloging', 'back_from_cataloging', 'ready_for_ingest'],
+                  ['new', 'under_advisor_review', 'advisor_changes_requested', 'under_grad_school_review', 'grad_school_changes_requested', 'ready_for_cataloging', 'grad_school_approved_but_waiting_for_routing', 'back_from_cataloging', 'ready_for_ingest'],
                   ['show'],
                   ['creating_user', 'advisor', 'etd_reviewer'],
                 ],[
@@ -230,7 +231,7 @@ module Sipity
                   ['destroy'],
                   ['etd_reviewer']
                 ],[
-                  ['new', 'under_advisor_review', 'advisor_changes_requested', 'under_grad_school_review', 'grad_school_changes_requested', 'ready_for_cataloging', 'back_from_cataloging', 'ready_for_ingest'],
+                  ['new', 'grad_school_approved_but_waiting_for_routing', 'under_advisor_review', 'advisor_changes_requested', 'under_grad_school_review', 'grad_school_changes_requested', 'ready_for_cataloging', 'back_from_cataloging', 'ready_for_ingest'],
                   ['debug'],
                   ['etd_reviewer']
                 ],[
@@ -256,6 +257,10 @@ module Sipity
                 ],[
                   ['under_grad_school_review', 'grad_school_changes_requested'],
                   ['grad_school_requests_change', 'send_to_cataloging', 'ingest_with_postponed_cataloging'],
+                  ['etd_reviewer']
+                ],[
+                  ['grad_school_approved_but_waiting_for_routing'],
+                  ['send_to_cataloging', 'ingest_with_postponed_cataloging'],
                   ['etd_reviewer']
                 ],[
                   ['ready_for_ingest'],

--- a/db/data/20150909173721_migration_to_include_cataloging_workflow.rb
+++ b/db/data/20150909173721_migration_to_include_cataloging_workflow.rb
@@ -29,8 +29,8 @@ class MigrationToIncludeCatalogingWorkflow < ActiveRecord::Migration
   end
 
   def each_etd_entities
-    Sipity::Models::WorkSubmission.find_each do |work_submission|
-      yield(convert_to_entity(work_submission.work)) if work_submission.work_area == etd_work_area
+    Sipity::Models::WorkSubmission.where(work_area: etd_work_area).find_each do |work_submission|
+      yield(convert_to_entity(work_submission.work))
     end
   end
 
@@ -45,7 +45,9 @@ class MigrationToIncludeCatalogingWorkflow < ActiveRecord::Migration
   end
 
   def required_strategy_state_for(entity)
-    Sipity::Models::Processing::StrategyState.where(strategy_id: entity.strategy_id, name: 'ready_for_cataloging').first
+    Sipity::Models::Processing::StrategyState.find_by!(
+      strategy_id: entity.strategy_id, name: 'grad_school_approved_but_waiting_for_routing'
+    )
   end
 
   def log_entities(successfully_migrated, errored_while_migrating)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150717153523) do
+ActiveRecord::Schema.define(version: 20151106140726) do
+
+  create_table "data_migrations", id: false, force: :cascade do |t|
+    t.string "version", limit: 255, null: false
+  end
+
+  add_index "data_migrations", ["version"], name: "unique_data_migrations", unique: true, using: :btree
 
   create_table "sipity_access_rights", force: :cascade do |t|
     t.string   "entity_id",         limit: 32,  null: false

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -72,8 +72,9 @@ module Sipity
           # demonstrates what's working
           expect(subject).to eq(
             [
-              "advisor_changes_requested", "back_from_cataloging", "grad_school_changes_requested", "ingested", "ingesting",
-              "new", "ready_for_cataloging", "ready_for_ingest", "under_advisor_review", "under_grad_school_review"
+              "advisor_changes_requested", "back_from_cataloging", "grad_school_approved_but_waiting_for_routing",
+              "grad_school_changes_requested", "ingested", "ingesting", "new", "ready_for_cataloging", "ready_for_ingest",
+              "under_advisor_review", "under_grad_school_review"
             ]
           )
         end


### PR DESCRIPTION
## Adding sequestering state for ETD workflow

@1751114f0fbc8f6bdee68ea05dd952a101f3d14e

Because at this point in time, we have marked objects as ready for
ingest; However they are not ready as they need to either go through
cataloging or be marked as ready for immediate ingest with delayed
cataloging.

The plan is to change the data migration, which has yet to run, to
move items from Ready for Ingest to the temporary, though more
appropriate 'grad_school_approved_but_waiting_for_routing'.

## Adding the data_migrations schema table.

@fa5cb37a243087e9f736babb845eaee0e2d27505
