### PR TITLE
Adding WorkSubmissionCallbacks handling

### DIFF
--- a/app/controllers/sipity/controllers/work_submission_callbacks_controller.rb
+++ b/app/controllers/sipity/controllers/work_submission_callbacks_controller.rb
@@ -1,0 +1,69 @@
+module Sipity
+  module Controllers
+    # The controller for handling callbacks for work submissions
+    class WorkSubmissionCallbacksController < ApplicationController
+      skip_before_action :verify_authenticity_token
+
+      class_attribute :response_handler_container
+      self.runner_container = Sipity::Runners::WorkSubmissionsRunners
+      self.response_handler_container = Sipity::ResponseHandlers::WorkSubmissionHandler
+
+      def command_action
+        run_and_respond_with_processing_action(work_id: work_id, attributes: command_attributes)
+      end
+
+      def initialize(*args, &block)
+        super(*args, &block)
+        self.processing_action_composer = ProcessingActionComposer.build_for_controller(controller: self)
+      end
+
+      delegate(
+        :prepend_processing_action_view_path_with,
+        :run_and_respond_with_processing_action,
+        to: :processing_action_composer
+      )
+
+      attr_accessor :view_object
+      helper_method :view_object
+      alias_method :model, :view_object
+      helper_method :model
+
+      # @TODO - With Cogitate this will need to be revisited
+      def authenticate_user!
+        authenticate_with_http_basic { |user, password| user_for_etd_ingester(user: user, password: password) } || super
+      end
+
+      # @TODO - With Cogitate this will need to be revisited
+      def user_for_etd_ingester(user:, password:, group_name: DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS, env: Figaro.env)
+        return false unless user == group_name
+        return false unless password == env.sipity_batch_ingester_access_key!
+        Sipity::Models::Group.find_by!(name: group_name)
+      end
+
+      private
+
+      attr_accessor :processing_action_composer
+
+      def work_id
+        params.require(:work_id)
+      end
+
+      # This is a bit different as I am matching to the WEBHOOK documentation. The WEBHOOK posts the following JSON body:
+      #
+      # ```json
+      #   { "host" : "libvirt8.library.nd.edu", "version" : "1.0.1", "job_name" : "ingest-45", "job_state" : "processing" }
+      # ```
+      #
+      # So I need to normalize this data to pass along to the command.
+      #
+      # @see https://github.com/ndlib/curatend-batch/blob/master/webhook.md
+      def command_attributes
+        params.fetch(:work) { HashWithIndifferentAccess.new }.merge(normalized_attributes_for_existing_callback_constraints)
+      end
+
+      def normalized_attributes_for_existing_callback_constraints
+        params.except(:action, :controller, :work_id, :processing_action_name, :work, :work_submission)
+      end
+    end
+  end
+end

--- a/app/controllers/sipity/controllers/work_submissions_controller.rb
+++ b/app/controllers/sipity/controllers/work_submissions_controller.rb
@@ -30,18 +30,6 @@ module Sipity
       alias_method :model, :view_object
       helper_method :model
 
-      # @TODO - With Cogitate this will need to be revisited
-      def authenticate_user!
-        authenticate_with_http_basic { |user, password| user_for_etd_ingester(user: user, password: password) } || super
-      end
-
-      # @TODO - With Cogitate this will need to be revisited
-      def user_for_etd_ingester(user:, password:, group_name: DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS, env: Figaro.env)
-        return false unless user == group_name
-        return false unless password == env.sipity_batch_ingester_access_key!
-        Sipity::Models::Group.find_by!(name: group_name)
-      end
-
       private
 
       attr_accessor :processing_action_composer

--- a/app/exporters/sipity/exporters/etd_exporter.rb
+++ b/app/exporters/sipity/exporters/etd_exporter.rb
@@ -78,7 +78,7 @@ module Sipity
       def webhook_url
         File.join(
           "#{Figaro.env.protocol!}://#{webhook_authorization_credentials}@#{Figaro.env.domain_name!}",
-          "/work_submissions/#{work.to_param}/do/ingest_completed"
+          "/work_submissions/#{work.to_param}/callback/ingest_completed"
         )
       end
 

--- a/app/forms/sipity/forms/work_submissions/etd/ingest_completed_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/ingest_completed_form.rb
@@ -5,15 +5,22 @@ module Sipity
       module Etd
         # Responsible for calling the ETD Ingester
         class IngestCompletedForm
