### PR TITLE
ULRA Emails

### DIFF
--- a/app/views/sipity/mailers/ulra_mailer/_important_dates.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/_important_dates.html.erb
@@ -1,0 +1,8 @@
+<h2>Important Dates</h2>
+
+<ul>
+  <li>3/13/16 Submission window opens</li>
+  <li>4/13/16 Complete application packages due</li>
+  <li>4/15/16 Award recipients notified</li>
+  <li>4/29/16 Awards given during the Undergraduate Scholars Conference Awards Reception</li>
+</ul>

--- a/app/views/sipity/mailers/ulra_mailer/_questions_and_about_ulra.erb
+++ b/app/views/sipity/mailers/ulra_mailer/_questions_and_about_ulra.erb
@@ -1,0 +1,16 @@
+<h2>Questions?</h2>
+
+<ul>
+  <li>Online application technical issues: <%= mail_to("cds@nd.edu") %></li>
+  <li>Policy/procedure questions: <%= mail_to("ulra­group@nd.edu") %></li>
+</ul>
+
+<h2>About ULRA</h2>
+
+<p>
+  Hesburgh Libraries and the Center for Undergraduate Scholarly Engagement (CUSE) award the annual Undergraduate Library Research Award (ULRA) to undergraduate students whose work demonstrates the highest levels of scholarship and information literacy.
+  Established in 2010 to promote intellectual discovery and the advancement of lifelong learning, the ULRA recognizes undergraduates who demonstrate excellent research skills that utilize a breadth of library resources, collections, and services for their scholarly and creative projects. Research projects are evaluated by teaching faculty and members of the ULRA selection committee.
+<p>
+<p>
+  <a href="http://library.nd.edu/ulra/">library.nd.edu/ulra</a>
+</p>

--- a/app/views/sipity/mailers/ulra_mailer/_questions_and_about_ulra.erb
+++ b/app/views/sipity/mailers/ulra_mailer/_questions_and_about_ulra.erb
@@ -8,8 +8,8 @@
 <h2>About ULRA</h2>
 
 <p>
-  Hesburgh Libraries and the Center for Undergraduate Scholarly Engagement (CUSE) award the annual Undergraduate Library Research Award (ULRA) to undergraduate students whose work demonstrates the highest levels of scholarship and information literacy.
-  Established in 2010 to promote intellectual discovery and the advancement of lifelong learning, the ULRA recognizes undergraduates who demonstrate excellent research skills that utilize a breadth of library resources, collections, and services for their scholarly and creative projects. Research projects are evaluated by teaching faculty and members of the ULRA selection committee.
+  <strong>Hesburgh Libraries and the Center for Undergraduate Scholarly Engagement</strong> (CUSE) award the annual Undergraduate Library Research Award (ULRA) to undergraduate students whose work demonstrates the highest levels of scholarship and information literacy.
+  Established in 2010 to promote intellectual discovery and the advancement of lifelong learning, the ULRA recognizes undergraduates who demonstrate excellent research skills that utilize a breadth of library resources, collections, and services for their scholarly and creative projects. Research projects are evaluated by teaching faculty and members of the <strong>ULRA selection committee</strong>.
 <p>
 <p>
   <a href="http://library.nd.edu/ulra/">library.nd.edu/ulra</a>

--- a/app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb
@@ -1,2 +1,11 @@
-Generated in:
-<code>app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb</code>
+<p>
+  A complete application package has been received for the <%= @entity.title %> project, and has been sent forward for review by the Selection Committee
+</p>
+
+<p>Thank you for your participation!</p>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/important_dates', object: @entity) %>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/questions_and_about_ulra', object: @entity) %>
+
+<!-- app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb -->

