### PR TITLE
ULRA emails that need to be sent

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -71,6 +71,7 @@ MethodLength:
     - 'spec/support/site_prism_support.rb'
     - 'app/services/sipity/guard_interface_expectation.rb'
     - 'app/services/sipity/services/notifier.rb'
+    - 'app/mailers/sipity/mailer_builder.rb'
 
 LineLength:
   Description: 'Limit lines to 140 characters.'
@@ -125,6 +126,7 @@ Metrics/AbcSize:
      - app/forms/sipity/forms/work_enrichments/attach_form.rb
      - 'app/repositories/sipity/commands/processing_commands.rb'
      - app/forms/sipity/forms/processing_form.rb
+     - app/mailers/sipity/mailer_builder.rb
 Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false

--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -11,6 +11,13 @@ module Sipity
     class RuntimeError < ::RuntimeError
     end
 
+    # When you have misconfigured the email options
+    class EmailAsOptionInvalidError < RuntimeError
+      def initialize(as:, valid_list:)
+        super("Invalid :as option for email notifier, #{as.inspect} is not in #{valid_list.inspect}")
+      end
+    end
+
     # When passing parameters through the job layer, passing complex objects
     # can cause problems; In that we don't want to pass state across the async
     # boundary.

--- a/app/mailers/sipity/mailer_builder.rb
+++ b/app/mailers/sipity/mailer_builder.rb
@@ -1,0 +1,83 @@
+require 'active_support/core_ext/array/wrap'
+require 'action_mailer/base'
+require 'sipity/exceptions'
+
+module Sipity
+  # Responsible for building, in a consistent manner, the various mailers.
+  class MailerBuilder
+    def self.build(mailer_suffix, &block)
+      builder = new
+      builder.instance_exec(&block) if block_given?
+      the_mailer_name = File.join('sipity/mailers', "#{mailer_suffix.to_s.underscore}_mailer")
+
+      Class.new(ActionMailer::Base) do
+        default from: Figaro.env.default_email_from, return_path: Figaro.env.default_email_return_path
+        layout 'mailer'
+
+        class_attribute :emails, instance_accessor: false
+        class_attribute :mailer_name
+        self.emails = builder.emails
+
+        # Without a mailer_name, the view lookup assumes "anonymous" and all hell breaks loose.
+        # This is because ActionMailer builds the mailer_name based on the class name. But in our
+        # case the class name is Anonymous (see the above Class.new)
+        self.mailer_name = the_mailer_name
+
+        emails.each do |email|
+          define_method(email.method_name) do |options = {}|
+            entity = options.fetch(:entity)
+            @entity = options.fetch(:decorator) { email.decorator }.new(entity)
+            mail(options.slice(:to, :cc, :bcc).merge(subject: email_subject(email.method_name)))
+          end
+        end
+
+        define_method(:email_subject) do |email_method_name|
+          prefix = t('application.name')
+          suffix = t("email_name.#{email_method_name}", scope: self.class.to_s.underscore, default: email_method_name.to_s.titleize)
+          "#{prefix}: #{suffix}"
+        end
+        private :email_subject
+      end
+    end
+
+    def initialize
+      @emails = []
+    end
+
+    def email(name:, as:)
+      @emails << Email.new(name: name, as: as)
+    end
+
+    attr_reader :emails, :as
+
+    # Responsible for assisting in the generation an email; Enforcing valid options etc.
+    class Email
+      AS_OPTIONS_LOOKUP = {
+        work: 'Sipity::Decorators::Emails::WorkEmailDecorator',
+        action: 'Sipity::Decorators::Emails::RegisteredActionDecorator',
+        comment: 'Sipity::Decorators::Emails::ProcessingCommentDecorator'
+      }
+      def initialize(name:, as:)
+        self.name = name
+        self.as = as
+      end
+
+      attr_reader :name, :as
+      alias_method :method_name, :name
+
+      def decorator
+        AS_OPTIONS_LOOKUP.fetch(as).constantize
+      end
+
+      private
+
+      attr_writer :name
+
+      def as=(input)
+        fail(Exceptions::EmailAsOptionInvalidError, as: input, valid_list: AS_OPTIONS_LOOKUP) unless AS_OPTIONS_LOOKUP.key?(input)
+        @as = input
+      end
+    end
+    private_constant :Email
+  end
+end

--- a/app/mailers/sipity/mailers/etd_mailer.rb
+++ b/app/mailers/sipity/mailers/etd_mailer.rb
@@ -1,65 +1,25 @@
 module Sipity
