### PR TITLE
#971 DirectoryMover module

### DIFF
--- a/app/exporters/sipity/exporters/batch_ingest_exporter.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter.rb
@@ -101,7 +101,7 @@ module Sipity
         end
 
         def move_files(source:, destination:)
-          FileUtils.mv(source, File.join(destination, '/'), verbose: true)
+          FileUtils.mv(source, File.join(destination, '/'))
         end
       end
     end

--- a/app/exporters/sipity/exporters/batch_ingest_exporter.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter.rb
@@ -86,7 +86,23 @@ module Sipity
         end
       end
 
-      class DirectoryMover
+      module DirectoryMover
+        DEFAULT_DESTINATION = Figaro.env.curate_batch_queue_mount_path!
+
+        module_function
+
+        def call(exporter:, destination_path: DEFAULT_DESTINATION)
+          prepare_destination(path: destination_path)
+          move_files(source: exporter.data_directory, destination: destination_path)
+        end
+
+        def prepare_destination(path:)
+          FileUtils.mkdir_p(path)
+        end
+
+        def move_files(source:, destination:)
+          FileUtils.mv(source, File.join(destination, '/'), verbose: true)
+        end
       end
     end
   end

--- a/app/exporters/sipity/exporters/batch_ingest_exporter.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter.rb
@@ -86,6 +86,9 @@ module Sipity
         end
       end
 
+      # The batch ingest process is triggered by file operations. When the data
+      # preparation is complete its containing directory is moved to the "queue"
+      # directory. This module manages moving the data.
       module DirectoryMover
         DEFAULT_DESTINATION = Figaro.env.curate_batch_queue_mount_path!
 

--- a/spec/exporters/sipity/exporters/batch_ingest_exporter/directory_mover_spec.rb
+++ b/spec/exporters/sipity/exporters/batch_ingest_exporter/directory_mover_spec.rb
@@ -5,7 +5,27 @@ module Sipity
   module Exporters
     class BatchIngestExporter
       RSpec.describe DirectoryMover do
-        xit('will respond to #call')
+
+        let(:exporter) { double('BatchIngestExporter', data_directory: '/tmp/sipity-1492') }
+        FileUtils = FileUtils::DryRun
+
+        describe '#call' do
+          it 'prepares the destination path' do
+            expect(described_class).to receive(:prepare_destination)
+            described_class.call(exporter: exporter)
+          end
+
+          it 'moves the data to the destination path' do
+            expect(described_class).to receive(:move_files)
+            described_class.call(exporter: exporter)
+          end
+        end
+
+        describe '#prepare_destination' do
+        end
+
+        describe '#move_files' do
+        end
       end
     end
   end

--- a/spec/exporters/sipity/exporters/batch_ingest_exporter/directory_mover_spec.rb
+++ b/spec/exporters/sipity/exporters/batch_ingest_exporter/directory_mover_spec.rb
@@ -7,7 +7,10 @@ module Sipity
       RSpec.describe DirectoryMover do
 
         let(:exporter) { double('BatchIngestExporter', data_directory: '/tmp/sipity-1492') }
-        FileUtils = FileUtils::DryRun
+        let(:source) { exporter.data_directory }
+        let(:destination) { 'tmp/queue' }
+
+        FileUtils = FileUtils::NoWrite
 
         describe '#call' do
           it 'prepares the destination path' do
@@ -22,9 +25,17 @@ module Sipity
         end
 
         describe '#prepare_destination' do
+          subject { described_class.prepare_destination(path: destination) }
+          # FileUtils.mkdir_p returns an array of the directories that were created
+          it { is_expected.to eq(Array.wrap(destination)) }
         end
 
         describe '#move_files' do
+          # FileUtils::NoWrite.mv always returns nil; it is difficult to verify correctness
+          it 'calls the .mv method' do
+            expect(FileUtils).to receive(:mv)
+            described_class.move_files(source: source, destination: destination)
+          end
         end
       end
     end


### PR DESCRIPTION
Implementing a small module that governs the last step of the batch ingest preparation. It wraps methods from FileUtils with additional context.