### PR TITLE
Fixing catalog system number coercion

### DIFF
--- a/config/initializers/power_converters.rb
+++ b/config/initializers/power_converters.rb
@@ -33,10 +33,14 @@ PowerConverter.define_conversion_for(:catalog_system_number) do |input|
   when Float
     nil
   else
-    begin
-      format("%09d", input)
-    rescue ArgumentError, TypeError
-      nil
+    if input.to_s =~ /\A\d{9}\Z/
+      input
+    else
+      begin
+        format("%#9.09d", input)
+      rescue ArgumentError, TypeError
+        nil
+      end
     end
   end
 end

--- a/spec/config/initializers/power_converters_spec.rb
+++ b/spec/config/initializers/power_converters_spec.rb
@@ -75,9 +75,10 @@ RSpec.describe 'power converters' do
     [
       ["1", "000000001"],
       ["1234567890000000", "1234567890000000"],
+      ['004316606', '004316606'],
       [123_456, "000123456"]
     ].each_with_index do |(to_convert, expected), index|
-      it "will convert #{to_convert.inspect} to #{expected} (Scenario ##{index}" do
+      it "will convert #{to_convert.inspect} to #{expected.inspect} (Scenario ##{index}" do
         expect(PowerConverter.convert(to_convert, to: :catalog_system_number)).to eq(expected)
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
@@ -10,7 +10,7 @@ module Sipity
           let(:user) { double('User') }
           let(:keywords) { { work: work, repository: repository, requested_by: user, attributes: {} } }
           let(:oclc_number) { "123456789" }
-          let(:catalog_system_number) { "123456789" }
+          let(:catalog_system_number) { "004316606" }
           subject do
             described_class.new(keywords.merge(attributes: { oclc_number: oclc_number, catalog_system_number: catalog_system_number }))
           end


### PR DESCRIPTION
A weird scenario in which the value "004316606" was converted to
"001154438". Not sure why, but I'm adding a guard condition for that
scenario.