### PR TITLE
Refactor work area presenter lookup

### DIFF
--- a/app/parameters/sipity/parameters/handled_response_parameter.rb
+++ b/app/parameters/sipity/parameters/handled_response_parameter.rb
@@ -48,8 +48,14 @@ module Sipity
         end
       end
 
+      # Inject these view path slugs into the rendering sequence. In doing so we
+      # are able to use specific partials and presenters but fallback on more
+      # generic presenters.
+      #
+      # @note Order is very important; The values yielded are with increased specificity.
       def with_each_additional_view_path_slug
-        yield('') # Important if we want to degrade to a fall-back.
+        yield('') # Can this be deprecated?
+        yield('core') # I want to move things up to core
         yield(work_area.slug) # Important if we want to leverage a specific template
       end
 

--- a/app/repositories/sipity/queries/additional_attribute_queries.rb
+++ b/app/repositories/sipity/queries/additional_attribute_queries.rb
@@ -26,15 +26,6 @@ module Sipity
         returning_value = returning_value.first if cardinality == :one || cardinality == 1
         returning_value
       end
-
-      def available_supervising_semester_for(ending_year: Time.zone.today.year, **)
-        (-3..0).each_with_object([]) do |year_delta, values|
-          year = ending_year.to_i + year_delta
-          ['Spring', 'Summer', 'Fall'].each do |season|
-            values << "#{season} #{year}"
-          end
-        end
-      end
     end
   end
 end

--- a/app/repositories/sipity/queries/submission_window_queries.rb
+++ b/app/repositories/sipity/queries/submission_window_queries.rb
@@ -12,6 +12,10 @@ module Sipity
       # @param work_area [#to_work_area]
       # @param as_of [Time]
       # @return ActiveRecord::Relation records from Models::SubmissionWindow
+      #
+      ## @note This query shares logic with OpenForStartingSubmissionsValidator#validate_each
+      #
+      # @see OpenForStartingSubmissionsValidator
       def find_open_submission_windows_by(work_area:, as_of: Time.zone.now)
         work_area = PowerConverter.convert_to_work_area(work_area)
         submission_windows = Models::SubmissionWindow.arel_table

--- a/app/repositories/sipity/queries/ulra_queries.rb
+++ b/app/repositories/sipity/queries/ulra_queries.rb
@@ -1,0 +1,15 @@
+module Sipity
+  module Queries
+    # Queries specific to ULRA
+    module UlraQueries
+      def available_supervising_semester_for(ending_year: Time.zone.today.year, **)
+        (-3..0).each_with_object([]) do |year_delta, values|
+          year = ending_year.to_i + year_delta
+          ['Spring', 'Summer', 'Fall'].each do |season|
+            values << "#{season} #{year}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/repositories/sipity/query_repository.rb
+++ b/app/repositories/sipity/query_repository.rb
@@ -17,6 +17,7 @@ module Sipity
     include Queries::RedirectQueries
     include Queries::SimpleControlledVocabularyQueries
     include Queries::SubmissionWindowQueries
+    include Queries::UlraQueries
     include Queries::WorkAreaQueries
     include Queries::WorkQueries
   end

--- a/app/validators/open_for_starting_submissions_validator.rb
+++ b/app/validators/open_for_starting_submissions_validator.rb
@@ -1,6 +1,10 @@
 require 'active_model/validator'
 
 # Responsible for validating that a submission window is open for starting submissions
+#
+# @note This validator shares logic with Sipity::Queries::SubmissionWindowQueries#find_open_submission_windows_by
+#
+# @see Sipity::Queries::SubmissionWindowQueries#find_open_submission_windows_by
 class OpenForStartingSubmissionsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     as_of = Time.zone.now

--- a/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
@@ -21,7 +21,7 @@ module Sipity
       end
 
       it 'will yield each additional view path slug' do
-        expect { |b| subject.with_each_additional_view_path_slug(&b) }.to yield_successive_args('', work_area.slug)
+        expect { |b| subject.with_each_additional_view_path_slug(&b) }.to yield_successive_args('', 'core', work_area.slug)
       end
 
       it 'will use the object\'s template if one is assigned' do

--- a/spec/repositories/sipity/queries/additional_attribute_queries_spec.rb
+++ b/spec/repositories/sipity/queries/additional_attribute_queries_spec.rb
@@ -23,16 +23,4 @@ RSpec.describe Sipity::Queries::AdditionalAttributeQueries, type: :isolated_repo
         to eq(['Title is Chicken', 'Title is Egg'])
     end
   end
