### PR TITLE
Fixing etd rights metadata export

### DIFF
--- a/app/mappers/sipity/mappers/etd_mapper.rb
+++ b/app/mappers/sipity/mappers/etd_mapper.rb
@@ -153,7 +153,7 @@ module Sipity
             RELS_EXT_URI.each { |key, uri| json.set!(key, uri) }
           end
           json.set!(EDITOR_PREDICATE_KEY, [Figaro.env.curate_batch_user_pid!])
-          json.set!(EDITOR_GROUP_PREDICATE_KEY, [Figaro.env.curate_batch_group_pid!])
+          json.set!(EDITOR_GROUP_PREDICATE_KEY, [Figaro.env.curate_grad_school_editing_group_pid!])
         end
       end
 

--- a/app/mappers/sipity/mappers/etd_mapper.rb
+++ b/app/mappers/sipity/mappers/etd_mapper.rb
@@ -27,6 +27,7 @@ module Sipity
       READ_KEY = 'read'.freeze
       EDIT_KEY = 'edit'.freeze
       READ_GROUP_KEY = 'read-groups'.freeze
+      EDIT_GROUP_KEY = 'edit-groups'.freeze
       EMBARGO_KEY = 'embargo-date'.freeze
 
       # RELS-EXT KEYS
@@ -158,7 +159,9 @@ module Sipity
 
       def decode_access_right
         # determine and add Public, Private, Embargo and ND only rights
-        decoded_access_rights = { READ_KEY => creator_usernames, EDIT_KEY => [BATCH_USER] }
+        decoded_access_rights = {
+          READ_KEY => creator_usernames, EDIT_KEY => [BATCH_USER], EDIT_GROUP_KEY => [Figaro.env.curate_grad_school_editing_group_pid!]
+        }
         case access_right
         when Models::AccessRight::OPEN_ACCESS
           decoded_access_rights[READ_GROUP_KEY] = [PUBLIC_ACCESS]

--- a/app/mappers/sipity/mappers/generic_file_mapper.rb
+++ b/app/mappers/sipity/mappers/generic_file_mapper.rb
@@ -25,6 +25,7 @@ module Sipity
       READ_KEY = 'read'.freeze
       EDIT_KEY = 'edit'.freeze
       READ_GROUP_KEY = 'read-groups'.freeze
+      EDIT_GROUP_KEY = 'edit-groups'.freeze
       EMBARGO_KEY = 'embargo-date'.freeze
       # RELS-EXT KEYS
       RELS_EXT_KEY = 'rels-ext'.freeze
@@ -180,7 +181,9 @@ module Sipity
 
       def decode_access_rights
         # determine and add Public, Private, Embargo and ND only rights
-        decoded_access_rights = { READ_KEY => creators, EDIT_KEY => [BATCH_USER] }
+        decoded_access_rights = {
+          READ_KEY => creators, EDIT_KEY => [BATCH_USER], EDIT_GROUP_KEY => [Figaro.env.curate_grad_school_editing_group_pid!]
+        }
         case access_right_code
         when Models::AccessRight::OPEN_ACCESS
           decoded_access_rights[READ_GROUP_KEY] = [PUBLIC_ACCESS]

--- a/app/mappers/sipity/mappers/generic_file_mapper.rb
+++ b/app/mappers/sipity/mappers/generic_file_mapper.rb
@@ -131,7 +131,7 @@ module Sipity
             RELS_EXT_URI.each { |key, uri| json.set!(key, uri) }
           end
           json.set!(EDITOR_PREDICATE_KEY, [Figaro.env.curate_batch_user_pid!])
-          json.set!(EDITOR_GROUP_PREDICATE_KEY, [Figaro.env.curate_batch_group_pid!])
+          json.set!(EDITOR_GROUP_PREDICATE_KEY, [Figaro.env.curate_grad_school_editing_group_pid!])
           json.set!(PARENT_PREDICATE_KEY, [namespaced_pid(work.id)])
         end
       end

--- a/config/application.yml
+++ b/config/application.yml
@@ -38,7 +38,7 @@ development:
   cas_destination_url: "http://localhost:3000"
   cas_follow_url: "http://localhost:3000"
   curate_batch_user_pid: "batch_user_pid"
-  curate_batch_group_pid: "batch_group_pid"
+  curate_grad_school_editing_group_pid: "batch_group_pid"
   curate_batch_data_mount_path: "local/data"
   curate_batch_queue_mount_path: "local/queue"
 
