### PR TITLE
Adding minor revisions to BatchIngestExporter

### DIFF
--- a/app/exporters/sipity/exporters/batch_ingest_exporter.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter.rb
@@ -11,10 +11,14 @@ module Sipity
       end
 
       def initialize(work:)
-        @work = work
+        self.work = work
       end
 
+      private
+
       attr_accessor :work
+
+      public
 
       def call
         AttachmentWriter.call(exporter: self)
@@ -25,9 +29,10 @@ module Sipity
       end
 
       def data_directory
-        @data_directory ||= File.join(DATA_PATH, "/sipity-#{work.id}")
+        @data_directory ||= File.join(DATA_PATH, "/sipity-#{work_id}")
       end
 
+      # REVIEW: Should this be called as the first part of the attachment writer?
       def make_data_directory
         FileUtils.mkdir_p(data_directory)
       end


### PR DESCRIPTION
* Favor using the attr_writer method instead of using an instance
  variable. By leveraging a setter method, we can add an interface
  check when we attempt to set the work. We also don't rely on internal
  state of the object but instead prefer to consume the internal API of
  that object.
* Privatize access to the `work` object. It does not appear that `work`
  is referred to elsewhere. Keeping the exposed methods to a minimum
  allows for greater flexibility later on. (i.e. you are not committing
  to any more of the public interface than required)
* Replace `work.id` with `#work_id`. This is a move for greater
  consistency in method usage.

Question does the privatization mean we should be passing the
exporter's work as a parameter? Or should we leave it exposed?