### PR TITLE
Adding batch ingester handling

### DIFF
--- a/app/controllers/sipity/controllers/work_submissions_controller.rb
+++ b/app/controllers/sipity/controllers/work_submissions_controller.rb
@@ -30,6 +30,18 @@ module Sipity
       alias_method :model, :view_object
       helper_method :model
 
+      # @TODO - With Cogitate this will need to be revisited
+      def authenticate_user!
+        authenticate_with_http_basic { |user, password| user_for_etd_ingester(user: user, password: password) } || super
+      end
+
+      # @TODO - With Cogitate this will need to be revisited
+      def user_for_etd_ingester(user:, password:, group_name: DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS, env: Figaro.env)
+        return false unless user == group_name
+        return false unless password == env.sipity_batch_ingester_access_key!
+        Sipity::Models::Group.find_by!(name: group_name)
+      end
+
       private
 
       attr_accessor :processing_action_composer

--- a/app/exporters/sipity/exporters/etd_exporter.rb
+++ b/app/exporters/sipity/exporters/etd_exporter.rb
@@ -74,10 +74,16 @@ module Sipity
         end
       end
 
-      # @TODO This is a place holder as I want to know what the source machine
-      # was for an import request.
+      # @TODO This is likely in the wrong place but its what I have.
       def webhook_url
-        "#{Figaro.env.protocol!}://#{Figaro.env.domain_name!}/bogus-webhook"
+        File.join(
+          "#{Figaro.env.protocol!}://#{webhook_authorization_credentials}@#{Figaro.env.domain_name!}",
+          "/work_submissions/#{work.to_param}/do/ingest_completed"
+        )
+      end
+
+      def webhook_authorization_credentials
+        "#{Sipity::DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS}:#{Figaro.env.sipity_batch_ingester_access_key!}"
       end
 
       def package_data

--- a/app/forms/sipity/forms/work_submissions/etd/ingest_completed_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/ingest_completed_form.rb
@@ -1,0 +1,23 @@
+require_relative '../../../forms'
+module Sipity
+  module Forms
+    module WorkSubmissions
+      module Etd
+        # Responsible for calling the ETD Ingester
+        class IngestCompletedForm
+          ProcessingForm.configure(form_class: self, base_class: Models::Work, processing_subject_name: :work, attribute_names: [])
+
+          def initialize(work:, requested_by:, **keywords)
+            self.work = work
+            self.requested_by = requested_by
+            self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
+          end
+
+          include ActiveModel::Validations
+
+          delegate :submit, to: :processing_action_form
+        end
+      end
+    end
+  end
+end

--- a/app/forms/sipity/forms/work_submissions/etd/submit_for_ingest_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/submit_for_ingest_form.rb
@@ -10,7 +10,7 @@ module Sipity
             attribute_names: []
           )
 
-          def initialize(work:, requested_by:, exporter: default_exporter, _attributes: {}, **keywords)
+          def initialize(work:, requested_by:, exporter: default_exporter, **keywords)
             self.work = work
             self.requested_by = requested_by
             self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)

--- a/config/application.yml
+++ b/config/application.yml
@@ -15,6 +15,7 @@ dragonfly_s3_root_path: 's3_root_dir'
 dragonfly_s3_secret_access_key: 'secret'
 dragonfly_s3_url_host: 'bucketname.aws.com'
 dragonfly_secret: "12345"