@@ -47,6 +47,6 @@ test:
   url_host: "http://localhost:3000"
   secret_key_base: 'bd6953190e19dabc215af75a5c856f584dca49a3ab729696946a80ec50f46094d4643d908b88b07011f898f5c6748f2ffa832c96bae409e5462f2cf3055f1ee7'
   curate_batch_user_pid: "batch_user_pid"
-  curate_batch_group_pid: "batch_group_pid"
+  curate_grad_school_editing_group_pid: "batch_group_pid"
   curate_batch_data_mount_path: "tmp/data"
   curate_batch_queue_mount_path: "tmp/queue"

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -4,7 +4,7 @@ Figaro.require_keys(
   'cas_base_url',
   'cas_validate_url',
   'curate_batch_data_mount_path',
-  'curate_batch_group_pid',
+  'curate_grad_school_editing_group_pid',
   'curate_batch_user_pid',
   'curate_nd_url_for_etds',
   'curate_nd_url_show_prefix_url',

--- a/spec/mappers/sipity/mappers/etd_mapper_spec.rb
+++ b/spec/mappers/sipity/mappers/etd_mapper_spec.rb
@@ -13,6 +13,7 @@ module Sipity
       let(:degree_map) { { "ms:name" => ["a degree_name"], "ms:discipline" => ["a program_name"], "ms:level" => 'TRANSLATED!' } }
       let(:title) { 'Title of the work' }
       let(:batch_user) { 'curate_batch_user' }
+      let(:etd_reviewer_group) { Figaro.env.curate_grad_school_editing_group_pid! }
 
       subject { described_class.new(work, repository: repository) }
 
@@ -48,7 +49,7 @@ module Sipity
         expected_json = JSON.parse(subject.call)
         expect(expected_json["pid"]).to eq("und:a_id")
         expect(expected_json["pid"]).to eq("und:a_id")
-        expect(expected_json["rights"]).to eq("read" => ['Hello'], "edit" => [batch_user])
+        expect(expected_json["rights"]).to eq("read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group])
         expect(expected_json["metadata"]["dc:title"]).to eq(title)
         expect(expected_json["metadata"]["dc:language"]).to eq(['eng'])
         expect(expected_json["metadata"]["dc:contributor"]).to eq([contributor_map])
@@ -66,7 +67,9 @@ module Sipity
           expect(work).to receive(:title).and_return(title)
           expect(work).to receive(:collaborators).and_return(collaborators)
           expected_json = JSON.parse(subject.call)
-          expect(expected_json["rights"]).to eq("read-groups" => ["public"], "read" => ['Hello'], "edit" => [batch_user])
+          expect(expected_json["rights"]).to eq(
+            "read-groups" => ["public"], "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group]
+          )
         end
 
         it 'have restricted access rights' do
@@ -78,7 +81,9 @@ module Sipity
           expect(work).to receive(:title).and_return(title)
           expect(work).to receive(:collaborators).and_return(collaborators)
           expected_json = JSON.parse(subject.call)
-          expect(expected_json["rights"]).to eq("read-groups" => ["restricted"], "read" => ['Hello'], "edit" => [batch_user])
+          expect(expected_json["rights"]).to eq(
+            "read-groups" => ["restricted"], "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group]
+          )
         end
 
         context 'will add embargo date to rights metadata' do
@@ -96,7 +101,7 @@ module Sipity
             expect(work).to receive(:collaborators).and_return(collaborators)
             expected_json = JSON.parse(subject.call)
             expect(expected_json["rights"]).to eq("embargo-date" => embargo_date, "read-groups" => ["public"],
-                                                  "read" => ['Hello'], "edit" => [batch_user])
+                                                  "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group])
           end
 
           it 'have public access rights with embargo date' do
@@ -110,7 +115,7 @@ module Sipity
             expect(work).to receive(:collaborators).and_return(collaborators)
             expected_json = JSON.parse(subject.call)
             expect(expected_json["rights"]).to eq("embargo-date" => embargo_date, "read-groups" => ["public"],
-                                                  "read" => ['Hello'], "edit" => [batch_user])
+                                                  "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group])
           end
         end
       end

--- a/spec/mappers/sipity/mappers/generic_file_mapper_spec.rb
+++ b/spec/mappers/sipity/mappers/generic_file_mapper_spec.rb
@@ -19,6 +19,7 @@ module Sipity
       let(:repository) { QueryRepositoryInterface.new }
       let(:creators) { [double(username: 'Hello')] }
       let(:batch_user) { 'curate_batch_user' }
+      let(:etd_reviewer_group) { Figaro.env.curate_grad_school_editing_group_pid! }
       let(:sample_file) { File.new(__FILE__) }
       let(:fedora_date) { Time.zone.today.strftime('%FZ') }
 
@@ -45,7 +46,7 @@ module Sipity
         expect(work).to receive(:id).and_return('a_work_id')
         expected_json = JSON.parse(subject.call)
         expect(expected_json["pid"]).to eq("und:a_pid")
-        expect(expected_json["rights"]).to eq("read" => ['Hello'], "edit" => [batch_user])
+        expect(expected_json["rights"]).to eq("read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group])
         expect(expected_json["metadata"]["dc:title"]).to eq(file.file_name)
         expect(expected_json["metadata"]["dc:dateSubmitted"]).to eq(fedora_date)
         expect(expected_json["metadata"]["dc:modified"]).to eq(fedora_date)
@@ -94,7 +95,9 @@ module Sipity
           expect(repository).to receive(:attachment_access_right).with(attachment: file).and_return(access_right)
           expect(work).to receive(:id).and_return('a_work_id')
           expected_json = JSON.parse(subject.call)
-          expect(expected_json["rights"]).to eq("read-groups" => ["public"], "read" => ['Hello'], "edit" => [batch_user])
+          expect(expected_json["rights"]).to eq(
+            "read-groups" => ["public"], "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group]
+          )
         end
 
         it 'have work access_right when file have no access rights ' do
@@ -104,7 +107,9 @@ module Sipity
           expect(repository).to receive(:attachment_access_right).with(attachment: file).and_return(access_right)
           expect(work).to receive(:id).and_return('a_work_id')
           expected_json = JSON.parse(subject.call)
-          expect(expected_json["rights"]).to eq("read-groups" => ["public"], "read" => ['Hello'], "edit" => [batch_user])
+          expect(expected_json["rights"]).to eq(
+            "read-groups" => ["public"], "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group]
+          )
         end
 
         it 'will use attachment access_right when available' do
@@ -114,7 +119,9 @@ module Sipity
           expect(repository).to receive(:attachment_access_right).with(attachment: file).and_return(access_right)
           expect(work).to receive(:id).and_return('a_work_id')
           expected_json = JSON.parse(subject.call)
-          expect(expected_json["rights"]).to eq("read-groups" => ["restricted"], "read" => ['Hello'], "edit" => [batch_user])
+          expect(expected_json["rights"]).to eq(
+            "read-groups" => ["restricted"], "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group]
+          )
         end
 
         context 'will add embargo date to rights metadata' do
@@ -131,7 +138,7 @@ module Sipity
             allow(repository).to receive(:attachment_access_right).with(attachment: file).and_return(access_right)
             expected_json = JSON.parse(subject.call)
             expect(expected_json["rights"]).to eq("embargo-date" => embargo_date, "read-groups" => ["public"],
-                                                  "read" => ['Hello'], "edit" => [batch_user])
+                                                  "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group])
           end
           it 'have public access rights with embargo date' do
             allow(repository).to receive(:attachment_access_right).with(attachment: file).and_return(access_right)
@@ -141,7 +148,7 @@ module Sipity
             expect(work).to receive(:id).and_return('a_id')
             expected_json = JSON.parse(subject.call)
             expect(expected_json["rights"]).to eq("embargo-date" => [embargo_date], "read-groups" => ["public"],
-                                                  "read" => ['Hello'], "edit" => [batch_user])
+                                                  "read" => ['Hello'], "edit" => [batch_user], "edit-groups" => [etd_reviewer_group])
           end
         end
       end


### PR DESCRIPTION
## Adding group editing rights metadata to ETD Work

@0acb10f162f82c94251540a1706a0f116951c5b8

It appears that CurateND has two entries related to group editors. One
in the RELS-EXT datastream and the other in the rightsMetadata
datastream. The one that appears to affect some of the CurateND
permissions is the rightsMetadata stream.

Ingested via the data migration process. The grad school can edit this
work (please note the PIDs redacted):
```xml
<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1" version="0.1">
  <copyright>
    <human type="title"/>
    <human type="description"/>
    <machine type="uri"/>
  </copyright>
  <access type="discover">
    <human/>
    <machine/>
  </access>
  <access type="read">
    <human/>
    <machine>

    <group>public</group></machine>
  </access>
  <access type="edit">
    <human/>
    <machine>
      <person>curate_batch_user</person>
      <group>und:YYY</group>
    </machine>
  </access>
  <embargo>
    <human/>
    <machine/>
  </embargo>
</rightsMetadata>
```

**AND**

```xml
<?xml version='1.0' encoding='utf-8' ?>
<rdf:RDF xmlns:ns0='http://projecthydra.org/ns/relations#' xmlns:ns1='info:fedora/fedora-system:def/model#' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
  <rdf:Description rdf:about='info:fedora/und:AAA'>
    <ns0:hasEditor rdf:resource='info:fedora/und:XXX' />
    <ns0:hasEditorGroup rdf:resource='info:fedora/und:YYY' />
    <ns1:hasModel rdf:resource='info:fedora/afmodel:Etd' />
  </rdf:Description>
</rdf:RDF>
```

Ingested via the Sipity ingest:

```xml
<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1" version="0.1">
  <copyright>
    <human type="title"/>
    <human type="description"/>
    <machine type="uri"/>
  </copyright>
  <access type="discover">
    <human/>
    <machine/>
  </access>
  <access type="read">
    <human/>
    <machine>
      <person>a_netid</person>
    </machine>
  </access>
  <access type="edit">
    <human/>
    <machine>
      <person>curate_batch_user</person>
    </machine>
  </access>
  <embargo>
    <human/>
    <machine/>
  </embargo>
</rightsMetadata>
```

```xml
<rdf:RDF xmlns:ns0='http://projecthydra.org/ns/relations#' xmlns:ns1='info:fedora/fedora-system:def/model#' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
  <rdf:Description rdf:about='info:fedora/und:BBB'>
    <ns0:hasEditor rdf:resource='info:fedora/und:XXX' />
    <ns0:hasEditorGroup rdf:resource='info:fedora/und:GGG' />
    <ns1:hasModel rdf:resource='info:fedora/afmodel:Etd' />
  </rdf:Description>
</rdf:RDF>
```

## Renaming variable name for clarity

@1aeaa7c65fb60324cd29fb4b99e8339da98ecd47

The previous name 'curate_batch_group_pid' implied a greater scope than
the 'curate_grad_school_editing_group_pid'.

## Adding group editing rights metadata to ETD File

@6fe9877a113dd30a56ffda0316a39b47cccbd589

See @0acb10f162f82c94251540a1706a0f116951c5b8

It appears that CurateND has two entries related to group editors. One
in the RELS-EXT datastream and the other in the rightsMetadata
datastream. The one that appears to affect some of the CurateND
permissions is the rightsMetadata stream.

Ingested via the data migration process. The grad school can edit this
work (please note the PIDs redacted):
```xml
<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1" version="0.1">
  <copyright>
    <human type="title"/>
    <human type="description"/>
    <machine type="uri"/>
  </copyright>
  <access type="discover">
    <human/>
    <machine/>
  </access>
  <access type="read">
    <human/>
    <machine>

    <group>public</group></machine>
  </access>
  <access type="edit">
    <human/>
    <machine>
      <person>curate_batch_user</person>
      <group>und:YYY</group>
    </machine>
  </access>
  <embargo>
    <human/>
    <machine/>
  </embargo>
</rightsMetadata>
```

**AND**

```xml
<?xml version='1.0' encoding='utf-8' ?>
<rdf:RDF xmlns:ns0='http://projecthydra.org/ns/relations#' xmlns:ns1='info:fedora/fedora-system:def/model#' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
  <rdf:Description rdf:about='info:fedora/und:AAA'>
    <ns0:hasEditor rdf:resource='info:fedora/und:XXX' />
    <ns0:hasEditorGroup rdf:resource='info:fedora/und:YYY' />
    <ns1:hasModel rdf:resource='info:fedora/afmodel:Etd' />
  </rdf:Description>
</rdf:RDF>
```

Ingested via the Sipity ingest:

```xml
<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1" version="0.1">
  <copyright>
    <human type="title"/>
    <human type="description"/>
    <machine type="uri"/>
  </copyright>
  <access type="discover">
    <human/>
    <machine/>
  </access>
  <access type="read">
    <human/>
    <machine>
      <person>a_netid</person>
    </machine>
  </access>
  <access type="edit">
    <human/>
    <machine>
      <person>curate_batch_user</person>
    </machine>
  </access>
  <embargo>
    <human/>
    <machine/>
  </embargo>
</rightsMetadata>
```

```xml
<rdf:RDF xmlns:ns0='http://projecthydra.org/ns/relations#' xmlns:ns1='info:fedora/fedora-system:def/model#' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
  <rdf:Description rdf:about='info:fedora/und:BBB'>
    <ns0:hasEditor rdf:resource='info:fedora/und:XXX' />
    <ns0:hasEditorGroup rdf:resource='info:fedora/und:GGG' />
    <ns1:hasModel rdf:resource='info:fedora/afmodel:Etd' />
  </rdf:Description>
</rdf:RDF>
```
