### PR TITLE
Remediating ETD author names

### DIFF
--- a/db/data/20160217141830_add_authorname_to_etd.rb
+++ b/db/data/20160217141830_add_authorname_to_etd.rb
@@ -1,0 +1,15 @@
+class AddAuthornameToEtd < ActiveRecord::Migration
+  def self.up
+    repository = Sipity::CommandRepository.new
+
+    Sipity::Models::Work.where(work_type: ['master_thesis', 'doctoral_dissertation']).find_each do |etd|
+      next if etd.additional_attributes.where(key: 'author_name').any?
+      user_names = repository.scope_users_for_entity_and_roles(entity: etd, roles: 'creating_user').pluck(:name)
+      repository.create_work_attribute_values!(work: etd, key: 'author_name', values: user_names)
+    end
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160210204153) do
+ActiveRecord::Schema.define(version: 20160217141830) do
 
   create_table "data_migrations", id: false, force: :cascade do |t|
     t.string "version", limit: 255, null: false


### PR DESCRIPTION
If there are Masters' Theses or Doctoral Dissertations that do not have an `author_name` field create the field and populate it with the name of the creating user.