-          ProcessingForm.configure(form_class: self, base_class: Models::Work, processing_subject_name: :work, attribute_names: [])
+          # @see https://github.com/ndlib/curatend-batch/blob/master/webhook.md
+          JOB_STATE_SUCCESS = 'success'.freeze
 
-          def initialize(work:, requested_by:, **keywords)
+          ProcessingForm.configure(
+            form_class: self, base_class: Models::Work, processing_subject_name: :work, attribute_names: [:job_state]
+          )
+
+          def initialize(work:, requested_by:, attributes: {}, **keywords)
             self.work = work
             self.requested_by = requested_by
             self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
+            self.job_state = attributes.fetch(:job_state, nil)
           end
 
           include ActiveModel::Validations
+          validates :job_state, inclusion: { in: [JOB_STATE_SUCCESS] }
 
           delegate :submit, to: :processing_action_form
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,10 @@ Rails.application.routes.draw do
     to: 'sipity/controllers/work_submissions#query_action'
   )
   [:post, :put, :patch, :delete].each do |http_verb_name|
+    send(
+      http_verb_name,
+      'work_submissions/:work_id/callback/:processing_action_name', to: 'sipity/controllers/work_submission_callbacks#command_action'
+    )
     send(http_verb_name, 'work_submissions/:work_id/do/:processing_action_name', to: 'sipity/controllers/work_submissions#command_action')
   end
 

--- a/spec/controllers/sipity/controllers/work_submission_callbacks_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submission_callbacks_controller_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+require 'sipity/controllers/work_submission_callbacks_controller'
+
+module Sipity
+  module Controllers
+    RSpec.describe WorkSubmissionCallbacksController, type: :controller do
+      let(:work) { Models::Work.new(id: 'abc') }
+      let(:work_area) { double(slug: 'buggy') }
+
+      before { allow(work).to receive(:work_area).and_return(work_area) }
+
+      context 'configuration' do
+        its(:runner_container) { should eq(Sipity::Runners::WorkSubmissionsRunners) }
+        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkSubmissionHandler) }
+      end
+
+      it { should respond_to :prepend_processing_action_view_path_with }
+      it { should respond_to :run_and_respond_with_processing_action }
+
+      context '#command_attributes' do
+
+        it 'will normalize parameters' do
+          given_params = {
+            "host" => "libvirt6.library.nd.edu", "version" => "1.0.0", "job_name" => "sipity-44558c99h70", "job_state" => "success",
+            "work_id" => "44558c99h70", "processing_action_name" => "ingest_completed", "work_submission" => {
+              "host" => "libvirt6.library.nd.edu", "version" => "1.0.0", "job_name" => "sipity-44558c99h70", "job_state" => "success"
+            }
+          }
+          expect_any_instance_of(ProcessingActionComposer).to receive(:run_and_respond_with_processing_action).with(
+            work_id: given_params.fetch('work_id'),
+            attributes: {
+              "host" => "libvirt6.library.nd.edu", "version" => "1.0.0", "job_name" => "sipity-44558c99h70", "job_state" => "success"
+            }
+          )
+          expect do
+            post 'command_action', given_params
+          end.to raise_error(ActionView::MissingTemplate, /command_action/) # Because auto-rendering
+        end
+      end
+
+      context '#authenticate_user!' do
+        before { allow_any_instance_of(ProcessingActionComposer).to receive(:run_and_respond_with_processing_action) }
+        let(:processing_action_name) { 'fun_things' }
+        context 'with Basic authentication credentials' do
+          it 'will attempt to find user_for_etd_ingester' do
+            user = double('User')
+            expect(controller).to receive(:user_for_etd_ingester).with(user: 'User', password: 'Password').and_return(user)
+            request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('User', 'Password')
+            controller.authenticate_user!
+          end
+        end
+
+        context 'without Basic authentication credentials' do
+          it 'will attempt to find user_for_etd_ingester' do
+            expect(controller).to_not receive(:user_for_etd_ingester)
+            expect { controller.authenticate_user! }.to raise_error(StandardError)
+          end
+        end
+      end
+
+      context '#user_for_etd_ingester' do
+        let(:valid_name) { Sipity::DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS }
+        let(:invalid_name) { 'nope' }
+        it 'will equal false if its not the ETD Ingester' do
+          expect(controller.user_for_etd_ingester(user: invalid_name, password: Figaro.env.sipity_batch_ingester_access_key!)).to eq(false)
+        end
+
+        it 'will equal false if that password is incorrect' do
+          expect(controller.user_for_etd_ingester(user: valid_name, password: 'nope')).to eq(false)
+        end
+
+        it 'will be the ETD Ingester group if the name and password match' do
+          group = double('Group')
+          expect(Sipity::Models::Group).to receive(:find_by!).with(name: valid_name).and_return(group)
+          expect(controller.user_for_etd_ingester(user: valid_name, password: Figaro.env.sipity_batch_ingester_access_key!)).to eq(group)
+        end
+      end
+
+      context 'POST #command_action' do
+        let(:processing_action_name) { 'fun_things' }
+        it 'will skip CSRF protections and pass along to the response handler' do
+          expect_any_instance_of(ProcessingActionComposer).to receive(:run_and_respond_with_processing_action)
+          expect(controller).to_not receive(:verify_authenticity_token)
+          # I don't want to mess around with all the possible actions
+          expect do
+            post 'command_action', work_id: work.id, processing_action_name: processing_action_name, work: { title: 'Hello' }
+          end.to raise_error(ActionView::MissingTemplate, /command_action/) # Because auto-rendering
+        end
+      end
+
+      context 'GET #query_action' do
+        let(:processing_action_name) { 'fun_things' }
+        it 'will not be routable' do
+          expect do
+            get 'query_action', work_id: work.id, processing_action_name: processing_action_name, work: { title: 'Hello' }
+          end.to raise_error(ActionController::UrlGenerationError)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -17,43 +17,6 @@ module Sipity
       it { should respond_to :prepend_processing_action_view_path_with }
       it { should respond_to :run_and_respond_with_processing_action }
 
