### PR TITLE
Updating Airbrake dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 4.2'
 # This is part of the v4.3.0 API
 # Once the following pull request is merged (or similar solution), then we
 # can hopefully use the Airbrake maintained gem. https://github.com/airbrake/airbrake/pull/397
-gem 'airbrake', github: 'jeremyf/airbrake'
+gem 'airbrake'
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass'
 gem 'coffee-rails', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,6 @@ GIT
     ezid-client (1.1.1)
 
 GIT
-  remote: git://github.com/jeremyf/airbrake.git
-  revision: 1e3c1c7c8ee9b2f7195243ac3e012f639b090171
-  specs:
-    airbrake (4.3.0)
-      builder
-      multi_json
-
-GIT
   remote: git://github.com/jeremyf/curly.git
   revision: 7209cb9e932f7cbd0839508b96cc979d61b19277
   branch: sipity-hack
@@ -126,6 +118,9 @@ GEM
       ice_nine (~> 0.11.0)
       memoizable (~> 0.4.0)
     addressable (2.3.8)
+    airbrake (4.3.3)
+      builder
+      multi_json
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -602,7 +597,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake!
+  airbrake
   autoprefixer-rails
   better_errors
   binding_of_caller

--- a/app/jobs/sipity/jobs/etd/bulk_ingest_job.rb
+++ b/app/jobs/sipity/jobs/etd/bulk_ingest_job.rb
@@ -58,10 +58,7 @@ module Sipity
           begin
             ActiveRecord::Base.transaction { work_ingester.call(parameters) }
           rescue StandardError => exception
-            exception_handler.call(
-              error_class: exception.class, error_message: exception.message,
-              parameters: parameters.merge(work_ingester: work_ingester, job_class: self.class)
-            )
+            exception_handler.call(exception, parameters: parameters.merge(work_ingester: work_ingester, job_class: self.class))
           end
         end
 

--- a/spec/jobs/sipity/jobs/etd/bulk_ingest_job_spec.rb
+++ b/spec/jobs/sipity/jobs/etd/bulk_ingest_job_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Sipity::Jobs::Etd::BulkIngestJob do
       )
       subject.call
       expect(exception_handler).to have_received(:call).with(
-        error_class: RuntimeError, error_message: 'Failed for work1', parameters: {
+        kind_of(RuntimeError), parameters: {
           work_id: work1.id, requested_by: subject.send(:requested_by), processing_action_name: subject.send(:processing_action_name),
           job_class: described_class, work_ingester: work_ingester
         }


### PR DESCRIPTION
A better solution than what I had proposed was accepted. So now
Airbrake's updated version handles any attempts to close an already
closed file.

See airbrake/airbrake#426 for further reference.