--- a/app/views/sipity/mailers/ulra_mailer/confirmation_of_ulra_submission_started.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/confirmation_of_ulra_submission_started.html.erb
@@ -1,2 +1,24 @@
-Generated in:
-<code>app/views/sipity/mailers/ulra_mailer/confirmation_of_submitted_to_ulra_committee.html.erb</code>
+<p>You have successfully started the student portion of your ULRA application.</p>
+
+<p>
+  In order for your application to be considered by the selection committee, please ensure that the following application components are completed and successfully submitted prior to the deadline:
+
+  <ul>
+    <li>Student Application Components
+      <ul>
+        <li>Application form</li>
+        <li>Application essay</li>
+        <li>Final project</li>
+      </ul>
+    </li>
+    <li>Advisor letter of recommendation</li>
+  </ul>
+</p>
+
+<p><strong>Continue working on your application here: </strong> <%= link_to(@entity.email_message_action_url, @entity.email_message_action_url) %></p>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/important_dates', object: @entity) %>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/questions_and_about_ulra', object: @entity) %>
+
+<!-- app/views/sipity/mailers/ulra_mailer/confirmation_of_ulra_submission_started.html.erb -->

--- a/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
@@ -21,30 +21,8 @@
 
 <p><strong>Upload your letter of recommendation (.pdf) here:</strong> <%= link_to(@entity.email_message_action_url, @entity.email_message_action_url) %></p>
 
-<h2>Important Dates</h2>
+<%= render(partial: 'sipity/mailers/ulra_mailer/important_dates', object: @entity) %>
 
-<ul>
-  <li>3/13/16 Submission window opens</li>
-  <li>4/13/16 Complete application packages due</li>
-  <li>4/15/16 Award recipients notified</li>
-  <li>4/29/16 Awards given during the Undergraduate Scholars Conference Awards Reception</li>
-</ul>
-
-<h2>Questions?</h2>
-
-<ul>
-  <li>Online application technical issues: <%= mail_to("cds@nd.edu") %></li>
-  <li>Policy/procedure questions: <%= mail_to("ulra­group@nd.edu") %></li>
-</ul>
-
-<h2>About ULRA</h2>
-
-<p>
-  Hesburgh Libraries and the Center for Undergraduate Scholarly Engagement (CUSE) award the annual Undergraduate Library Research Award (ULRA) to undergraduate students whose work demonstrates the highest levels of scholarship and information literacy.
-  Established in 2010 to promote intellectual discovery and the advancement of lifelong learning, the ULRA recognizes undergraduates who demonstrate excellent research skills that utilize a breadth of library resources, collections, and services for their scholarly and creative projects. Research projects are evaluated by teaching faculty and members of the ULRA selection committee.
-<p>
-<p>
-  <a href="http://library.nd.edu/ulra/">library.nd.edu/ulra</a>
-</p>
+<%= render(partial: 'sipity/mailers/ulra_mailer/questions_and_about_ulra', object: @entity) %>
 
 <!--app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb-->

--- a/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= @entity.creator_names.to_sentence %> has initiated an application for the Undergraduate Library Research Award for their project: “<%= @entity.title %>”.
+  <%= @entity.creator_names.to_sentence %> has initiated an application for the Undergraduate Library Research Award for their project: <strong><%= @entity.title %></strong>.
 </p>
 
 <p>