-      context '#authenticate_user!' do
-        before { allow_any_instance_of(ProcessingActionComposer).to receive(:run_and_respond_with_processing_action) }
-        let(:processing_action_name) { 'fun_things' }
-        context 'with Basic authentication credentials' do
-          it 'will attempt to find user_for_etd_ingester' do
-            user = double('User')
-            expect(controller).to receive(:user_for_etd_ingester).with(user: 'User', password: 'Password').and_return(user)
-            request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('User', 'Password')
-            controller.authenticate_user!
-          end
-        end
-        context 'without Basic authentication credentials' do
-          it 'will attempt to find user_for_etd_ingester' do
-            expect(controller).to_not receive(:user_for_etd_ingester)
-            expect { controller.authenticate_user! }.to raise_error(StandardError)
-          end
-        end
-      end
-
-      context '#user_for_etd_ingester' do
-        let(:valid_name) { Sipity::DataGenerators::WorkTypes::EtdGenerator::ETD_INGESTORS }
-        let(:invalid_name) { 'nope' }
-        it 'will equal false if its not the ETD Ingester' do
-          expect(controller.user_for_etd_ingester(user: invalid_name, password: Figaro.env.sipity_batch_ingester_access_key!)).to eq(false)
-        end
-
-        it 'will equal false if that password is incorrect' do
-          expect(controller.user_for_etd_ingester(user: valid_name, password: 'nope')).to eq(false)
-        end
-
-        it 'will be the ETD Ingester group if the name and password match' do
-          group = double('Group')
-          expect(Sipity::Models::Group).to receive(:find_by!).with(name: valid_name).and_return(group)
-          expect(controller.user_for_etd_ingester(user: valid_name, password: Figaro.env.sipity_batch_ingester_access_key!)).to eq(group)
-        end
-      end
-
       context 'GET #query_action' do
         let(:processing_action_name) { 'fun_things' }
         it 'will will collaborate with the processing action composer' do

--- a/spec/exporters/sipity/exporters/etd_exporter_spec.rb
+++ b/spec/exporters/sipity/exporters/etd_exporter_spec.rb
@@ -17,7 +17,7 @@ module Sipity
 
       its(:default_repository) { should respond_to :work_attachments }
       its(:webhook_authorization_credentials) { should be_a(String) }