+sipity_batch_ingester_access_key: '1234'
 ezid_client_default_shoulder: "doi:10.5072/FK2"
 ezid_client_password: apitest
 ezid_client_user: apitest

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,6 +1,9 @@
 Figaro.require_keys(
   'airbrake_api_key',
   'airbrake_host',
+  'curate_batch_data_mount_path',
+  'curate_batch_group_pid',
+  'curate_batch_user_pid',
   'curate_nd_url_for_etds',
   'curate_nd_url_show_prefix_url',
   'default_email_from',
@@ -8,13 +11,11 @@ Figaro.require_keys(
   'domain_name',
   'hesburgh_api_auth_token',
   'hesburgh_api_host',
-  'protocol',
   'noid_pool',
   'noid_port',
   'noid_server',
+  'protocol',
   'secret_key_base',
+  'sipity_batch_ingester_access_key',
   'url_host',
-  'curate_batch_user_pid',
-  'curate_batch_group_pid',
-  'curate_batch_data_mount_path'
 )

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -17,6 +17,43 @@ module Sipity
       it { should respond_to :prepend_processing_action_view_path_with }
       it { should respond_to :run_and_respond_with_processing_action }
 
+      context '#authenticate_user!' do
+        before { allow_any_instance_of(ProcessingActionComposer).to receive(:run_and_respond_with_processing_action) }
+        let(:processing_action_name) { 'fun_things' }
+        context 'with Basic authentication credentials' do
+          it 'will attempt to find user_for_etd_ingester' do
+            user = double('User')
+            expect(controller).to receive(:user_for_etd_ingester).with(user: 'User', password: 'Password').and_return(user)
+            request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('User', 'Password')
+            controller.authenticate_user!
+          end
+        end
+        context 'without Basic authentication credentials' do
+          it 'will attempt to find user_for_etd_ingester' do
+            expect(controller).to_not receive(:user_for_etd_ingester)
+            expect { controller.authenticate_user! }.to raise_error(StandardError)
+          end
+        end
+      end
+
+      context '#user_for_etd_ingester' do
+        let(:valid_name) { Sipity::DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS }
+        let(:invalid_name) { 'nope' }
+        it 'will equal false if its not the ETD Ingester' do
+          expect(controller.user_for_etd_ingester(user: invalid_name, password: Figaro.env.sipity_batch_ingester_access_key!)).to eq(false)
+        end
+
+        it 'will equal false if that password is incorrect' do
+          expect(controller.user_for_etd_ingester(user: valid_name, password: 'nope')).to eq(false)
+        end
+
+        it 'will be the ETD Ingester group if the name and password match' do
+          group = double('Group')
+          expect(Sipity::Models::Group).to receive(:find_by!).with(name: valid_name).and_return(group)
+          expect(controller.user_for_etd_ingester(user: valid_name, password: Figaro.env.sipity_batch_ingester_access_key!)).to eq(group)
+        end
+      end
+
       context 'GET #query_action' do
         let(:processing_action_name) { 'fun_things' }
         it 'will will collaborate with the processing action composer' do

--- a/spec/exporters/sipity/exporters/etd_exporter_spec.rb
+++ b/spec/exporters/sipity/exporters/etd_exporter_spec.rb
@@ -5,7 +5,7 @@ module Sipity
   module Exporters
     RSpec.describe EtdExporter do
       let(:access_right) { ['private_access'] }
-      let(:work) { double }
+      let(:work) { Sipity::Models::Work.new(id: 'abc123') }
       let(:repository) { QueryRepositoryInterface.new }
       let(:creators) { [double(username: 'Hello')] }
       let(:title) { 'Title of the work' }
@@ -16,6 +16,8 @@ module Sipity
       subject { described_class.new(work, repository: repository) }
 
       its(:default_repository) { should respond_to :work_attachments }
+      its(:webhook_authorization_credentials) { should be_a(String) }
+      its(:webhook_url) { should match(%r{/work_submissions/#{work.to_param}/do/ingest_completed$}) }
 
       it 'will instantiate then call the instance' do
         expect(described_class).to receive(:new).and_return(double(call: true))

--- a/spec/forms/sipity/forms/work_submissions/etd/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/ingest_completed_form_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'sipity/forms/work_submissions/etd/ingest_completed_form'
+
+module Sipity
+  module Forms
+    module WorkSubmissions
+      module Etd
+        RSpec.describe IngestCompletedForm do
+          let(:work) { Models::Work.new(id: '1234') }
+          let(:repository) { CommandRepositoryInterface.new }
+          let(:attributes) { {} }
+          let(:keywords) { { work: work, repository: repository, requested_by: user } }
+          let(:user) { double('User') }
+          subject { described_class.new(keywords) }
+
+          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+
+          it { should respond_to :work }
+          it { should delegate_method(:submit).to(:processing_action_form) }
+
+          context 'with invalid data' do
+            before { expect(subject).to receive(:valid?).and_return(false) }
+            its(:submit) { should eq(false) }
+          end
+
+          context 'with valid data' do
+            before do
+              allow(subject.send(:processing_action_form)).to receive(:submit).and_return(work)
+            end
+            its(:submit) { should eq(work) }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Adding sipity batch ingester key

@a3fa52ae0e02a4c7be801c4ea3e6a783c3a17f6d

I need a way for the batch ingester to be treated as an authorized
user. This authorization is important for the bulk ingest job that
issues a WEBHOOK upon completion.

## Removing the _attributes keyword

@5e32087ad8f6dac973591289e52f8ae140591e87

This works with positional variables (i.e. `def foo(var1, _var2)`), but not
with keyword variables. So instead of an explicit, yet ignored, keyword
variable have the `**keywords` kargs swallow the possible `attributes:`
keyword.

## Adding web hook abilities for ingest completed

@10bf250252691087ce87e5cff5222deea8980674

I need a state advancing form that has no frills. Its purpose is to
provide a common entry point for marking something as ingested.

## Adding "hack" to allow ETD ingester

@e11986d004fa9748d99ebaff70fe4881cc54b32b

I'm hacking in HTTP basic authentication behavior. This is a hard-coded
and rather ugly solution. I'm deferring the more elegant solution until
we integrate with Cogitate.
