### PR TITLE
Updates concerning ulra

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/ulra_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/ulra_work_types.config.json
@@ -67,10 +67,7 @@
       }, {
         "name": "access_policy",
         "states": [{
-          "name": ["new", "pending_advisor_completion"],
-          "roles": ["creating_user", "advising"]
-        }, {
-          "name": ["pending_student_completion", "under_review"],
+          "name": ["new", "pending_advisor_completion","pending_student_completion", "under_review"],
           "roles": ["creating_user"]
         }],
         "attributes": {
@@ -106,7 +103,7 @@
       }, {
         "name": "faculty_response",
         "states": [{
-          "name": ["new", "pending_student_completion", "pending_advisor_completion"],
+          "name": ["new", "pending_advisor_completion"],
           "roles": ["advising"]
         }]
       }, {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,7 +352,7 @@ en:
       citation:
         type: 'Citation format'
       work:
-        representative_attachment_id: 'Please select your primary file'
+        representative_attachment_id: 'Which file best represents your project'
         files: 'Select files to upload'
     hints:
       work:

--- a/db/data/20160128183836_remove_faculty_ability_to_update_access_policy.rb
+++ b/db/data/20160128183836_remove_faculty_ability_to_update_access_policy.rb
@@ -1,0 +1,20 @@
+class RemoveFacultyAbilityToUpdateAccessPolicy < ActiveRecord::Migration
+  def self.up
+    advising_role = Sipity::Models::Role['advising']
+    advising_role.processing_strategy_roles.find_each do |strategy_role|
+      strategy_role.strategy_state_action_permissions.find_each do |state_action_permission|
+        case state_action_permission.strategy_state_action.strategy_action.name
+        when 'access_policy'
+          state_action_permission.destroy
+        when 'faculty_response'
+          next unless state_action_permission.strategy_state_action.originating_strategy_state.name == 'pending_student_completion'
+          state_action_permission.strategy_state_action.destroy
+        end
+      end
+    end
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Tweaking access_policy and faculty_response rules

@e66d66e9a6760e8691a3e7eb53835ada161f1f99

The advising faculty member should not have additional todo items once
they have completed their letter of recommendation.

Likewise, the advising faculty member should not have access to any
access policy related tasks.

## Updating language concerning representative file

@530204ca31b4c93a42a2b18bd2e64fc049b5e87e

Prefer "Which file best represents your project" instead of primary
file.