+  # :nodoc:
   module Mailers
     # This class is responsible for creating/delivering emails associated with
     # the ETD work area.
-    class EtdMailer < ActionMailer::Base
-      default from: Figaro.env.default_email_from, return_path: Figaro.env.default_email_return_path
-      layout 'mailer'
+    EtdMailer = MailerBuilder.build('etd') do
+      email(name: :advisor_signoff_is_complete, as: :work)
+      email(name: :confirmation_of_advisor_signoff_is_complete, as: :work)
+      email(name: :confirmation_of_work_created, as: :work)
+      email(name: :confirmation_of_submit_for_review, as: :work)
+      email(name: :confirmation_of_grad_school_signoff, as: :work)
+      email(name: :grad_school_requests_cataloging, as: :work)
+      email(name: :submit_for_review, as: :work)
 
-      NOTIFCATION_METHOD_NAMES_FOR_WORK = [
-        :advisor_signoff_is_complete,
-        :confirmation_of_advisor_signoff_is_complete,
-        :confirmation_of_work_created,
-        :confirmation_of_submit_for_review,
-        :confirmation_of_grad_school_signoff,
-        :grad_school_requests_cataloging,
-        :submit_for_review
-      ].freeze
+      email(name: :confirmation_of_advisor_signoff, as: :action)
 
-      NOTIFCATION_METHOD_NAMES_FOR_WORK.each do |method_name|
-        define_method(method_name) do |options = {}|
-          entity = options.fetch(:entity)
-          @entity = options.fetch(:decorator) { Decorators::Emails::WorkEmailDecorator }.new(entity)
-          mail(options.slice(:to, :cc, :bcc).merge(subject: email_subject(method_name)))
-        end
-      end
-
-      NOTIFCATION_METHOD_NAMES_FOR_REGISTERED_ACTION = [
-        :confirmation_of_advisor_signoff
-      ].freeze
-
-      NOTIFCATION_METHOD_NAMES_FOR_REGISTERED_ACTION.each do |method_name|
-        define_method(method_name) do |options = {}|
-          entity = options.fetch(:entity)
-          @entity = options.fetch(:decorator) { Decorators::Emails::RegisteredActionDecorator }.new(entity)
-          mail(options.slice(:to, :cc, :bcc).merge(subject: email_subject(method_name)))
-        end
-      end
-
-      NOTIFCATION_METHOD_NAMES_FOR_PROCESSING_COMMENTS = [
-        :advisor_requests_change,
-        :grad_school_requests_change,
-        :request_change_on_behalf_of,
-        :respond_to_advisor_request,
-        :respond_to_grad_school_request,
-        :cataloger_request_change
-      ].freeze
-
-      NOTIFCATION_METHOD_NAMES_FOR_PROCESSING_COMMENTS.each do |method_name|
-        define_method(method_name) do |options = {}|
-          entity = options.fetch(:entity)
-          @entity = options.fetch(:decorator) { Decorators::Emails::ProcessingCommentDecorator }.new(entity)
-          mail(options.slice(:to, :cc, :bcc).merge(subject: email_subject(method_name)))
-        end
-      end
-
-      private
-
-      def email_subject(email_method_name)
-        prefix = t('application.name')
-        suffix = t("email_name.#{email_method_name}", scope: self.class.to_s.underscore, default: email_method_name.to_s.titleize)
-        "#{prefix}: #{suffix}"
-      end
+      email(name: :advisor_requests_change, as: :comment)
+      email(name: :grad_school_requests_change, as: :comment)
+      email(name: :request_change_on_behalf_of, as: :comment)
+      email(name: :respond_to_advisor_request, as: :comment)
+      email(name: :respond_to_grad_school_request, as: :comment)
+      email(name: :cataloger_request_change, as: :comment)
     end
   end
 end

--- a/app/mailers/sipity/mailers/ulra_mailer.rb
+++ b/app/mailers/sipity/mailers/ulra_mailer.rb
@@ -1,0 +1,14 @@
+module Sipity
+  # :nodoc:
+  module Mailers
+    # This class is responsible for creating/delivering emails associated with
+    # the ULRA work area.
+    UlraMailer = MailerBuilder.build('ulra') do
+      email(name: :confirmation_of_submitted_to_ulra_committee, as: :work)
+      email(name: :confirmation_of_ulra_submission_started, as: :work)
+      email(name: :faculty_assigned_for_ulra_submission, as: :work)
+      email(name: :faculty_completed_their_portion_of_ulra, as: :work)
+      email(name: :student_completed_their_portion_of_ulra, as: :work)
+    end
+  end
+end