-      its(:webhook_url) { should match(%r{/work_submissions/#{work.to_param}/do/ingest_completed$}) }
+      its(:webhook_url) { should match(%r{/work_submissions/#{work.to_param}/callback/ingest_completed$}) }
 
       it 'will instantiate then call the instance' do
         expect(described_class).to receive(:new).and_return(double(call: true))

--- a/spec/forms/sipity/forms/work_submissions/etd/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/ingest_completed_form_spec.rb
@@ -9,14 +9,20 @@ module Sipity
           let(:work) { Models::Work.new(id: '1234') }
           let(:repository) { CommandRepositoryInterface.new }
           let(:attributes) { {} }
-          let(:keywords) { { work: work, repository: repository, requested_by: user } }
+          let(:keywords) { { work: work, repository: repository, requested_by: user, attributes: { job_state: 'success' } } }
           let(:user) { double('User') }
           subject { described_class.new(keywords) }
 
           its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:processing_action_name) { should eq('ingest_completed') }
+
+          it { should respond_to :job_state }
 
           it { should respond_to :work }
           it { should delegate_method(:submit).to(:processing_action_form) }
+
+          include Shoulda::Matchers::ActiveModel
+          it { should validate_inclusion_of(:job_state).in_array([described_class::JOB_STATE_SUCCESS]) }
 
           context 'with invalid data' do
             before { expect(subject).to receive(:valid?).and_return(false) }

--- a/spec/routing/work_submission_routing_spec.rb
+++ b/spec/routing/work_submission_routing_spec.rb
@@ -52,11 +52,46 @@ describe 'work area routing spec' do
           action: 'command_action',
           processing_action_name: 'edit'
         }
+      ], [
+        :post,
+        {
+          path: "/work_submissions/1234/callback/a_callback",
+          controller: 'sipity/controllers/work_submission_callbacks',
+          work_id: '1234',
+          action: 'command_action',
+          processing_action_name: 'a_callback'
+        }
+      ], [
+        :patch,
+        {
+          path: "/work_submissions/1234/callback/a_callback",
+          controller: 'sipity/controllers/work_submission_callbacks',
+          work_id: '1234',
+          action: 'command_action',
+          processing_action_name: 'a_callback'
+        }
+      ], [
+        :put,
+        {
+          path: "/work_submissions/1234/callback/a_callback",
+          controller: 'sipity/controllers/work_submission_callbacks',
+          work_id: '1234',
+          action: 'command_action',
+          processing_action_name: 'a_callback'
+        }
+      ], [
+        :delete,
+        {
+          path: "/work_submissions/1234/callback/a_callback",
+          controller: 'sipity/controllers/work_submission_callbacks',
+          work_id: '1234',
+          action: 'command_action',
+          processing_action_name: 'a_callback'
+        }
       ]
     ].each do |http_method, settings|
       it "will #{http_method.to_s.upcase} #{settings.fetch(:path)}" do
-        expect(send(http_method, settings.fetch(:path))).
-          to route_to(settings.except(:path).merge(controller: controller))
+        expect(send(http_method, settings.fetch(:path))).to route_to({ controller: controller }.merge(settings.except(:path)))
       end
     end
 


### PR DESCRIPTION
When I went to test the behavior in the integration environment, I
encountered the following exception; This exposed a few cases I did not
consider:

1. CSRF protection needs to be turned off
2. There is more than one callback that is issued during the processing
   a. processing
   b. success
3. The callback payload is not quite configured in the same way as the
   application is expecting

So changes have been made by adding a custom callback route and
controller. This means the original work submission controller does
not have a current need for HTTP Authentication check. I have also
kept the scope of callbacks to exclude GET requests. I must also
account for specific shape of the callback.

And I must not allow a callback of job_state: 'processing' to update
the work's processing state to 'ingested'.

```console
I, [2015-11-17T15:42:39.405288 #529]  INFO -- :   Parameters: {
  "host"=>"libvirt6.library.nd.edu", "version"=>"1.0.0",
  "job_name"=>"sipity-44558c99h70", "job_state"=>"processing",
  "work_id"=>"44558c99h70",
   "processing_action_name"=>"ingest_completed", "work_submission"=>{
    "host"=>"libvirt6.library.nd.edu", "version"=>"1.0.0",
    "job_name"=>"sipity-44558c99h70", "job_state"=>"processing"
  }}
W, [2015-11-17T15:42:39.406874 #529]  WARN -- : Can't verify CSRF token
  authenticity
I, [2015-11-17T15:42:39.408352 #529]  INFO -- : Completed 422
  Unprocessable Entity in 2ms (ActiveRecord: 0.0ms)
F, [2015-11-17T15:42:39.436619 #529] FATAL -- :
ActionController::InvalidAuthenticityToken
```