--- a/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb
@@ -1,2 +1,50 @@
-Generated in:
-<code>app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb</code>
+<p>
+  <%= @entity.creator_names.to_sentence %> has initiated an application for the Undergraduate Library Research Award for their project: “<%= @entity.title %>”.
+</p>
+
+<p>
+  <strong>Please submit a letter of recommendation (.pdf) in support of this project prior to the deadline:</strong>
+
+  <ul>
+    <li>Please briefly describe the nature of your supervision of this project.</li>
+    <li>
+      Please comment on the quality of the research/scholarship and the depth of inquiry demonstrated by the student's project, including the following (as applicable):
+      <ul>
+        <li>Whether the sources used were appropriate for the scope of the project and its method</li>
+        <li>Whether the methods of research/scholarship were consistent with disciplinary standards</li>
+      <ul>
+    </li>
+    <li>How did the student's use of library resources and/or services (such as print, electronic, database, special collections, etc.) contribute to the outcome of this project?</li>
+    <li>The evaluators are particularly interested in how the use of library materials, services and/or other resources contributed to making the project comprehensive, original, or unique.</li>
+  </ul>
+<p>
+
+<p><strong>Upload your letter of recommendation (.pdf) here:</strong> <%= link_to(@entity.email_message_action_url, @entity.email_message_action_url) %></p>
+
+<h2>Important Dates</h2>
+
+<ul>
+  <li>3/13/16 Submission window opens</li>
+  <li>4/13/16 Complete application packages due</li>
+  <li>4/15/16 Award recipients notified</li>
+  <li>4/29/16 Awards given during the Undergraduate Scholars Conference Awards Reception</li>
+</ul>
+
+<h2>Questions?</h2>
+
+<ul>
+  <li>Online application technical issues: <%= mail_to("cds@nd.edu") %></li>
+  <li>Policy/procedure questions: <%= mail_to("ulra­group@nd.edu") %></li>
+</ul>
+
+<h2>About ULRA</h2>
+
+<p>
+  Hesburgh Libraries and the Center for Undergraduate Scholarly Engagement (CUSE) award the annual Undergraduate Library Research Award (ULRA) to undergraduate students whose work demonstrates the highest levels of scholarship and information literacy.
+  Established in 2010 to promote intellectual discovery and the advancement of lifelong learning, the ULRA recognizes undergraduates who demonstrate excellent research skills that utilize a breadth of library resources, collections, and services for their scholarly and creative projects. Research projects are evaluated by teaching faculty and members of the ULRA selection committee.
+<p>
+<p>
+  <a href="http://library.nd.edu/ulra/">library.nd.edu/ulra</a>
+</p>
+
+<!--app/views/sipity/mailers/ulra_mailer/faculty_assigned_for_ulra_submission.html.erb-->

--- a/app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb
@@ -1,2 +1,6 @@
-Generated in:
-<code>app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb</code>
+<p>You have successfully submitted your Letter of Recommendation for <%= @entity.creator_names.to_sentence %>’s <strong><%= @entity.title %></strong> project.</p>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/important_dates', object: @entity) %>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/questions_and_about_ulra', object: @entity) %>
+<!-- app/views/sipity/mailers/ulra_mailer/faculty_completed_their_portion_of_ulra.html.erb -->

--- a/app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb
@@ -5,6 +5,10 @@
   If not received by the due date, your application is not eligible for consideration, even if your components were submitted on time.
 </p>
 
+<p>
+  <strong>Note:</strong> If you submitted a writing sample in place of your final project file, you must submit a <strong>complete</strong> final project file to be eligible to receive the award.
+</p>
+
 <%= render(partial: 'sipity/mailers/ulra_mailer/important_dates', object: @entity) %>
 
 <%= render(partial: 'sipity/mailers/ulra_mailer/questions_and_about_ulra', object: @entity) %>

--- a/app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb
@@ -1,2 +1,12 @@
-Generated in:
-<code>app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb</code>
+<p>You have successfully submitted the student portion of your ULRA application.</p>
+
+<p>
+  <strong>Note:</strong> It is your responsibility to ensure that your advisor submits the letter of recommendation before the deadline.
+  If not received by the due date, your application is not eligible for consideration, even if your components were submitted on time.
+</p>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/important_dates', object: @entity) %>
+
+<%= render(partial: 'sipity/mailers/ulra_mailer/questions_and_about_ulra', object: @entity) %>
+
+<!-- app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb -->

--- a/app/views/sipity/mailers/ulra_mailer/student_has_indicated_attachments_are_complete.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/student_has_indicated_attachments_are_complete.html.erb
@@ -1,2 +1,4 @@
-Generated in:
-<code>app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb</code>
+<p>
+  <%= @entity.creator_names.to_sentence %> has uploaded the completed version of their Final Project "<%= link_to(@entity.title, @entity.email_message_action_url) %>".</p>
+</p>
+<!-- app/views/sipity/mailers/ulra_mailer/student_completed_their_portion_of_ulra.html.erb -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,7 @@ en:
   sipity/mailers/ulra_mailer:
     email_name:
       faculty_assigned_for_ulra_submission: "Action Requested - ULRA - Advisor Letter of Recommendation Requested"
