### PR TITLE
Adding guard clause for auto HTML scrubbing

### DIFF
--- a/lib/hesburgh/lib/html_scrubber.rb
+++ b/lib/hesburgh/lib/html_scrubber.rb
@@ -41,6 +41,8 @@ module Hesburgh
 
         # A convenience method for sanitiziation
         def sanitize(input)
+          return '' unless input.present?
+          return input unless input.is_a?(String)
           Loofah.fragment(input).scrub!(self).to_s.strip
         end
         alias_method :call, :sanitize

--- a/spec/lib/hesburgh/lib/html_scrubber_spec.rb
+++ b/spec/lib/hesburgh/lib/html_scrubber_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
     {
       nil => '',
       ' ' => '',
+      Date.new(2015, 10, 1) => Date.new(2015, 10, 1),
       %( <p>Hello</p> ) => %(Hello),
       %(<p>Hello</p>) => %(Hello),
       %(Hello) => %(Hello),


### PR DESCRIPTION
In the case of Dates being persisted, the HTML scrubbing was throwing
an exception. I'm instead adding a few short circuit options to avoid
this nasty exception.

Fixes https://errbit.library.nd.edu/apps/55280e706a6f68a6d2090000/problems/5653714c6a6f687909ab0200