--- a/app/views/sipity/mailers/etd_mailer/advisor_requests_change.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/advisor_requests_change.html.erb
@@ -4,8 +4,8 @@
   Your director will then be prompted to review the changes.
 </p>
 
-<%= render partial: 'comment', object: @entity %>
+<%= render partial: 'sipity/mailers/etd_mailer/comment', object: @entity %>
 
-<%= render partial: 'etd_submission_assistance' %>
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/etd_submission_assistance' %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/advisor_signoff_is_complete.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/advisor_signoff_is_complete.html.erb
@@ -11,4 +11,4 @@
   </ul>
 </p>
 
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/cataloger_request_change.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/cataloger_request_change.html.erb
@@ -7,5 +7,5 @@
 
 <p>You can review the issues at: <%= link_to @entity.email_message_action_url, @entity.email_message_action_url %>.</p>
 
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/confirmation_of_advisor_signoff.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/confirmation_of_advisor_signoff.html.erb
@@ -1,5 +1,5 @@
 <p>On <%= @entity.action_taken_at.to_formatted_s(:long_ordinal) %>, <%= @entity.on_behalf_of %> approved <%= link_to "your #{@entity.work_type}", @entity.email_message_action_url %> for submission to the Graduate School.</p>
 
-<%= render partial: 'etd_submission_assistance' %>
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/etd_submission_assistance' %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/confirmation_of_advisor_signoff_is_complete.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/confirmation_of_advisor_signoff_is_complete.html.erb
@@ -1,5 +1,5 @@
 <p>Your research director committee has approved your <%= @entity.work_type %> for submission to the Graduate School. Your document has now been added to the Graduate School’s queue for review.</p>
 
-<%= render partial: 'etd_submission_assistance' %>
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/etd_submission_assistance' %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/confirmation_of_grad_school_signoff.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/confirmation_of_grad_school_signoff.html.erb
@@ -45,5 +45,5 @@
   <% end %>
 </ul>
 
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/confirmation_of_submit_for_review.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/confirmation_of_submit_for_review.html.erb
@@ -17,6 +17,6 @@ Your <%= 'director'.pluralize(@entity.reviewers.count) %> may then log in to the
 
 <p>Please note: You will be unable to edit the document or the record while your submission is undergoing review. As your document completes each review stage, you will receive an email notice to apprise you of the status.</p>
 
-<%= render partial: 'etd_submission_assistance' %>
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/etd_submission_assistance' %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/confirmation_of_work_created.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/confirmation_of_work_created.html.erb
@@ -9,6 +9,6 @@
 
 <p>After you’ve completed the descriptive information and uploaded your file(s), be sure to click the "<%= t('sipity/works.state_advancing_actions.label.submit_for_review', default: 'Submit for Review') %>" button to begin the final review process. <em>Please note: you will be unable to edit the record while it is under review.</em></p>
 
-<%= render partial: 'etd_submission_assistance' %>
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/etd_submission_assistance' %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/grad_school_requests_cataloging.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/grad_school_requests_cataloging.html.erb
@@ -14,5 +14,5 @@
   <li>Submitted for advisor approval: <%= @entity.submission_date.to_sentence %></li>
 </ul>
 
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/grad_school_requests_change.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/grad_school_requests_change.html.erb
@@ -9,5 +9,5 @@
 
 <p>If you have questions about your comments, the ETD record, or the other <a href="http://www.google.com/url?q=http%3A%2F%2Fgraduateschool.nd.edu%2Fresources-for-current-students%2Fdt%2Fdt-checklist%2F&sa=D&sntz=1&usg=AFQjCNGvwVT72W1yRY7b1cf01bMby9lmxw">submission materials</a>, please contact me or my assistant at <a href="mailto:dteditor@nd.edu">dteditor@nd.edu</a> or 574-631-7545 for assistance.</p>
 
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/release_suspended_catalog_record.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/release_suspended_catalog_record.html.erb
@@ -18,5 +18,5 @@
   <li>Submitted for advisor approval: <%= @entity.submission_date.to_sentence %></li>
 </ul>
 
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/request_change_on_behalf_of.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/request_change_on_behalf_of.html.erb
@@ -5,8 +5,8 @@
   Your director will then be prompted to review the changes.
 </p>
 