-  context '#available_supervising_semester_for' do
-    it 'will return an array of semesters' do
-      expect(test_repository.available_supervising_semester_for(ending_year: 2015, work: work)).to eq(
-        [
-          "Spring 2012", "Summer 2012", "Fall 2012",
-          "Spring 2013", "Summer 2013", "Fall 2013",
-          "Spring 2014", "Summer 2014", "Fall 2014",
-          "Spring 2015", "Summer 2015", "Fall 2015"
-        ]
-      )
-    end
-  end
 end

--- a/spec/repositories/sipity/queries/submission_window_queries_spec.rb
+++ b/spec/repositories/sipity/queries/submission_window_queries_spec.rb
@@ -31,6 +31,30 @@ module Sipity
         end
       end
 
+      context '#find_open_submission_windows_by' do
+        let(:as_of) { Time.zone.now }
+
+        it 'will return alphabetized entries which are open as of the current date' do
+          [
+            {
+              work_area_id: work_area.id, slug: 'use', open_for_starting_submissions_at: 2.hours.ago
+            }, {
+              work_area_id: work_area.id, slug: 'another', open_for_starting_submissions_at: 4.hours.ago,
+              closed_for_starting_submissions_at: 5.hours.from_now
+            }, {
+              work_area_id: work_area.id + 2, slug: 'skip_other_area', open_for_starting_submissions_at: 2.hours.ago
+            }, {
+              work_area_id: work_area.id, slug: 'skip_in_future', open_for_starting_submissions_at: 2.hours.from_now
+            }, {
+              work_area_id: work_area.id, slug: 'skip_now_closed', open_for_starting_submissions_at: 4.hours.ago,
+              closed_for_starting_submissions_at: 2.hours.ago
+            }
+          ].each do |attributes|
+            Models::SubmissionWindow.create!(attributes)
+          end
+          expect(test_repository.find_open_submission_windows_by(work_area: work_area).pluck(:slug)).to eq(['another', 'use'])
+        end
+      end
       context '#build_submission_window_processing_action_form' do
         let(:parameters) { { submission_window: double, processing_action_name: double, attributes: double, requested_by: double } }
         let(:form) { double }

--- a/spec/repositories/sipity/queries/ulra_queries_spec.rb
+++ b/spec/repositories/sipity/queries/ulra_queries_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'sipity/queries/ulra_queries'
+
+RSpec.describe Sipity::Queries::UlraQueries, type: :isolated_repository_module do
+  let(:work) { Sipity::Models::Work.new(id: 1) }
+  let(:another_work) { Sipity::Models::Work.new(id: 2) }
+  context '#available_supervising_semester_for' do
+    it 'will return an array of semesters' do
+      expect(test_repository.available_supervising_semester_for(ending_year: 2015, work: work)).to eq(
+        [
+          "Spring 2012", "Summer 2012", "Fall 2012",
+          "Spring 2013", "Summer 2013", "Fall 2013",
+          "Spring 2014", "Summer 2014", "Fall 2014",
+          "Spring 2015", "Summer 2015", "Fall 2015"
+        ]
+      )
+    end
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -53,7 +53,7 @@ module Sipity
     def authorized_for_processing?(user:, entity:, action:)
     end
 
-    # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
+    # @see ./app/repositories/sipity/queries/ulra_queries.rb
     def available_supervising_semester_for(ending_year: Time.zone.today.year, **)
     end
 

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -37,7 +37,7 @@ module Sipity
     def authorized_for_processing?(user:, entity:, action:)
     end
 
-    # @see ./app/repositories/sipity/queries/additional_attribute_queries.rb
+    # @see ./app/repositories/sipity/queries/ulra_queries.rb
     def available_supervising_semester_for(ending_year: Time.zone.today.year, **)
     end
 


### PR DESCRIPTION
## Attempting to consolidate the presenter rendering

@0bf5ddca105caeb7e7587460e1f74a5a6395cb29

In thinking about rendering options, I have a concept of "core" for the
various processing entities (WorkArea, SubmissionWindow, and Work).
These concepts provide for rendering specific templates, forms, and
presenters yet falling back on general (i.e. core) presenters when a
specific object is not found.

I'm trying to resolve issue #957 through exploratory refactoring.

## Extracting ULRA specific queries

@ebb127203150146b0c195a61c78a3d3fbf0fa5f0

While it is possible this method would exist across multiple work
areas, I'd like to keep the logic separated for the time being.

## Adding #find_open_submission_windows_by

@528c57b718a6271c35cee8c1825bdff3f76da0a4

As the method implies, this method finds open submission windows based
on the given date. Consider that the business logic is distributed
across the Repository and the OpenForStartingSubmissionsValidator.

Related to #957

## Adding documentation

@b6bf573fa4a94cb97d6744ef8bf7d378d83a7494

To clarify the newly added method and draw attention to the related
method.
