### PR TITLE
Adding creator to the show page

### DIFF
--- a/app/presenters/sipity/controllers/creator_presenter.rb
+++ b/app/presenters/sipity/controllers/creator_presenter.rb
@@ -1,0 +1,29 @@
+require 'sipity/controllers/translation_assistant'
+
+module Sipity
+  module Controllers
+    # Responsible for presenting a collaborator.
+    class CreatorPresenter < Curly::Presenter
+      presents :creator
+
+      def initialize(context, options = {})
+        # Because the keys could be string or symbol
+        self.work_submission = options.fetch('work_submission') { options.fetch(:work_submission) }
+        super
+      end
+
+      def label(identifier)
+        TranslationAssistant.call(scope: :predicates, subject: work_submission, object: identifier, predicate: :label)
+      end
+
+      def name
+        creator.to_s
+      end
+
+      private
+
+      attr_accessor :work_submission
+      attr_reader :creator
+    end
+  end
+end

--- a/app/presenters/sipity/controllers/work_submissions/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_submissions/show_presenter.rb
@@ -74,6 +74,14 @@ module Sipity
           collaborators.present?
         end
 
+        def creators?
+          creators.present?
+        end
+
+        def creators
+          @creators ||= repository.scope_users_for_entity_and_roles(entity: work_submission, roles: Sipity::Models::Role::CREATING_USER)
+        end
+
         def work_type
           TranslationAssistant.call(scope: :work_types, subject: work_submission.work_type)
         end

--- a/app/views/sipity/controllers/work_submissions/show.html.curly
+++ b/app/views/sipity/controllers/work_submissions/show.html.curly
@@ -39,6 +39,21 @@
             <dd class="value title">{{ title }}</dd>
             <dt class="predicate work-type">{{label.work_type}}</dt>
             <dd class="value work-type">{{work_type}}</dd>
+            {{#creators?}}
+              <dt class="predicate creators">{{label.creators}}</dt>
+              <dd class="value creators">
+                <ul class="nested-attributes-list">
+                  {{*creators}}
+                    <li class="nested-attribute-list">
+                      <dl class="nested-attribute-definition">
+                        <dt class="predicate name">{{label.name}}</dt>
+                        <dd class="value name">{{name}}</dd>
+                      </dl>
+                    </li>
+                  {{/creators}}
+                </ul>
+              </dd>
+            {{/creators?}}
             {{#collaborators?}}
               <dt class="predicate collaborators">{{label.collaborators}}</dt>
               <dd class="value collaborators">

--- a/spec/presenters/sipity/controllers/creator_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/creator_presenter_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'sipity/controllers/creator_presenter'
+
+module Sipity
+  module Controllers
+    RSpec.describe CreatorPresenter do
+      let(:context) { PresenterHelper::Context.new(current_user: current_user, render: true) }
+      let(:current_user) { double }
+      let(:creator) { double(to_s: 'Hello World') }
+      let(:work) { Models::Work.new(id: '1') }
+      subject { described_class.new(context, work_submission: work, creator: creator) }
+
+      its(:name) { should eq(creator.to_s) }
+
+      it 'will translate the identified label' do
+        expect(TranslationAssistant).to receive(:call).with(scope: :predicates, object: 'name', subject: work, predicate: :label).
+          and_return('My Name Is')
+        expect(subject.label('name')).to eq('My Name Is')
+      end
+    end
+  end
+end

--- a/spec/presenters/sipity/controllers/work_submissions/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_submissions/show_presenter_spec.rb
@@ -10,7 +10,7 @@ module Sipity
         let(:current_user) { double('Current User') }
         let(:work_submission) { Models::Work.new(id: 'hello-world') }
         let(:repository) { QueryRepositoryInterface.new }
-        subject { described_class.new(context, work_submission: work_submission) }
+        subject { described_class.new(context, work_submission: work_submission, repository: repository) }
 
         its(:default_repository) { should respond_to :find_current_comments_for }
 
@@ -114,6 +114,22 @@ module Sipity
           expect(ComposableElements::ProcessingActionsComposer).to receive(:new).
             with(user: current_user, entity: work_submission)
           subject
+        end
+
+        context '#creators?' do
+          it 'will be true if there is at least one creating user' do
+            expect(repository).to receive(:scope_users_for_entity_and_roles).with(
+              entity: work_submission, roles: Sipity::Models::Role::CREATING_USER
+            ).and_return(['Hello'])
+            expect(subject.creators?).to eq(true)
+          end
+
+          it 'will be true if there is are no creating users' do
+            expect(repository).to receive(:scope_users_for_entity_and_roles).with(
+              entity: work_submission, roles: Sipity::Models::Role::CREATING_USER
+            ).and_return([])
+            expect(subject.creators?).to eq(false)
+          end
         end
 
         it 'exposes resourceful_actions' do


### PR DESCRIPTION
Prior to this commit, there was no information related to who created
the given work submission. This is a necessary field for anyone
cataloging the given work, and is helpful for people reviewing the
data.