+      faculty_completed_their_portion_of_ulra: "ULRA - Advisor Portion - Letter of Recommendation Submitted"
   sipity/emails:
     access_controls:
       restricted_access: 'Restricted Access'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,7 @@ en:
     email_name:
       faculty_assigned_for_ulra_submission: "Action Requested - ULRA - Advisor Letter of Recommendation Requested"
       faculty_completed_their_portion_of_ulra: "ULRA - Advisor Portion - Letter of Recommendation Submitted"
+      confirmation_of_ulra_submission_started: "ULRA - Student Application Portion - Submission Started"
   sipity/emails:
     access_controls:
       restricted_access: 'Restricted Access'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,6 +371,7 @@ en:
       faculty_assigned_for_ulra_submission: "Action Requested - ULRA - Advisor Letter of Recommendation Requested"
       faculty_completed_their_portion_of_ulra: "ULRA - Advisor Portion - Letter of Recommendation Submitted"
       confirmation_of_ulra_submission_started: "ULRA - Student Application Portion - Submission Started"
+      student_completed_their_portion_of_ulra: "ULRA - Student Application Portion - Submission Completed"
   sipity/emails:
     access_controls:
       restricted_access: 'Restricted Access'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,6 +366,9 @@ en:
       respond_to_grad_school_request: "Author response to Graduate School's change request(s)"
       advisor_requests_change: "Your research director has requested changes to your submission"
       confirmation_of_submit_for_review: "Confirmation of submission for review"
+  sipity/mailers/ulra_mailer:
+    email_name:
+      faculty_assigned_for_ulra_submission: "Action Requested - ULRA - Advisor Letter of Recommendation Requested"
   sipity/emails:
     access_controls:
       restricted_access: 'Restricted Access'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -372,6 +372,7 @@ en:
       faculty_completed_their_portion_of_ulra: "ULRA - Advisor Portion - Letter of Recommendation Submitted"
       confirmation_of_ulra_submission_started: "ULRA - Student Application Portion - Submission Started"
       student_completed_their_portion_of_ulra: "ULRA - Student Application Portion - Submission Completed"
+      confirmation_of_submitted_to_ulra_committee: "ULRA - Complete Application Package Received"
   sipity/emails:
     access_controls:
       restricted_access: 'Restricted Access'


### PR DESCRIPTION
## Adding Advisor Letter of Recommendation Requested

@4339ee0bc3edda55f873b36395d8c6cd0dace903

The email, as decided by the ULRA committee, has been transcribed from
their notes.

## Extracting ULRA email partials

@4ab81146e37de3ab8b4f716cbaf1967f47223717

This information is used across several emails, so I'm extracting a
partial.

## Updating font weight for ULRA about section

@09176f48c58826c815099ff95eec4a030241cd31

In the documents that I'm working from, I forgot to account for font
weight.

## Adding Advisor Portion Completed

@f55984090a6ca51de6cb18ac708f1b8214f2d487

The email, as decided by the ULRA committee, has been transcribed from
their notes.

## Adding Student Application - Submission Started

@21247fd558fda9b2624b821dd8c7b3599203187d

The email, as decided by the ULRA committee, has been transcribed from
their notes.

## Adding­ Student Application­ Submission Completed

@aa6e4b4d1c912df307b25ce029df24f5c319453b

The email, as decided by the ULRA committee, has been transcribed from
their notes.

## Adding­ - Confirm Submission to ULRA Committee

@a1f2fc0030e53eeefa34f15dc27bf10ce463db95

The email, as decided by the ULRA committee, has been transcribed from
their notes.

## Adding terse ULRA email for internal updates

@17e7a0de8f32ebf8c58ac7ec7a9c2fe719990f64


## Updating copy concerning ULRA emails

@7a87ec1ee7c502bee105622b21d89ca48ba7c9cf

