### PR TITLE
Adding cardinality to work attribute queries.

### DIFF
--- a/app/repositories/sipity/queries/additional_attribute_queries.rb
+++ b/app/repositories/sipity/queries/additional_attribute_queries.rb
@@ -1,16 +1,23 @@
+require 'sipity/conversions/convert_to_work'
+require 'active_support/core_ext/array/wrap'
+
 module Sipity
   module Queries
     # Queries
     # TODO: These methods need to no longer be module_functions; I believe the
     #   direction is to look towards creating service objects.
     module AdditionalAttributeQueries
-      def work_attribute_values_for(work:, key:)
-        Models::AdditionalAttribute.where(work: work, key: key).pluck(:value)
+      def work_attribute_values_for(work:, key:, cardinality: :many)
+        work = Conversions::ConvertToWork.call(work)
+        scope = Models::AdditionalAttribute.where(work_id: work.id, key: key)
+        scope = scope.limit(cardinality) unless cardinality == :many
+        scope.pluck(:value)
       end
 
       def work_attribute_key_value_pairs(work:, keys: [])
-        query = Models::AdditionalAttribute.where(work: work).order(:work_id, :key)
-        query = query.where(key: keys) if keys.present?
+        work = Conversions::ConvertToWork.call(work)
+        query = Models::AdditionalAttribute.where(work_id: work.id).order(:work_id, :key)
+        query = query.where(key: Array.wrap(keys)) if keys.present?
         query.pluck(:key, :value)
       end
     end

--- a/spec/repositories/sipity/queries/additional_attribute_queries_spec.rb
+++ b/spec/repositories/sipity/queries/additional_attribute_queries_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'sipity/queries/additional_attribute_queries'
+
+RSpec.describe Sipity::Queries::AdditionalAttributeQueries, type: :isolated_repository_module do
+  let(:work) { Sipity::Models::Work.new(id: 1) }
+  let(:another_work) { Sipity::Models::Work.new(id: 2) }
+  context '#work_attribute_values_for' do
+    subject { test_repository.work_attribute_values_for(work: work, key: 'alternate_title') }
+    before do
+      Sipity::Models::AdditionalAttribute.create!(work_id: work.id, key: 'alternate_title', value: 'Title is Chicken')
+      Sipity::Models::AdditionalAttribute.create!(work_id: another_work.id, key: 'alternate_title', value: 'Title is Soup')
+      Sipity::Models::AdditionalAttribute.create!(work_id: work.id, key: 'abstract', value: 'An Abstract')
+      Sipity::Models::AdditionalAttribute.create!(work_id: work.id, key: 'alternate_title', value: 'Title is Egg')
+    end
+
+    it 'will limit search to the given work' do
+      expect(test_repository.work_attribute_values_for(work: work, key: 'alternate_title')).to eq(['Title is Chicken', 'Title is Egg'])
+    end
+
+    it 'will limit based on cardinality' do
+      expect(test_repository.work_attribute_values_for(work: work, key: 'alternate_title', cardinality: 1)).to eq(['Title is Chicken'])
+    end
+  end
+  context '#work_attribute_key_value_pairs' do
+    before do
+      Sipity::Models::AdditionalAttribute.create!(work_id: work.id, key: 'alternate_title', value: 'Title is Chicken')
+      Sipity::Models::AdditionalAttribute.create!(work_id: another_work.id, key: 'alternate_title', value: 'Title is Soup')
+      Sipity::Models::AdditionalAttribute.create!(work_id: work.id, key: 'abstract', value: 'An Abstract')
+      Sipity::Models::AdditionalAttribute.create!(work_id: work.id, key: 'alternate_title', value: 'Title is Egg')
+    end
+
+    it 'will limit based on given keys' do
+      expect(test_repository.work_attribute_key_value_pairs(work: work, keys: 'alternate_title')).
+        to eq([["alternate_title", "Title is Chicken"], ["alternate_title", "Title is Egg"]])
+    end
+
+    it 'will return all keys if none are given' do
+      expect(test_repository.work_attribute_key_value_pairs(work: work)).
+        to eq([["abstract", "An Abstract"], ["alternate_title", "Title is Chicken"], ["alternate_title", "Title is Egg"]])
+    end
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -370,7 +370,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
-    def work_attribute_values_for(work:, key:)
+    def work_attribute_values_for(work:, key:, cardinality: :many)
     end
 
     # @see ./app/repositories/sipity/queries/collaborator_queries.rb

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -242,7 +242,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
-    def work_attribute_values_for(work:, key:)
+    def work_attribute_values_for(work:, key:, cardinality: :many)
     end
 
     # @see ./app/repositories/sipity/queries/collaborator_queries.rb


### PR DESCRIPTION
Because sometimes I want just one attribute and other times I'll want
many. This puts the declaration on the form that calls the method. It
also moves towards a more expressive design.