-<%= render partial: 'comment', object: @entity %>
+<%= render partial: 'sipity/mailers/etd_mailer/comment', object: @entity %>
 
-<%= render partial: 'etd_submission_assistance' %>
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/etd_submission_assistance' %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/respond_to_advisor_request.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/respond_to_advisor_request.html.erb
@@ -2,5 +2,5 @@
   <%= @entity.name_of_commentor %> has responded to a request for changes to <%= link_to @entity.title, @entity.email_message_action_url %>
 </p>
 
-<%= render partial: 'comment', object: @entity %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/comment', object: @entity %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/respond_to_grad_school_request.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/respond_to_grad_school_request.html.erb
@@ -2,5 +2,5 @@
   <%= @entity.name_of_commentor %> has responded to a request for changes to the formal submission of the doctoral dissertation or master's thesis <%= link_to @entity.title, @entity.email_message_action_url %>.
 </p>
 
-<%= render partial: 'comment', object: @entity %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/comment', object: @entity %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/etd_mailer/submit_for_review.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/submit_for_review.html.erb
@@ -9,5 +9,5 @@
 
 <p>If you have questions about this process, do not currently have a NetID, or are unable to complete either of these approval options, please email me at <a href="mailto:shill2@nd.edu" target="_top">shill2@nd.edu</a> or call <a href="tel:574.631.7545">574-631-7545</a> for assistance.</p>
 
-<%= render partial: 'grad_school_email_signature' %>
-<%= render(partial: 'action_in_the_inbox', object: @entity) %>
+<%= render partial: 'sipity/mailers/etd_mailer/grad_school_email_signature' %>
+<%= render(partial: 'sipity/mailers/etd_mailer/action_in_the_inbox', object: @entity) %>

--- a/app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb
@@ -1,0 +1,2 @@
+Generated in:
+<code>app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb</code>

--- a/app/views/sipity/mailers/ulra_mailer/confirmation_of_ulra_submission_started.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/confirmation_of_ulra_submission_started.html.erb
@@ -1,0 +1,2 @@
+Generated in:
+<code>app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb</code>

--- a/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
@@ -1,0 +1,2 @@
+Generated in:
+<code>app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb</code>

--- a/app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb
@@ -1,0 +1,2 @@
+Generated in:
+<code>app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb</code>

--- a/app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb
@@ -1,0 +1,2 @@
+Generated in:
+<code>app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb</code>

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -4,6 +4,10 @@ require 'sipity/exceptions'
 
 module Sipity
   module Exceptions
+    RSpec.describe EmailAsOptionInvalidError do
+      subject { described_class.new(as: :chicken, valid_list: [:hello]) }
+      its(:message) { should be_a(String) }
+    end
     RSpec.describe ResponseHandlerError do
       subject { described_class.new(object: double, errors: [], status: :failure) }
       its(:message) { should be_a(String) }

--- a/spec/mailers/sipity/mailer_builder_spec.rb
+++ b/spec/mailers/sipity/mailer_builder_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'sipity/mailer_builder'
+
+module Sipity
+  RSpec.describe MailerBuilder do
+    context '.build' do
+      subject { described_class.build('wookie') { email(name: 'chewbacca', as: :work) } }
+      its(:superclass) { should eq(ActionMailer::Base) }
+      its(:mailer_name) { should eq('sipity/mailers/wookie_mailer') }
+      its(:emails) { should be_a(Array) }
+      its(:instance_methods) { should include(:chewbacca) }
+
+      it 'will not build if given the wrong as: option for email configuration' do
+        expect do
+          described_class.build('wookie') { email(name: 'chewbacca', as: :monster) }
+        end.to raise_error(Exceptions::EmailAsOptionInvalidError)
+      end
+    end
+  end
+end

--- a/spec/mailers/sipity/mailers/etd_mailer_spec.rb
+++ b/spec/mailers/sipity/mailers/etd_mailer_spec.rb
@@ -18,35 +18,16 @@ module Sipity
       let(:user) { User.new(name: 'User') }
       let(:actor) { Models::Processing::Actor.new(proxy_for: user) }
       let(:to) { 'test@example.com' }
