### PR TITLE
ULRA workflow modeling

### DIFF
--- a/app/data_generators/sipity/data_generators/email_notification_generator.rb
+++ b/app/data_generators/sipity/data_generators/email_notification_generator.rb
@@ -1,0 +1,63 @@
+require 'active_support/core_ext/array/wrap'
+
+module Sipity
+  # :nodoc:
+  module DataGenerators
+    # Responsible for building the appropriate email generation
+    class EmailNotificationGenerator
+      def self.call(**keywords)
+        new(**keywords).call
+      end
+      def initialize(strategy:, reason:, scope:, email_name:, recipients:)
+        self.strategy = strategy
+        self.reason = reason
+        self.email_name = email_name
+        self.recipients = recipients
+        assign_scope(strategy: strategy, scope: scope, reason: reason)
+      end
+
+      def call
+        email = persist_email
+        assign_recipients_to(email: email)
+        assign_scope_and_reason_to(email: email)
+      end
+
+      private
+
+      def persist_email
+        Models::Notification::Email.find_or_create_by!(method_name: email_name)
+      end
+
+      def assign_recipients_to(email:)
+        recipients.slice(:to, :cc, :bcc).each do |(recipient_strategy, recipient_roles)|
+          Array.wrap(recipient_roles).each do |role|
+            email.recipients.find_or_create_by!(role: PowerConverter.convert_to_role(role), recipient_strategy: recipient_strategy.to_s)
+          end
+        end
+      end
+
+      def assign_scope_and_reason_to(email:)
+        Models::Notification::NotifiableContext.find_or_create_by!(
+          scope_for_notification: scope,
+          reason_for_notification: reason,
+          email: email
+        )
+      end
+
+      attr_accessor :strategy, :reason, :email_name, :recipients
+      attr_reader :scope
+
+      # Note this is a rather hideous switch statement related to coercing data.
+      def assign_scope(strategy:, scope:, reason:)
+        @scope = begin
+          case reason
+          when Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN
+            Conversions::ConvertToProcessingAction.call(scope, scope: strategy)
+          when Parameters::NotificationContextParameter::REASON_ENTERED_STATE
+            PowerConverter.convert(scope, to: :strategy_state, scope: strategy)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/etd_generator.rb
@@ -313,99 +313,74 @@ module Sipity
               # Define associated emails by a named thing
               [
                 {
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'start_a_submission',
                   emails: { confirmation_of_work_created: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'submit_for_review',
                   emails: {
                     confirmation_of_submit_for_review: { to: 'creating_user' },
                     submit_for_review: { to: ['advisor'] }
                   }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'advisor_signoff',
                   emails: { confirmation_of_advisor_signoff: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'signoff_on_behalf_of',
                   emails: { confirmation_of_advisor_signoff: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'advisor_requests_change',
                   emails: { advisor_requests_change: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'request_change_on_behalf_of',
                   emails: { request_change_on_behalf_of: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'respond_to_advisor_request',
                   emails: { respond_to_advisor_request: { to: 'advisor', cc: 'creating_user'} }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'respond_to_grad_school_request',
                   emails: { respond_to_grad_school_request: { to: 'etd_reviewer', cc: 'creating_user'} }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'grad_school_requests_change',
                   emails: { grad_school_requests_change: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'grad_school_signoff',
                   emails: { confirmation_of_grad_school_signoff: { to: 'creating_user' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'send_to_cataloging',
                   emails: { grad_school_requests_cataloging: { to: 'cataloger' } }
                 },{
-                  named_container: Models::Processing::StrategyAction,
+                  reason: Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN,
                   name: 'send_back_to_grad_school',
                   emails: { cataloger_request_change: { to: 'etd_reviewer' } }
                 },{
-                  named_container: Models::Processing::StrategyState,
+                  reason: Parameters::NotificationContextParameter::REASON_ENTERED_STATE,
                   name: 'under_grad_school_review',
                   emails: {
                     advisor_signoff_is_complete: { to: 'etd_reviewer', cc: 'creating_user' },
                     confirmation_of_advisor_signoff_is_complete: { to: 'creating_user' }
                   }
                 },{
-                  named_container: Models::Processing::StrategyState,
+                  reason: Parameters::NotificationContextParameter::REASON_ENTERED_STATE,
                   name: 'ingested',
                   emails: { release_suspended_catalog_record: { to: 'cataloger' } }
                 }
               ].each do |email_config|
-                named_container = email_config.fetch(:named_container)
-                name = email_config.fetch(:name)
-                named_container.where(name: name, strategy: etd_strategy).each do |named_thing|
-                  email_config.fetch(:emails).each do |email_name, recipients|
-                    the_email = Models::Notification::Email.find_or_create_by!(method_name: email_name) do |email|
-                      recipients.slice(:to, :cc, :bcc).each do |(recipient_strategy, recipient_roles)|
-                        Array.wrap(recipient_roles).each do |recipient_role|
-                          find_or_initialize_or_create!(
-                            context: email,
-                            receiver: email.recipients,
-                            role: Models::Role.find_by!(name: recipient_role),
-                            recipient_strategy: recipient_strategy.to_s
-                          )
-                        end
-                      end
-                    end
-                    reason_for_notification = begin
-                      case named_thing
-                      when Models::Processing::StrategyAction
-                        Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN
-                      when Models::Processing::StrategyState
-                        Parameters::NotificationContextParameter::REASON_ENTERED_STATE
-                      end
-                    end
-                    Models::Notification::NotifiableContext.find_or_create_by!(
-                      scope_for_notification: named_thing,
-                      reason_for_notification: reason_for_notification,
-                      email: the_email
-                    )
-                  end
+                email_config.fetch(:emails).each do |email_name, recipients|
+                  EmailNotificationGenerator.call(
+                    strategy: etd_strategy, email_name: email_name, recipients: recipients, scope: email_config.fetch(:name),
+                    reason: email_config.fetch(:reason)
+                  )
                 end
               end
             end

--- a/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
@@ -11,6 +11,7 @@ module Sipity
         PROCESSING_ROLE_NAMES = [
           Models::Role::CREATING_USER,
           Models::Role::ADVISOR,
+          Models::Role::DATA_OBSERVER,
           Models::Role::ULRA_REVIEWER
         ]
         ULRA_REVIEW_COMMITTEE_GROUP_NAME = 'ULRA Review Committee'
@@ -56,30 +57,58 @@ module Sipity
             show: {
               states: {
                 initial_state_name => { roles: ['creating_user', 'advisor', 'ulra_reviewer'] },
-                under_review: { roles: ['creating_user', 'advisor', 'ulra_reviewer'] }
+                under_review: { roles: ['creating_user', 'advisor', 'ulra_reviewer'] },
+                pending_advisor_completion: { roles: ['creating_user', 'advisor', 'ulra_reviewer'] },
+                pending_student_completion: { roles: ['creating_user', 'advisor', 'ulra_reviewer'] },
+                review_completed: { roles: ['creating_user', 'advisor', 'ulra_reviewer'] }
               }
             },
             destroy: {
               states: {
                 initial_state_name => { roles: ['creating_user', 'ulra_reviewer'] },
+                pending_advisor_completion: { roles: ['creating_user', 'ulra_reviewer'] },
+                pending_student_completion: { roles: ['creating_user', 'ulra_reviewer'] },
                 under_review: { roles: ['ulra_reviewer'] }
               }
             },
             plan_of_study: {
-              states: { initial_state_name => { roles: ['creating_user'] } }
+              states: {
+                initial_state_name => { roles: ['creating_user'] },
+                pending_advisor_completion: { roles: ['creating_user'] }
+              }
             },
             publisher_information: {
-              states: { initial_state_name => { roles: ['creating_user'] } }
+              states: {
+                initial_state_name => { roles: ['creating_user'] },
+                pending_advisor_completion: { roles: ['creating_user'] }
+              }
             },
             research_process: {
-              states: { initial_state_name => { roles: ['creating_user'] } }
+              states: {
+                initial_state_name => { roles: ['creating_user'] },
+                pending_advisor_completion: { roles: ['creating_user'] }
+              }
             },
             faculty_response: {
-              states: { initial_state_name => { roles: ['advisor'] } }
+              states: {
+                initial_state_name => { roles: ['advisor'] },
+                pending_student_completion: { roles: ['advisor'] }
+              }
+            },
+            submit_student_portion: {
+              states: { initial_state_name => { roles: ['creating_user'] } },
+              transition_to: :pending_advisor_completion,
+              required_actions: [:plan_of_study, :publisher_information, :research_process]
+            },
+            submit_advisor_portion: {
+              states: { initial_state_name => { roles: ['advisor'] } },
+              transition_to: :pending_student_completion,
+              required_actions: [:faculty_response]
             },
             submit_for_review: {
               states: {
-                initial_state_name => { roles: ['creating_user', 'advisor'] }
+                pending_student_completion: { roles: ['creating_user'] },
+                pending_advisor_completion: { roles: ['advisor'] }
               },
               transition_to: :under_review,
               required_actions: [:plan_of_study, :publisher_information, :research_process, :faculty_response]

--- a/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
+++ b/app/data_generators/sipity/data_generators/work_types/ulra_generator.rb
@@ -51,34 +51,35 @@ module Sipity
         end
 
         def generate_state_diagram(processing_strategy:, initial_state:)
+          initial_state_name = initial_state.name.to_sym
           {
             show: {
               states: {
-                initial_state.name.to_sym => { roles: ['creating_user', 'advisor', 'ulra_reviewer'] },
+                initial_state_name => { roles: ['creating_user', 'advisor', 'ulra_reviewer'] },
                 under_review: { roles: ['creating_user', 'advisor', 'ulra_reviewer'] }
               }
             },
             destroy: {
               states: {
-                initial_state.name.to_sym => { roles: ['creating_user', 'ulra_reviewer'] },
+                initial_state_name => { roles: ['creating_user', 'ulra_reviewer'] },
                 under_review: { roles: ['ulra_reviewer'] }
               }
             },
             plan_of_study: {
-              states: { initial_state.name.to_sym => { roles: ['creating_user'] } }
+              states: { initial_state_name => { roles: ['creating_user'] } }
             },
             publisher_information: {
-              states: { initial_state.name.to_sym => { roles: ['creating_user'] } }
+              states: { initial_state_name => { roles: ['creating_user'] } }
             },
             research_process: {
-              states: { initial_state.name.to_sym => { roles: ['creating_user'] } }
+              states: { initial_state_name => { roles: ['creating_user'] } }
             },
             faculty_response: {
-              states: { initial_state.name.to_sym => { roles: ['advisor'] } }
+              states: { initial_state_name => { roles: ['advisor'] } }
             },
             submit_for_review: {
               states: {
-                initial_state.name.to_sym => { roles: ['creating_user', 'advisor'] }
+                initial_state_name => { roles: ['creating_user', 'advisor'] }
               },
               transition_to: :under_review,
               required_actions: [:plan_of_study, :publisher_information, :research_process, :faculty_response]

--- a/app/models/sipity/models/notification/notifiable_context.rb
+++ b/app/models/sipity/models/notification/notifiable_context.rb
@@ -10,7 +10,7 @@ module Sipity
       # StrategyState and Email.
       #
       # @example
-      #   strategy = Sipity::Models::Processing::StrategyState.new
+      #   strategy_state = Sipity::Models::Processing::StrategyState.new
       #   email = Sipity::Models::Notification::Email.new
       #
       #   Sipity::Models::Notification::NotifiableContext.new(

--- a/app/models/sipity/models/notification/notifiable_context.rb
+++ b/app/models/sipity/models/notification/notifiable_context.rb
@@ -1,3 +1,5 @@
+require 'sipity/parameters/notification_context_parameter'
+
 module Sipity
   module Models
     module Notification
@@ -22,6 +24,8 @@ module Sipity
         self.table_name = 'sipity_notification_notifiable_contexts'
         belongs_to :scope_for_notification, polymorphic: true
         belongs_to :email, class_name: 'Sipity::Models::Notification::Email'
+
+        enum(reason_for_notification: Parameters::NotificationContextParameter::VALID_REASONS_FOR_ENUM)
       end
     end
   end

--- a/app/parameters/sipity/parameters/notification_context_parameter.rb
+++ b/app/parameters/sipity/parameters/notification_context_parameter.rb
@@ -5,6 +5,12 @@ module Sipity
     class NotificationContextParameter
       REASON_ACTION_IS_TAKEN = 'action_is_taken'.freeze
       REASON_ENTERED_STATE = 'entered_state'.freeze
+
+      VALID_REASONS_FOR_ENUM = {
+        REASON_ACTION_IS_TAKEN => REASON_ACTION_IS_TAKEN,
+        REASON_ENTERED_STATE => REASON_ENTERED_STATE
+      }.freeze
+
       attr_reader :scope, :reason, :the_thing, :requested_by, :on_behalf_of
       def initialize(**keywords)
         self.the_thing = keywords.fetch(:the_thing)
@@ -24,6 +30,11 @@ module Sipity
       end
 
       attr_writer :scope, :the_thing, :requested_by, :on_behalf_of, :reason
+
+      def reason=(value)
+        fail ArgumentError, "Expected #{value.inspect} in #{VALID_REASONS_FOR_ENUM.inspect}" unless VALID_REASONS_FOR_ENUM.key?(value)
+        @reason = value
+      end
     end
   end
 end

--- a/db/data/20151202183937_removing_submit_for_review_from_ulra.rb
+++ b/db/data/20151202183937_removing_submit_for_review_from_ulra.rb
@@ -1,0 +1,15 @@
+class RemovingSubmitForReviewFromUlra < ActiveRecord::Migration
+  def self.up
+    work_type = Sipity::Models::WorkType[Sipity::Models::WorkType::ULRA_SUBMISSION]
+    strategy = work_type.strategy_usage.strategy
+    submit_for_review_action = strategy.strategy_actions.find_by!(name: 'submit_for_review')
+    submit_for_review_action.strategy_state_actions.includes(:originating_strategy_state).each do |state_actions|
+      next unless state_actions.originating_strategy_state.name == 'new'
+      state_actions.destroy
+    end
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151201155313) do
+ActiveRecord::Schema.define(version: 20151202183937) do
 
   create_table "data_migrations", id: false, force: :cascade do |t|
     t.string "version", limit: 255, null: false

--- a/spec/data_generators/sipity/data_generators/email_notification_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/email_notification_generator_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'sipity/parameters/notification_context_parameter'
+
+module Sipity
+  module DataGenerators
+    RSpec.describe EmailNotificationGenerator do
+      let(:strategy) { Models::Processing::Strategy.new(id: 1) }
+      let(:scope) { 'show' }
+      let(:email_name) { :the_weasel }
+      let(:recipients) { { to: 'creating_user', cc: 'advisor', bcc: 'data_observer' } }
+
+      context '#call' do
+        context 'with for reason: REASON_ACTION_IS_TAKEN' do
+          let(:reason) { Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN }
+          it 'will generate the requisite entries' do
+            strategy_action = Sipity::Models::Processing::StrategyAction.create!(strategy_id: strategy.id, name: scope)
+            expect do
+              expect do
+                expect do
+                  described_class.call(strategy: strategy, reason: reason, scope: scope, email_name: email_name, recipients: recipients)
+                end.to change { Models::Notification::Email.count }.by(1)
+              end.to change { Models::Notification::EmailRecipient.count }.by(3)
+            end.to change { strategy_action.notifiable_contexts.count }.by(1)
+          end
+        end
+
+        context 'with for reason: REASON_ENTERED_STATE' do
+          let(:reason) { Parameters::NotificationContextParameter::REASON_ENTERED_STATE }
+          it 'will generate the requisite entries' do
+            strategy_state = Sipity::Models::Processing::StrategyState.create!(strategy_id: strategy.id, name: scope)
+            expect do
+              expect do
+                expect do
+                  described_class.call(strategy: strategy, reason: reason, scope: scope, email_name: email_name, recipients: recipients)
+                end.to change { Models::Notification::Email.count }.by(1)
+              end.to change { Models::Notification::EmailRecipient.count }.by(3)
+            end.to change { strategy_state.notifiable_contexts.count }.by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/data_generators/sipity/data_generators/work_types/ulra_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_types/ulra_generator_spec.rb
@@ -18,10 +18,12 @@ module Sipity
           expect do
             expect do
               expect do
-                subject.call(work_area: work_area, submission_window: submission_window)
-              end.to change { Models::WorkType.count }.by(described_class::WORK_TYPE_NAMES.count)
-            end.to change { Models::Processing::Strategy.count }.by(described_class::WORK_TYPE_NAMES.count)
-          end.to change { Models::Processing::StrategyResponsibility.count }.by(described_class::WORK_TYPE_NAMES.count)
+                expect do
+                  subject.call(work_area: work_area, submission_window: submission_window)
+                end.to change { Models::WorkType.count }.by(described_class::WORK_TYPE_NAMES.count)
+              end.to change { Models::Processing::Strategy.count }.by(described_class::WORK_TYPE_NAMES.count)
+            end.to change { Models::Processing::StrategyResponsibility.count }.by(described_class::WORK_TYPE_NAMES.count)
+          end.to change { Models::Notification::Email.count }
 
           # It can be called repeatedly without updating things
           [:update_attribute, :update_attributes, :update_attributes!, :save, :save!, :update, :update!].each do |method_names|

--- a/spec/models/sipity/models/notification/notifiable_context_spec.rb
+++ b/spec/models/sipity/models/notification/notifiable_context_spec.rb
@@ -12,6 +12,11 @@ module Sipity
           its(:column_names) { should include('reason_for_notification') }
           its(:column_names) { should include('email_id') }
         end
+
+        subject { described_class.new }
+        it 'will raise an ArgumentError if you provide an invalid #reason_for_notification' do
+          expect { subject.reason_for_notification = '__incorrect_name__' }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/parameters/sipity/parameters/notification_context_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/notification_context_parameter_spec.rb
@@ -31,8 +31,12 @@ module Sipity
         end
 
         it 'will use the given reason' do
-          subject = described_class.new(keywords.merge(reason: 'casseroles'))
-          expect(subject.reason).to eq('casseroles')
+          subject = described_class.new(keywords.merge(reason: 'entered_state'))
+          expect(subject.reason).to eq('entered_state')
+        end
+
+        it 'will raise an exception if an invalid reason is given' do
+          expect { described_class.new(keywords.merge(reason: 'casseroles')) }.to raise_error(ArgumentError)
         end
       end
     end

--- a/spec/repositories/sipity/queries/notification_queries_spec.rb
+++ b/spec/repositories/sipity/queries/notification_queries_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 require 'sipity/queries/notification_queries'
+require 'sipity/parameters/notification_context_parameter'
 
 module Sipity
   module Queries
     RSpec.describe NotificationQueries, type: :isolated_repository_module do
 
       context '#email_notifications_for' do
-        let(:reason_for_notification) { 'action_is_taken' }
+        let(:reason_for_notification) { Parameters::NotificationContextParameter::REASON_ACTION_IS_TAKEN }
+        let(:another_reason_for_notification) { Parameters::NotificationContextParameter::REASON_ENTERED_STATE }
         let(:scope_for_notification) { Models::Processing::StrategyAction.new(id: 1) }
         let(:separate_scope_for_notification) { Models::Processing::StrategyAction.new(id: 2) }
         let!(:email_not_to_send) { Models::Notification::Email.create!(method_name: 'not_to_send') }
@@ -21,13 +23,13 @@ module Sipity
           Models::Notification::NotifiableContext.create!(
             scope_for_notification_id: scope_for_notification.id,
             scope_for_notification_type: Conversions::ConvertToPolymorphicType.call(scope_for_notification),
-            reason_for_notification: "some_other_#{reason_for_notification}",
+            reason_for_notification: another_reason_for_notification,
             email: email_not_to_send
           )
           Models::Notification::NotifiableContext.create!(
             scope_for_notification_id: separate_scope_for_notification.id,
             scope_for_notification_type: Conversions::ConvertToPolymorphicType.call(separate_scope_for_notification),
-            reason_for_notification: "some_other_#{reason_for_notification}",
+            reason_for_notification: another_reason_for_notification,
             email: email_not_to_send
           )
         end


### PR DESCRIPTION
## Extracting a local variable

@f99aa72a0c660617612a326316a55d71d981203f

Instead of repeat of knowledge extract a common variable name.

## Updating ULRA's workflow completion process

@f8181ae9c8149e0991d85b3dfa2f023f0dc657e7

Instead of having two different todo items within the workflow, I'm
opting to have students choose to sign off and faculty. This sends the
work into an interstitial state that the other person can work on.

To see the effect of this, compare the before and after processing
diagrams.

To get the processing diagram for this commit use the following:

```console
$ rake bootstrap
$ rails r scripts/commands/generate_state_machine_diagrams.rb
$ open artifacts/state_machines/ulra_submission_processing.dot -a Graphviz
```

Related to #949

## Tidying up an example

@fc725447df6f8694b5af63212a4db4edebb92d07

[skip ci]

## Adding enumeration to email notification reason

@a688e7af3032151305b889b5d9fa8d9d9eec19e9

Instead of allowing any old reason, enforce the valid values.

## Adding an EmailNotificationGenerator

@20077b0a4721e12ba9a5ff4715a3da55b5b4de4d

I need a reliable mechanism for associating the appropriate records for
email notification delivery.

## Leveraging EmailNotificationGenerator for ETDs

@4b33ceb4ca2f9778f8d4817132529c31e3c585ab

I want to reuse that logic, so I'm looking to have a consolidated
generation strategy.

## Configuring ULRA actions to send emails

@9dd66cfeb9d30d8e5a79e97eb65acba0dee42863

Note: This is the data entries required for ULRA to send the emails.
The email templates have not been created, so nothing will work
outright.

Related to #949
