### PR TITLE
Updating dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,8 @@ group :development, :test do
   gem 'pry-rescue', require: false
   gem 'pry-stack_explorer', require: false
   gem 'rspec-its'
-  gem 'rspec-rails'
+  gem 'rspec', '~>3.4.0'
+  gem 'rspec-rails', '~>3.4.0'
   gem 'commitment'
   gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
     erubis (2.7.0)
     excon (0.45.4)
     execjs (2.6.0)
-    faker (1.6.2)
+    faker (1.6.3)
       i18n (~> 0.5)
     fastercsv (1.5.5)
     ffi (1.9.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,7 +544,7 @@ GEM
     slop (3.6.0)
     sorcerer (1.0.2)
     sparkr (0.4.1)
-    spring (1.6.3)
+    spring (1.6.4)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (3.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/duke-libraries/ezid-client.git
-  revision: 669fe7f1c568d11f88519ad4579cd89fc4f92d8f
+  revision: 951c32bda20e978e13d478f4eb835676376c7fc9
   specs:
-    ezid-client (1.2.0)
+    ezid-client (1.3.0)
       hashie
 
 GIT
@@ -52,7 +52,7 @@ GIT
 
 GIT
   remote: git://github.com/ndlib/locabulary.git
-  revision: 69ec6264ca8246d2f9809afc0fe83155116a1fa1
+  revision: 20663d5468ce2f4ad1d3297595473c94f55f51b4
   branch: master
   specs:
     locabulary (0.2.0)
@@ -132,14 +132,12 @@ GEM
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    brakeman (3.1.5)
+    brakeman (3.2.1)
       erubis (~> 2.6)
-      fastercsv (~> 1.5)
       haml (>= 3.0, < 5.0)
       highline (>= 1.6.20, < 2.0)
-      multi_json (~> 1.2)
-      ruby2ruby (>= 2.1.1, < 2.3.0)
-      ruby_parser (~> 3.7.0)
+      ruby2ruby (~> 2.3.0)
+      ruby_parser (~> 3.8.1)
       safe_yaml (>= 1.0)
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
@@ -211,7 +209,7 @@ GEM
       rubycas-client (>= 2.2.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160128)
+    domain_name (0.5.20160216)
       unf (>= 0.0.5, < 1.0.0)
     dragonfly-s3_data_store (1.2)
       dragonfly (~> 1.0)
@@ -245,11 +243,10 @@ GEM
       dry-equalizer (~> 0.2)
       dry-logic (~> 0.1, >= 0.1.2)
     erubis (2.7.0)
-    excon (0.45.4)
+    excon (0.46.0)
     execjs (2.6.0)
     faker (1.6.3)
       i18n (~> 0.5)
-    fastercsv (1.5.5)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -265,7 +262,7 @@ GEM
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (1.35.0)
+    fog-core (1.36.0)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
@@ -363,7 +360,7 @@ GEM
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
-    mysql2 (0.4.2)
+    mysql2 (0.4.3)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -474,7 +471,7 @@ GEM
     rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
-    rspec-rails (3.4.2)
+    rspec-rails (3.4.1)
       actionpack (>= 3.0, < 4.3)
       activesupport (>= 3.0, < 4.3)
       railties (>= 3.0, < 4.3)
@@ -490,10 +487,10 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 0.3)
     ruby-progressbar (1.7.5)
-    ruby2ruby (2.2.0)
+    ruby2ruby (2.3.0)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.0)
-    ruby_parser (3.7.3)
+    ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
     rubycas-client (2.3.9)
       activesupport
@@ -550,7 +547,7 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.1)
+    sprockets-rails (3.0.3)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -667,10 +667,11 @@ DEPENDENCIES
   rb-readline
   rdiscount
   responders (~> 2.0)
+  rspec (~> 3.4.0)
   rspec-given
   rspec-html-matchers (~> 0.6)
   rspec-its
-  rspec-rails
+  rspec-rails (~> 3.4.0)
   rubocop
   sanitize
   sass-rails


### PR DESCRIPTION
## Updating spring dependency

@3a8187cd5ba219e154813e7671c8c276ecde6aee

`$ ./script/update-dependency spring`

## Updating faker dependency

@e99e705cfb27219b33a6dbb8a6deebeb89a4ee87

`$ ./script/update-dependency faker`

## Updating rspec-* dependency

@595e351363a581b91ec01142f5f2f1ce9b524ceb

There is a pending release of RSpec (3.5.0.beta1) that was getting
updated. I don't want to use that, so I'm freezing to 3.4.x versions.
Once the beta1 is released, I'll proceed.

## Updating secondary gem dependencies

@7a6a3733ad025b6769a305fe75336b03e642bf44

`$ bundle update`