-
-      described_class::NOTIFCATION_METHOD_NAMES_FOR_WORK.each do |work_notification_method_name|
-        context "##{work_notification_method_name}" do
-          it 'should send an email' do
-            processing_entity # making sure its declared
-            described_class.send(work_notification_method_name, entity: work, to: to).deliver_now
-            expect(ActionMailer::Base.deliveries.count).to eq(1)
-          end
-        end
+      let(:comment) { Models::Processing::Comment.new(actor: actor, entity: processing_entity) }
+      let(:action) do
+        Models::Processing::EntityActionRegister.new(entity: processing_entity, on_behalf_of_actor: actor, created_at: Time.zone.now)
       end
 
-      described_class::NOTIFCATION_METHOD_NAMES_FOR_PROCESSING_COMMENTS.each do |email_method|
-        context "##{email_method}" do
-          let(:processing_comment) { Models::Processing::Comment.new(actor: actor, entity: processing_entity) }
+      described_class.emails.each do |email|
+        context "##{email.method_name}" do
           it 'should send an email' do
-            described_class.send(email_method, entity: processing_comment, to: to).deliver_now
-            expect(ActionMailer::Base.deliveries.count).to eq(1)
-          end
-        end
-      end
-
-      described_class::NOTIFCATION_METHOD_NAMES_FOR_REGISTERED_ACTION.each do |email_method|
-        context "##{email_method}" do
-          # YOWZA! This is a lot of collaborators!
-          let(:registered_action) do
-            Models::Processing::EntityActionRegister.new(entity: processing_entity, on_behalf_of_actor: actor, created_at: Time.zone.now)
-          end
-          it 'should send an email' do
-            described_class.send(email_method, entity: registered_action, to: to).deliver_now
+            processing_entity
+            described_class.send(email.method_name, entity: send(email.as), to: to).deliver_now
             expect(ActionMailer::Base.deliveries.count).to eq(1)
           end
         end

--- a/spec/mailers/sipity/mailers/ulra_mailer_spec.rb
+++ b/spec/mailers/sipity/mailers/ulra_mailer_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'sipity/mailers/etd_mailer'
+module Sipity
+  module Mailers
+    describe UlraMailer do
+      before do
+        ActionMailer::Base.delivery_method = :test
+        ActionMailer::Base.perform_deliveries = true
+        ActionMailer::Base.deliveries = []
+        allow(work).to receive(:persisted?).and_return(true)
+      end
+      after do
+        ActionMailer::Base.deliveries.clear
+      end
+
+      let(:work) { Models::Work.new(id: '123', work_type: 'doctoral_dissertation', title: 'a title') }
+      let(:processing_entity) { work.build_processing_entity(strategy_id: '1', strategy_state_id: '1', proxy_for: work) }
+      let(:user) { User.new(name: 'User') }
+      let(:actor) { Models::Processing::Actor.new(proxy_for: user) }
+      let(:to) { 'test@example.com' }
+
+      described_class.emails.each do |email|
+        context "##{email.method_name}" do
+          it 'should send an email' do
+            processing_entity # making sure its declared
+            described_class.send(email.method_name, entity: work, to: to).deliver_now
+            expect(ActionMailer::Base.deliveries.count).to eq(1)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Adding a placeholder body for ULRA emails

@dcef535714384c07284ef5161278314fb4dc75f8

This resolves the first pass of the ULRA emails. Its enough to see what
is sent and when.

## Adding exception to provide greater clarity

@47f2545b59230c2be5f52580096c999f78b8242e


## Extracting a common email class builder method

@6244f6c931917947f6d20c10e9f4b890ad91b19f

Prior to this commit the EtdMailer had a heavy load of duplicate logic.
It wasn't as declarative as it could be.

This commit extracts a builder method that allows for the predictable
generation of the EtdMailer and an upcoming UlraMailer object. The
predictability is desirable from an validation and proper composition
stand point.

It should be noted that a few oddities are introduced with the builder,
namely the view paths in partials gets rather weird (i.e. see comments
in the builder for more details).

By extracting a function responsible for building the emailer in a
consistent manner, I can swap out the details of the actual email
subsystem. This could've been done by creating a subclass of the
ActionMailer::Base and adding the configuration options there. But then
we have an explicit 3 levels of inheritance, which becomes nasty.

It should also be noted that by moving towards this composition, it would
be possible to express the email notifications in a configuration file.
One thing I've been thinking about is whether the entire workflow should
be articulated in some kind of localized data structure instead of the
database. But that is another thought for later.

## Adding ULRA email handler

@b74c6232bc4e7bd636251956ccca44d775168462

Much like the ETD email handler, the ULRA email handler is easy to
configure.

Related to #946
