### PR TITLE
Updates for etd changes

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -281,7 +281,7 @@
       "attributes": {
         "presentation_sequence": 1
       },
-      "transition_to": "grad_school_approved_but_waiting_for_routing",
+      "transition_to": "ready_for_cataloging",
       "states": [{
         "name": ["under_grad_school_review", "grad_school_changes_requested"],
         "roles": ["etd_reviewing"]
@@ -680,7 +680,7 @@
       "attributes": {
         "presentation_sequence": 1
       },
-      "transition_to": "grad_school_approved_but_waiting_for_routing",
+      "transition_to": "ready_for_cataloging",
       "states": [{
         "name": ["under_grad_school_review", "grad_school_changes_requested"],
         "roles": ["etd_reviewing"]

--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -291,6 +291,16 @@
         "to": "creating_user"
       }]
     }, {
+      "name": "grad_school_final_signoff",
+      "attributes": {
+        "presentation_sequence": 1
+      },
+      "transition_to": "ready_for_cataloging",
+      "states": [{
+        "name": ["grad_school_approved_but_waiting_for_routing"],
+        "roles": ["etd_reviewing"]
+      }]
+    }, {
       "name": "grad_school_requests_change",
       "attributes": {
         "presentation_sequence": 2,
@@ -678,6 +688,16 @@
       "emails": [{
         "name": "confirmation_of_grad_school_signoff",
         "to": "creating_user"
+      }]
+    }, {
+      "name": "grad_school_final_signoff",
+      "attributes": {
+        "presentation_sequence": 1
+      },
+      "transition_to": "ready_for_cataloging",
+      "states": [{
+        "name": ["grad_school_approved_but_waiting_for_routing"],
+        "roles": ["etd_reviewing"]
       }]
     }, {
       "name": "grad_school_requests_change",

--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -313,7 +313,7 @@
       },
       "transition_to": "ready_for_cataloging",
       "states": [{
-        "name": ["back_from_cataloging", "ready_for_cataloging"],
+        "name": ["back_from_cataloging"],
         "roles": ["etd_reviewing"]
       }],
       "emails": [{
@@ -702,7 +702,7 @@
       },
       "transition_to": "ready_for_cataloging",
       "states": [{
-        "name": ["back_from_cataloging", "ready_for_cataloging"],
+        "name": ["back_from_cataloging"],
         "roles": ["etd_reviewing"]
       }],
       "emails": [{

--- a/app/forms/sipity/forms/work_submissions/etd/cataloging_complete_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/cataloging_complete_form.rb
@@ -54,6 +54,10 @@ module Sipity
 
           private
 
+          def catalog_system_number=(input)
+            @catalog_system_number = PowerConverter.convert(input, to: :catalog_system_number) { input }
+          end
+
           def view_context
             Draper::ViewContext.current
           end

--- a/app/forms/sipity/forms/work_submissions/etd/cataloging_complete_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/cataloging_complete_form.rb
@@ -9,22 +9,20 @@ module Sipity
           ProcessingForm.configure(
             form_class: self, base_class: Models::Work, processing_subject_name: :work,
             template: Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME,
-            attribute_names: [:agree_to_signoff, :oclc_number, :catalog_system_number]
+            attribute_names: [:oclc_number, :catalog_system_number]
           )
 
           def initialize(work:, requested_by:, attributes: {}, **keywords)
             self.work = work
             self.requested_by = requested_by
             self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
-            self.agree_to_signoff = attributes[:agree_to_signoff]
             self.oclc_number = attributes.fetch(:oclc_number) { oclc_number_from_work }
             self.catalog_system_number = attributes.fetch(:catalog_system_number) { catalog_system_number_from_work }
           end
 
           include ActiveModel::Validations
-          validates :agree_to_signoff, acceptance: { accept: true }
-          validates :oclc_number, presence: true
-          validates :catalog_system_number, presence: true
+          validates :oclc_number, presence: true, format: /\A\d{6,}\Z/
+          validates :catalog_system_number, presence: true, format: /\A\d{9}\Z/
 
           # @param f SimpleFormBuilder
           #
@@ -35,11 +33,6 @@ module Sipity
             # Because simple form threw the following exception:
             # `I18n::InvalidPluralizationData: translation data {:label=>"ALEPH system number"} can not be used with :count => 1`
             markup << f.input(:catalog_system_number, input_html: { required: 'required' }, label: 'ALEPH system number').html_safe
-            markup << f.input(
-              :agree_to_signoff,
-              as: :boolean, inline_label: signoff_agreement, label: false, wrapper_class: 'checkbox',
-              input_html: { required: 'required' } # There is no way to add true boolean attributes to simle_form fields.
-            ).html_safe
           end
 
           def legend
@@ -60,10 +53,6 @@ module Sipity
           end
 
           private
-
-          def agree_to_signoff=(value)
-            @agree_to_signoff = PowerConverter.convert_to_boolean(value)
-          end
 
           def view_context
             Draper::ViewContext.current

--- a/app/forms/sipity/forms/work_submissions/etd/grad_school_final_signoff_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/grad_school_final_signoff_form.rb
@@ -1,0 +1,42 @@
+require 'sipity/forms/processing_form'
+require 'active_model/validations'
+require_relative '../../../forms'
+
+module Sipity
+  module Forms
+    module WorkSubmissions
+      module Etd
+        # Responsible for submitting the final Grad School approval.
+        class GradSchoolFinalSignoffForm
+          ProcessingForm.configure(
+            form_class: self, base_class: Models::Work, attribute_names: [], processing_subject_name: :work,
+            template: Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME
+          )
+
+          def initialize(work:, requested_by:, **keywords)
+            self.work = work
+            self.requested_by = requested_by
+            self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
+          end
+
+          include ActiveModel::Validations
+
+          # @param f SimpleFormBuilder
+          #
+          # @return String
+          def render(*)
+            %(
+              <legend>
+                Prior to the cataloging portion being complete, the Graduate School had signed off on this ETD.
+                At the time, the cataloging portion of this process was incomplete.
+                With the cataloging workflow for ETDs completed, you are now finalizing that workflow.
+              </legend>
+            ).html_safe
+          end
+
+          delegate :submit, to: :processing_action_form
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/power_converters.rb
+++ b/config/initializers/power_converters.rb
@@ -28,6 +28,19 @@ PowerConverter.define_conversion_for(:boolean) do |input|
   end
 end
 
+PowerConverter.define_conversion_for(:catalog_system_number) do |input|
+  case input
+  when Float
+    nil
+  else
+    begin
+      format("%09d", input)
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end
+
 PowerConverter.define_conversion_for(:demodulized_class_name) do |input|
   case input
   when Symbol, String

--- a/spec/config/initializers/power_converters_spec.rb
+++ b/spec/config/initializers/power_converters_spec.rb
@@ -71,6 +71,30 @@ RSpec.describe 'power converters' do
     end
   end
 
+  context 'catalog_system_number' do
+    [
+      ["1", "000000001"],
+      ["1234567890000000", "1234567890000000"],
+      [123_456, "000123456"]
+    ].each_with_index do |(to_convert, expected), index|
+      it "will convert #{to_convert.inspect} to #{expected} (Scenario ##{index}" do
+        expect(PowerConverter.convert(to_convert, to: :catalog_system_number)).to eq(expected)
+      end
+    end
+
+    [
+      'A', false, 0.1
+    ].each_with_index do |to_convert, index|
+      it "will not convert #{to_convert.inspect} (Scenario ##{index}" do
+        expect { PowerConverter.convert(to_convert, to: :catalog_system_number) }.to raise_error(PowerConverter::ConversionError)
+      end
+
+      it "will yield (and not fail) on a failed conversion of #{to_convert.inspect} (Scenario ##{index}" do
+        expect(PowerConverter.convert(to_convert, to: :catalog_system_number) { 'VALUE' }).to eq('VALUE')
+      end
+    end
+  end
+
   context 'strategy_state' do
     let(:strategy_state) { Sipity::Models::Processing::StrategyState.new(id: 1, name: 'hello') }
     let(:strategy) { Sipity::Models::Processing::Strategy.new(id: 2, name: 'strategy') }

--- a/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
@@ -19,6 +19,13 @@ module Sipity
           it { should validate_presence_of(:oclc_number) }
           it { should validate_presence_of(:catalog_system_number) }
 
+          context '#catalog_system_number' do
+            it "will prepend 0s for catalog_system_number's smaller than 9 digits" do
+              subject = described_class.new(keywords.merge(attributes: { catalog_system_number: '123' }))
+              expect(subject.catalog_system_number).to eq('000000123')
+            end
+          end
+
           context '#render' do
             it 'will render HTML safe submission terms and confirmation' do
               form_object = double('Form Object')

--- a/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
@@ -10,19 +10,14 @@ module Sipity
           let(:user) { double('User') }
           let(:keywords) { { work: work, repository: repository, requested_by: user, attributes: {} } }
           let(:oclc_number) { "123456789" }
-          let(:catalog_system_number) { "abc" }
+          let(:catalog_system_number) { "123456789" }
           subject do
-            described_class.new(
-              keywords.merge(
-                attributes: { agree_to_signoff: true, oclc_number: oclc_number, catalog_system_number: catalog_system_number }
-              )
-            )
+            described_class.new(keywords.merge(attributes: { oclc_number: oclc_number, catalog_system_number: catalog_system_number }))
           end
 
           include Shoulda::Matchers::ActiveModel
           it { should validate_presence_of(:oclc_number) }
           it { should validate_presence_of(:catalog_system_number) }
-          it { should validate_acceptance_of(:agree_to_signoff) }
 
           context '#render' do
             it 'will render HTML safe submission terms and confirmation' do
@@ -31,7 +26,6 @@ module Sipity
               expect(form_object).to receive(:input).with(
                 :catalog_system_number, input_html: { required: "required" }, label: 'ALEPH system number'
               ).and_return("<input />")
-              expect(form_object).to receive(:input).with(:agree_to_signoff, hash_including(as: :boolean)).and_return("<input />")
               expect(subject.render(f: form_object)).to be_html_safe
             end
           end

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_final_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_final_signoff_form_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'support/sipity/command_repository_interface'
+require 'sipity/forms/work_submissions/etd/grad_school_final_signoff_form'
+
+module Sipity
+  module Forms
+    module WorkSubmissions
+      module Etd
+        RSpec.describe GradSchoolFinalSignoffForm do
+          let(:work) { double('Work') }
+          let(:repository) { CommandRepositoryInterface.new }
+          let(:user) { double('User') }
+          let(:keywords) { { work: work, repository: repository, requested_by: user, attributes: {} } }
+          subject { described_class.new(**keywords) }
+
+          context 'validation' do
+            it 'will require agreement to the signoff' do
+              expect(described_class.new(**keywords)).to be_valid
+            end
+          end
+
+          context '#render' do
+            it 'will render HTML safe legend' do
+              form_object = double('Form Object')
+              expect(subject.render(f: form_object)).to be_html_safe
+            end
+          end
+
+          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+
+          it { should delegate_method(:submit).to(:processing_action_form) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Tidying up Cataloging Complete form

@c910f32c6bba78baa1aa7d10841bbd435bf34d3e

We didn't need the catalogers to agree to the update.
And we wanted to provide information for them.

## Adding power converter for catalog system number

@c797a7eabf3815eafe0a3839f0c3eda54bbeb0c8


## Tidying up an odd ETD workflow action/state

@229c9bc97d96f7021a01e958cd7aa786f77a5df5

The action "send_to_cataloging" did not make sense to be available in
the "ready_for_cataloging" state.

## Adding action to get ETDs to cataloging

@cf6d4aa406d913bc6616d726eb673f9c266d5a81

Based on the data schema, an action may only transition to one state.
So I need an interstitial action.

## Switching ETD workflow to allow for cataloging

@bc3726019dd70c09d40522aec6cb63007d0388ff

Prior to this commit, all "Grad School Signoff" requests would
sequester the data into a holding state. This was necessary as part of
the migration to Cataloging using Sipity.
