### PR TITLE
Replacing should with is expected

### DIFF
--- a/spec/config/initializers/dragonfly_spec.rb
+++ b/spec/config/initializers/dragonfly_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe 'config/initializers/dragonfly.rb' do
   context 'configuration' do
     context 'for Dragonfly.app.server' do
       subject { Dragonfly.app.server }
-      its(:url_host) { should be_present }
-      its(:url_format) { should eq "/attachments/:job/:name" }
+      its(:url_host) { is_expected.to be_present }
+      its(:url_format) { is_expected.to eq "/attachments/:job/:name" }
     end
     context 'for Dragonfly.app' do
       subject { Dragonfly.app }
-      its(:secret) { should be_present }
-      its(:response_headers) { should eq("Cache-Control" => "private, max-age=10800") }
+      its(:secret) { is_expected.to be_present }
+      its(:response_headers) { is_expected.to eq("Cache-Control" => "private, max-age=10800") }
     end
   end
 end

--- a/spec/controllers/sipity/controllers/processing_action_composer_spec.rb
+++ b/spec/controllers/sipity/controllers/processing_action_composer_spec.rb
@@ -30,7 +30,7 @@ module Sipity
           its(:response_handler) { should respond_to(:call) }
         end
 
-        it { should_not respond_to(:prepend_processing_action_view_path_with) }
+        it { is_expected.not_to respond_to(:prepend_processing_action_view_path_with) }
 
         it 'will expose #run_and_respond_with_processing_action' do
           expect(runner).to receive(:call).with(work_id: 1, processing_action_name: processing_action_name).

--- a/spec/controllers/sipity/controllers/processing_action_composer_spec.rb
+++ b/spec/controllers/sipity/controllers/processing_action_composer_spec.rb
@@ -27,7 +27,7 @@ module Sipity
               processing_action_name: processing_action_name
             )
           end
-          its(:response_handler) { should respond_to(:call) }
+          its(:response_handler) { is_expected.to respond_to(:call) }
         end
 
         it { is_expected.not_to respond_to(:prepend_processing_action_view_path_with) }
@@ -59,12 +59,12 @@ module Sipity
 
         subject { described_class.build_for_controller(controller: controller, response_handler: response_handler) }
 
-        its(:processing_action_name) { should eq(processing_action_name) }
-        it { should respond_to(:processing_action_name) }
+        its(:processing_action_name) { is_expected.to eq(processing_action_name) }
+        it { is_expected.to respond_to(:processing_action_name) }
 
         context 'with default build options' do
           subject { described_class.build_for_controller(controller: controller, processing_action_name: 'york') }
-          its(:response_handler) { should respond_to(:call) }
+          its(:response_handler) { is_expected.to respond_to(:call) }
         end
 
         it 'will allow a specific processing action name to be provided' do

--- a/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/submission_windows_controller_spec.rb
@@ -7,8 +7,8 @@ module Sipity
       let(:submission_window) { Models::SubmissionWindow.new(slug: 'start', work_area: work_area) }
       let(:work_area) { Models::WorkArea.new(slug: 'etd') }
       context 'configuration' do
-        its(:runner_container) { should eq(Runners::SubmissionWindowRunners) }
-        its(:response_handler_container) { should eq(ResponseHandlers::SubmissionWindowHandler) }
+        its(:runner_container) { is_expected.to eq(Runners::SubmissionWindowRunners) }
+        its(:response_handler_container) { is_expected.to eq(ResponseHandlers::SubmissionWindowHandler) }
       end
 
       context 'GET #query_action' do

--- a/spec/controllers/sipity/controllers/visitors_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/visitors_controller_spec.rb
@@ -10,8 +10,8 @@ module Sipity
       let(:runner) { double('Runner', run: [status, work_area]) }
 
       context 'configuration' do
-        its(:runner_container) { should eq(Sipity::Runners::VisitorsRunner) }
-        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkAreaHandler) }
+        its(:runner_container) { is_expected.to eq(Sipity::Runners::VisitorsRunner) }
+        its(:response_handler_container) { is_expected.to eq(Sipity::ResponseHandlers::WorkAreaHandler) }
       end
 
       context 'GET #work_area' do

--- a/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_areas_controller_spec.rb
@@ -9,8 +9,8 @@ module Sipity
       # REVIEW: It is possible the runner will return a well formed object
       let(:runner) { double('Runner', run: [status, work_area]) }
       context 'configuration' do
-        its(:runner_container) { should eq(Sipity::Runners::WorkAreaRunners) }
-        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkAreaHandler) }
+        its(:runner_container) { is_expected.to eq(Sipity::Runners::WorkAreaRunners) }
+        its(:response_handler_container) { is_expected.to eq(Sipity::ResponseHandlers::WorkAreaHandler) }
       end
 
       context '#query_or_command_attributes' do

--- a/spec/controllers/sipity/controllers/work_submission_callbacks_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submission_callbacks_controller_spec.rb
@@ -10,12 +10,12 @@ module Sipity
       before { allow(work).to receive(:work_area).and_return(work_area) }
 
       context 'configuration' do
-        its(:runner_container) { should eq(Sipity::Runners::WorkSubmissionsRunners) }
-        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkSubmissionHandler) }
+        its(:runner_container) { is_expected.to eq(Sipity::Runners::WorkSubmissionsRunners) }
+        its(:response_handler_container) { is_expected.to eq(Sipity::ResponseHandlers::WorkSubmissionHandler) }
       end
 
-      it { should respond_to :prepend_processing_action_view_path_with }
-      it { should respond_to :run_and_respond_with_processing_action }
+      it { is_expected.to respond_to :prepend_processing_action_view_path_with }
+      it { is_expected.to respond_to :run_and_respond_with_processing_action }
 
       context '#command_attributes' do
 

--- a/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/work_submissions_controller_spec.rb
@@ -10,12 +10,12 @@ module Sipity
       before { allow(work).to receive(:work_area).and_return(work_area) }
 
       context 'configuration' do
-        its(:runner_container) { should eq(Sipity::Runners::WorkSubmissionsRunners) }
-        its(:response_handler_container) { should eq(Sipity::ResponseHandlers::WorkSubmissionHandler) }
+        its(:runner_container) { is_expected.to eq(Sipity::Runners::WorkSubmissionsRunners) }
+        its(:response_handler_container) { is_expected.to eq(Sipity::ResponseHandlers::WorkSubmissionHandler) }
       end
 
-      it { should respond_to :prepend_processing_action_view_path_with }
-      it { should respond_to :run_and_respond_with_processing_action }
+      it { is_expected.to respond_to :prepend_processing_action_view_path_with }
+      it { is_expected.to respond_to :run_and_respond_with_processing_action }
 
       context 'GET #query_action' do
         let(:processing_action_name) { 'fun_things' }

--- a/spec/data_generators/sipity/data_generators/submission_window_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/submission_window_generator_spec.rb
@@ -7,8 +7,8 @@ module Sipity
     let(:path) { Rails.root.join('app/data_generators/sipity/data_generators/submission_windows/etd_submission_windows.config.json') }
     subject { described_class.new(work_area: work_area, data: {}, validator: validator) }
 
-    its(:default_validator) { should respond_to(:call) }
-    its(:default_schema) { should respond_to(:call) }
+    its(:default_validator) { is_expected.to respond_to(:call) }
+    its(:default_schema) { is_expected.to respond_to(:call) }
 
     it 'exposes .call as a convenience method' do
       expect_any_instance_of(described_class).to receive(:call)

--- a/spec/data_generators/sipity/data_generators/work_area_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_area_generator_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     let(:path) { Rails.root.join('app/data_generators/sipity/data_generators/work_areas/etd_work_area.config.json') }
     subject { described_class.new(data: {}, validator: validator) }
 
-    its(:default_validator) { should respond_to(:call) }
-    its(:default_schema) { should respond_to(:call) }
+    its(:default_validator) { is_expected.to respond_to(:call) }
+    its(:default_schema) { is_expected.to respond_to(:call) }
 
     it 'exposes .call as a convenience method' do
       expect_any_instance_of(described_class).to receive(:call)

--- a/spec/data_generators/sipity/data_generators/work_type_generator_spec.rb
+++ b/spec/data_generators/sipity/data_generators/work_type_generator_spec.rb
@@ -49,8 +49,8 @@ module Sipity
 
     subject { described_class.new(submission_window: submission_window, data: {}, validator: validator) }
 
-    its(:default_validator) { should respond_to(:call) }
-    its(:default_schema) { should respond_to(:call) }
+    its(:default_validator) { is_expected.to respond_to(:call) }
+    its(:default_schema) { is_expected.to respond_to(:call) }
 
     it 'exposes .generate_from_json_file as a convenience method' do
       expect_any_instance_of(described_class).to receive(:call)

--- a/spec/decorators/sipity/decorators/base_object_with_composed_attributes_delegator_spec.rb
+++ b/spec/decorators/sipity/decorators/base_object_with_composed_attributes_delegator_spec.rb
@@ -12,9 +12,9 @@ module Sipity
         expect(subject.chicken).to eq(base_object.chicken)
       end
 
-      it { should respond_to :age }
-      it { should respond_to :chicken }
-      it { should respond_to :title }
+      it { is_expected.to respond_to :age }
+      it { is_expected.to respond_to :chicken }
+      it { is_expected.to respond_to :title }
 
       it 'will expose additional collaborators of the object' do
         expect(subject.title).to eq(keywords.fetch(:title))

--- a/spec/decorators/sipity/decorators/comparable_simple_delegator_spec.rb
+++ b/spec/decorators/sipity/decorators/comparable_simple_delegator_spec.rb
@@ -6,13 +6,13 @@ module Sipity
       let(:decorating_class) { Class.new(described_class) { self.base_class = Models::Work } }
       let(:underlying_object) { double }
       subject { decorating_class.new(underlying_object) }
-      its(:model_name) { should eq(decorating_class.base_class.model_name) }
+      its(:model_name) { is_expected.to eq(decorating_class.base_class.model_name) }
 
       context 'class methods' do
         subject { decorating_class }
-        it { should delegate_method(:model_name).to(:base_class) }
-        it { should delegate_method(:name).to(:base_class) }
-        it { should delegate_method(:human_attribute_name).to(:base_class) }
+        it { is_expected.to delegate_method(:model_name).to(:base_class) }
+        it { is_expected.to delegate_method(:name).to(:base_class) }
+        it { is_expected.to delegate_method(:human_attribute_name).to(:base_class) }
       end
 
       context 'instantiating an instance of the class' do

--- a/spec/decorators/sipity/decorators/dashboard_view_spec.rb
+++ b/spec/decorators/sipity/decorators/dashboard_view_spec.rb
@@ -20,8 +20,8 @@ module Sipity
         expect(subject.works).to eq(works)
       end
 
-      its(:default_repository) { should respond_to(:find_works_for) }
-      its(:processing_state) { should eq(filter.fetch(:processing_state)) }
+      its(:default_repository) { is_expected.to respond_to(:find_works_for) }
+      its(:processing_state) { is_expected.to eq(filter.fetch(:processing_state)) }
     end
   end
 end

--- a/spec/decorators/sipity/decorators/emails/processing_comment_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/processing_comment_decorator_spec.rb
@@ -12,14 +12,14 @@ module Sipity
         let(:processing_comment) { Models::Processing::Comment.new(comment: 'hello', actor: actor, entity: entity) }
         subject { described_class.new(processing_comment) }
 
-        its(:comment) { should eq processing_comment.comment }
-        its(:name_of_commentor) { should eq(user.name) }
-        its(:work_type) { should eq('Doctoral dissertation') }
-        its(:title) { should eq(work.title) }
-        its(:email_message_action_description) { should eq("Review comments for “#{work.title}”") }
-        its(:email_message_action_name) { should eq("Review comments") }
-        its(:email_message_action_name) { should eq("Review comments") }
-        its(:email_message_action_url) { should match(%r{/#{work.to_param}\Z}) }
+        its(:comment) { is_expected.to eq processing_comment.comment }
+        its(:name_of_commentor) { is_expected.to eq(user.name) }
+        its(:work_type) { is_expected.to eq('Doctoral dissertation') }
+        its(:title) { is_expected.to eq(work.title) }
+        its(:email_message_action_description) { is_expected.to eq("Review comments for “#{work.title}”") }
+        its(:email_message_action_name) { is_expected.to eq("Review comments") }
+        its(:email_message_action_name) { is_expected.to eq("Review comments") }
+        its(:email_message_action_url) { is_expected.to match(%r{/#{work.to_param}\Z}) }
       end
     end
   end

--- a/spec/decorators/sipity/decorators/emails/registered_action_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/registered_action_decorator_spec.rb
@@ -21,14 +21,14 @@ module Sipity
         let(:repository) { QueryRepositoryInterface.new }
         subject { described_class.new(registered_action, repository: repository) }
 
-        its(:work_type) { should eq('Doctoral dissertation') }
-        its(:title) { should eq(work.title) }
-        its(:email_message_action_description) { should eq("Go to Doctoral dissertation “#{work.title}”") }
-        its(:email_message_action_name) { should eq("Go to Doctoral dissertation") }
-        its(:email_message_action_url) { should match(%r{/#{work.to_param}\Z}) }
-        its(:action_taken_at) { should eq registered_action.created_at }
-        its(:requested_by) { should eq requesting_user }
-        its(:on_behalf_of) { should eq on_behalf_of_user }
+        its(:work_type) { is_expected.to eq('Doctoral dissertation') }
+        its(:title) { is_expected.to eq(work.title) }
+        its(:email_message_action_description) { is_expected.to eq("Go to Doctoral dissertation “#{work.title}”") }
+        its(:email_message_action_name) { is_expected.to eq("Go to Doctoral dissertation") }
+        its(:email_message_action_url) { is_expected.to match(%r{/#{work.to_param}\Z}) }
+        its(:action_taken_at) { is_expected.to eq registered_action.created_at }
+        its(:requested_by) { is_expected.to eq requesting_user }
+        its(:on_behalf_of) { is_expected.to eq on_behalf_of_user }
       end
     end
   end

--- a/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
@@ -48,28 +48,28 @@ module Sipity
           end
         end
 
-        its(:permanent_url) { should be_a(String) }
-        its(:work_type) { should eq('Doctoral dissertation') }
-        its(:title) { should eq(work.title) }
-        its(:email_message_action_description) { should eq("Review Doctoral dissertation “#{work.title}”") }
-        its(:email_message_action_name) { should eq("Review Doctoral dissertation") }
-        its(:email_message_action_url) { should match(%r{/#{work.to_param}\Z}) }
-        its(:collaborators) { should eq(collaborators) }
-        its(:reviewers) { should eq(reviewers) }
-        its(:creator_names) { should eq(['John', 'Ringo']) }
-        its(:accessible_objects) { should eq(accessible_objects) }
-        its(:program_names) { should eq(program_names) }
-        its(:degree) { should eq(degree) }
-        its(:creator_netids) { should eq(creator_netids) }
-        its(:publishing_intent) { should eq(publishing_intent) }
-        its(:patent_intent) { should eq(patent_intent) }
-        its(:submission_date) { should eq(submission_date) }
+        its(:permanent_url) { is_expected.to be_a(String) }
+        its(:work_type) { is_expected.to eq('Doctoral dissertation') }
+        its(:title) { is_expected.to eq(work.title) }
+        its(:email_message_action_description) { is_expected.to eq("Review Doctoral dissertation “#{work.title}”") }
+        its(:email_message_action_name) { is_expected.to eq("Review Doctoral dissertation") }
+        its(:email_message_action_url) { is_expected.to match(%r{/#{work.to_param}\Z}) }
+        its(:collaborators) { is_expected.to eq(collaborators) }
+        its(:reviewers) { is_expected.to eq(reviewers) }
+        its(:creator_names) { is_expected.to eq(['John', 'Ringo']) }
+        its(:accessible_objects) { is_expected.to eq(accessible_objects) }
+        its(:program_names) { is_expected.to eq(program_names) }
+        its(:degree) { is_expected.to eq(degree) }
+        its(:creator_netids) { is_expected.to eq(creator_netids) }
+        its(:publishing_intent) { is_expected.to eq(publishing_intent) }
+        its(:patent_intent) { is_expected.to eq(patent_intent) }
+        its(:submission_date) { is_expected.to eq(submission_date) }
         its(:catalog_system_number) do
           expect(repository).to receive(:work_attribute_values_for).with(
             work: work, key: Sipity::Models::AdditionalAttribute::CATALOG_SYSTEM_NUMBER, cardinality: 1
           ).and_return(1234)
 
-          should eq(1234)
+          is_expected.to eq(1234)
         end
 
         its(:additional_committe_members) do

--- a/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/emails/work_email_decorator_spec.rb
@@ -76,13 +76,13 @@ module Sipity
           allow(subject).to receive(:collaborators).and_return(['John', 'Ringo'])
           allow(subject).to receive(:reviewers).and_return(['Ringo'])
           additional_committe_members = ['John']
-          should eq(additional_committe_members)
+          is_expected.to eq(additional_committe_members)
         end
 
         its(:work_access) do
           allow(Models::AccessRightFacade).to receive(:new).
             with(work, work: work).and_return(work_access)
-          should eq(work_access)
+          is_expected.to eq(work_access)
         end
 
         its(:accessible_files) do
@@ -90,7 +90,7 @@ module Sipity
             with(work: work, predicate_name: :all).and_return(accessible_files)
           allow(Models::AccessRightFacade).to receive(:new).
             and_return(accessible_file)
-          should eq(accessible_files)
+          is_expected.to eq(accessible_files)
         end
 
       end

--- a/spec/decorators/sipity/decorators/processing/processing_comment_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/processing/processing_comment_decorator_spec.rb
@@ -19,10 +19,10 @@ module Sipity
         end
         subject { described_class.new(processing_comment) }
 
-        its(:comment) { should eq processing_comment.comment }
-        its(:created_date) { should match(/2015/) }
-        its(:name_of_commentor) { should eq(user.name) }
-        its(:work_type) { should eq('Doctoral Dissertation') }
+        its(:comment) { is_expected.to eq processing_comment.comment }
+        its(:created_date) { is_expected.to match(/2015/) }
+        its(:name_of_commentor) { is_expected.to eq(user.name) }
+        its(:work_type) { is_expected.to eq('Doctoral Dissertation') }
       end
     end
   end

--- a/spec/decorators/sipity/decorators/work_decorator_spec.rb
+++ b/spec/decorators/sipity/decorators/work_decorator_spec.rb
@@ -11,8 +11,8 @@ module Sipity
         expect(subject.to_s).to eq(work.title)
       end
 
-      its(:date_created) { should be_a(String) }
-      its(:title) { should be_html_safe }
+      its(:date_created) { is_expected.to be_a(String) }
+      its(:title) { is_expected.to be_html_safe }
 
       context '#creators and #creator_names' do
         let(:creators) { [double(name: 'Hello')] }

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -6,52 +6,52 @@ module Sipity
   module Exceptions
     RSpec.describe InvalidSchemaError do
       subject { described_class.new(errors: { key: 'error' }) }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe EmailAsOptionInvalidError do
       subject { described_class.new(as: :chicken, valid_list: [:hello]) }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
     RSpec.describe ResponseHandlerError do
       subject { described_class.new(object: double, errors: [], status: :failure) }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe ExistingMethodsAlreadyDefined do
       subject { described_class.new('hello', [:ab, :cd]) }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe ConversionError do
       subject { described_class.new('hello') }
-      its(:message) { should be_a(String) }
-      its(:conversion_target) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
+      its(:conversion_target) { is_expected.to be_a(String) }
     end
 
     RSpec.describe UnprocessableResourcefulActionNameError do
       subject { described_class.new(container: 'Container', object: 'hello') }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe AuthenticationFailureError do
       subject { described_class.new('hello') }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe UnhandledResponseError do
       subject { described_class.new('hello') }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe InterfaceExpectationError do
       subject { described_class.new(object: 'hello', expectations: :fly) }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe InterfaceCollaboratorExpectationError do
       subject { described_class.new(object: 'hello', collaborator_expectations: { fly: :guy }) }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe AuthorizationFailureError do
@@ -59,15 +59,15 @@ module Sipity
       let(:action) { double }
       let(:entity) { double }
       subject { described_class.new(user: user, action_to_authorize: action, entity: entity) }
-      its(:message) { should be_a(String) }
-      its(:user) { should eq(user) }
-      its(:action_to_authorize) { should eq(action) }
-      its(:entity) { should eq(entity) }
+      its(:message) { is_expected.to be_a(String) }
+      its(:user) { is_expected.to eq(user) }
+      its(:action_to_authorize) { is_expected.to eq(action) }
+      its(:entity) { is_expected.to eq(entity) }
     end
 
     RSpec.describe ConceptNotFoundError do
       subject { described_class.new(container: 'hello', name: 'world') }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
 
     RSpec.describe InvalidStateError do
@@ -76,24 +76,24 @@ module Sipity
       context 'without an expected state' do
         let(:expected) { nil }
         subject { described_class.new(entity: entity, actual: actual, expected: expected) }
-        its(:entity) { should eq(entity) }
-        its(:actual) { should eq(actual) }
-        its(:expected) { should eq(expected) }
-        its(:message) { should be_a(String) }
+        its(:entity) { is_expected.to eq(entity) }
+        its(:actual) { is_expected.to eq(actual) }
+        its(:expected) { is_expected.to eq(expected) }
+        its(:message) { is_expected.to be_a(String) }
       end
 
       context 'with an expected state' do
         let(:expected) { '"expected"' }
         subject { described_class.new(entity: entity, actual: actual, expected: expected) }
-        its(:entity) { should eq(entity) }
-        its(:actual) { should eq(actual) }
-        its(:message) { should be_a(String) }
+        its(:entity) { is_expected.to eq(entity) }
+        its(:actual) { is_expected.to eq(actual) }
+        its(:message) { is_expected.to be_a(String) }
       end
     end
 
     RSpec.describe SenderNotFoundError do
       subject { described_class.new('hello') }
-      its(:message) { should be_a(String) }
+      its(:message) { is_expected.to be_a(String) }
     end
   end
 end

--- a/spec/exporters/sipity/exporters/etd_exporter_spec.rb
+++ b/spec/exporters/sipity/exporters/etd_exporter_spec.rb
@@ -15,13 +15,13 @@ module Sipity
 
       subject { described_class.new(work, repository: repository) }
 
-      its(:default_repository) { should respond_to :work_attachments }
-      its(:webhook_authorization_credentials) { should be_a(String) }
+      its(:default_repository) { is_expected.to respond_to :work_attachments }
+      its(:webhook_authorization_credentials) { is_expected.to be_a(String) }
 
       # The .json is important as it helps this Rails application negotiate the content. Without the .json,
       # the batch ingest process is posting a "Content-Type: application/json" but Rails is falling back to
       # an HTML response; Which doesn't work because the HTML template does not exist.
-      its(:webhook_url) { should match(%r{/work_submissions/#{work.to_param}/callback/ingest_completed.json$}) }
+      its(:webhook_url) { is_expected.to match(%r{/work_submissions/#{work.to_param}/callback/ingest_completed.json$}) }
 
       it 'will instantiate then call the instance' do
         expect(described_class).to receive(:new).and_return(double(call: true))

--- a/spec/forms/sipity/forms/base_form_spec.rb
+++ b/spec/forms/sipity/forms/base_form_spec.rb
@@ -5,10 +5,10 @@ module Sipity
   module Forms
     RSpec.describe BaseForm do
 
-      its(:to_key) { should be_empty }
-      its(:policy_enforcer) { should be_nil }
-      its(:to_param) { should be_nil }
-      its(:persisted?) { should eq(false) }
+      its(:to_key) { is_expected.to be_empty }
+      its(:policy_enforcer) { is_expected.to be_nil }
+      its(:to_param) { is_expected.to be_nil }
+      its(:persisted?) { is_expected.to eq(false) }
 
       context '#submit' do
         context 'with invalid data' do

--- a/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/attachments_extension_spec.rb
@@ -26,16 +26,16 @@ module Sipity
           )
         end
 
-        its(:default_predicate_name) { should eq('attachment') }
+        its(:default_predicate_name) { is_expected.to eq('attachment') }
 
-        it { should respond_to :repository }
-        it { should respond_to :files }
-        it { should respond_to :attach_or_update_files }
-        it { should respond_to :attachments_attributes= }
-        it { should respond_to :attachments }
-        it { should delegate_method(:errors).to(:form) }
+        it { is_expected.to respond_to :repository }
+        it { is_expected.to respond_to :files }
+        it { is_expected.to respond_to :attach_or_update_files }
+        it { is_expected.to respond_to :attachments_attributes= }
+        it { is_expected.to respond_to :attachments }
+        it { is_expected.to delegate_method(:errors).to(:form) }
 
-        its(:default_predicate_name) { should eq('attachment') }
+        its(:default_predicate_name) { is_expected.to eq('attachment') }
 
         context '#attachments_associated_with_the_work?' do
           it 'will be false if no files nor attachments_metadata exists' do

--- a/spec/forms/sipity/forms/composable_elements/on_behalf_of_collaborator_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/on_behalf_of_collaborator_spec.rb
@@ -10,8 +10,8 @@ module Sipity
 
         subject { described_class.new(form: form, repository: repository) }
 
-        it { should respond_to(:on_behalf_of_collaborator_id) }
-        it { should respond_to(:on_behalf_of_collaborator_id=) }
+        it { is_expected.to respond_to(:on_behalf_of_collaborator_id) }
+        it { is_expected.to respond_to(:on_behalf_of_collaborator_id=) }
 
         it 'will forward delegate #on_behalf_of_collaborator to the underlying repository' do
           expect(repository).to receive(:collaborators_that_can_advance_the_current_state_of).and_return([someone, sometwo])

--- a/spec/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension_spec.rb
+++ b/spec/forms/sipity/forms/composable_elements/publishing_and_patenting_intent_extension_spec.rb
@@ -9,8 +9,8 @@ module Sipity
         let(:repository) { CommandRepositoryInterface.new }
         subject { described_class.new(form: form, repository: repository) }
 
-        its(:default_repository) { should respond_to :update_work_attribute_values! }
-        its(:default_repository) { should respond_to :get_controlled_vocabulary_values_for_predicate_name }
+        its(:default_repository) { is_expected.to respond_to :update_work_attribute_values! }
+        its(:default_repository) { is_expected.to respond_to :get_controlled_vocabulary_values_for_predicate_name }
 
         it 'guards that the form has a work' do
           expect { described_class.new(form: double, repository: repository) }.to raise_error(Exceptions::InterfaceExpectationError)
@@ -22,7 +22,7 @@ module Sipity
               with(name: subject.send(:work_publication_strategy_predicate_name)).and_return(['hello', 'world'])
           end
 
-          it { should respond_to :work_publication_strategy }
+          it { is_expected.to respond_to :work_publication_strategy }
 
           it 'will have #work_publication_strategies_for_select that are all symbols' do
             expect(subject.work_publication_strategies_for_select.all? { |strategy| strategy.is_a?(Symbol) }).to be_truthy
@@ -47,7 +47,7 @@ module Sipity
               with(name: subject.send(:work_patent_strategy_predicate_name)).and_return(['hello', 'world'])
           end
 
-          it { should respond_to :work_patent_strategy }
+          it { is_expected.to respond_to :work_patent_strategy }
 
           it 'will have #work_patent_strategies_for_select that are all symbols' do
             expect(subject.work_patent_strategies_for_select.all? { |strategy| strategy.is_a?(Symbol) }).to be_truthy

--- a/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
+++ b/spec/forms/sipity/forms/core/manage_account_profile_form_spec.rb
@@ -11,7 +11,7 @@ module Sipity
         let(:attributes) { { agreed_to_terms_of_service: '1', preferred_name: 'Billy Joe Armstrong' } }
         subject { described_class.new(requested_by: user, repository: repository, attributes: attributes) }
 
-        its(:default_repository) { should respond_to(:user_agreed_to_terms_of_service) }
+        its(:default_repository) { is_expected.to respond_to(:user_agreed_to_terms_of_service) }
 
         context 'validations' do
           context 'with invalid data' do

--- a/spec/forms/sipity/forms/processing_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_form_spec.rb
@@ -55,7 +55,7 @@ module Sipity
         its(:base_class) { should eq(Models::Work) }
         its(:policy_enforcer) { should eq(Policies::WorkPolicy) }
         its(:template) { should eq('hello_world') }
-        it { should_not be_persisted }
+        it { is_expected.not_to be_persisted }
         it { should delegate_method(:param_key).to(:model_name) }
         it { should delegate_method(:to_processing_entity).to(:processing_action_form) }
         it { should delegate_method(:to_processing_action).to(:processing_action_form) }

--- a/spec/forms/sipity/forms/processing_form_spec.rb
+++ b/spec/forms/sipity/forms/processing_form_spec.rb
@@ -45,31 +45,31 @@ module Sipity
           end
         end
         before { described_class.configure(form_class: form_class, base_class: Models::Work, attribute_names: [:title, :job]) }
-        it { should respond_to :work }
-        it { should respond_to :entity }
-        it { should respond_to :title }
-        it { should respond_to :job }
-        it { should respond_to :requested_by }
-        its(:processing_subject_name) { should eq('work') }
-        its(:attribute_names) { should eq([:title, :job]) }
-        its(:base_class) { should eq(Models::Work) }
-        its(:policy_enforcer) { should eq(Policies::WorkPolicy) }
-        its(:template) { should eq('hello_world') }
+        it { is_expected.to respond_to :work }
+        it { is_expected.to respond_to :entity }
+        it { is_expected.to respond_to :title }
+        it { is_expected.to respond_to :job }
+        it { is_expected.to respond_to :requested_by }
+        its(:processing_subject_name) { is_expected.to eq('work') }
+        its(:attribute_names) { is_expected.to eq([:title, :job]) }
+        its(:base_class) { is_expected.to eq(Models::Work) }
+        its(:policy_enforcer) { is_expected.to eq(Policies::WorkPolicy) }
+        its(:template) { is_expected.to eq('hello_world') }
         it { is_expected.not_to be_persisted }
-        it { should delegate_method(:param_key).to(:model_name) }
-        it { should delegate_method(:to_processing_entity).to(:processing_action_form) }
-        it { should delegate_method(:to_processing_action).to(:processing_action_form) }
-        it { should delegate_method(:to_work_area).to(:processing_action_form) }
-        it { should delegate_method(:processing_action_name).to(:processing_action_form) }
+        it { is_expected.to delegate_method(:param_key).to(:model_name) }
+        it { is_expected.to delegate_method(:to_processing_entity).to(:processing_action_form) }
+        it { is_expected.to delegate_method(:to_processing_action).to(:processing_action_form) }
+        it { is_expected.to delegate_method(:to_work_area).to(:processing_action_form) }
+        it { is_expected.to delegate_method(:processing_action_name).to(:processing_action_form) }
         it 'will delegate repository to processing_action_form' do
           expect(subject.send(:repository)).to eq(subject.send(:processing_action_form).send(:repository))
         end
       end
 
-      it { should delegate_method(:valid?).to(:form) }
+      it { is_expected.to delegate_method(:valid?).to(:form) }
 
-      its(:default_repository) { should respond_to :register_action_taken_on_entity }
-      its(:default_translator) { should respond_to :call }
+      its(:default_repository) { is_expected.to respond_to :register_action_taken_on_entity }
+      its(:default_translator) { is_expected.to respond_to :call }
 
       context '#translate' do
         it 'should delegate translation to the translator' do

--- a/spec/forms/sipity/forms/submission_windows/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/core/show_form_spec.rb
@@ -11,10 +11,10 @@ module Sipity
           let(:submission_window) { double }
           subject { described_class.new(submission_window: submission_window, processing_action_name: processing_action_name) }
 
-          its(:policy_enforcer) { should eq Sipity::Policies::SubmissionWindowPolicy }
-          its(:processing_action_name) { should eq processing_action_name }
+          its(:policy_enforcer) { is_expected.to eq Sipity::Policies::SubmissionWindowPolicy }
+          its(:processing_action_name) { is_expected.to eq processing_action_name }
 
-          it { should be_a(Models::SubmissionWindow) }
+          it { is_expected.to be_a(Models::SubmissionWindow) }
         end
       end
     end

--- a/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/etd/start_a_submission_form_spec.rb
@@ -21,29 +21,29 @@ module Sipity
             allow_any_instance_of(described_class).to receive(:possible_work_publication_strategies).and_return(['already_published'])
           end
 
-          it { should implement_processing_form_interface }
+          it { is_expected.to implement_processing_form_interface }
 
           context 'its class configuration' do
             subject { described_class }
-            its(:base_class) { should eq(Models::Work) }
-            its(:model_name) { should eq(Models::Work.model_name) }
+            its(:base_class) { is_expected.to eq(Models::Work) }
+            its(:model_name) { is_expected.to eq(Models::Work.model_name) }
             it 'will delegate human_attribute_name to the base class' do
               expect(Models::Work).to receive(:human_attribute_name).and_call_original
               expect(subject.human_attribute_name(:title)).to be_a(String)
             end
           end
 
-          its(:policy_enforcer) { should eq Policies::SubmissionWindowPolicy }
-          its(:base_class) { should eq Models::Work }
-          its(:default_repository) { should respond_to :create_work! }
-          its(:default_repository) { should respond_to :find_submission_window_by }
-          its(:processing_subject_name) { should eq :submission_window }
-          its(:entity) { should eq submission_window }
-          its(:to_work_area) { should eq(work_area) }
-          its(:form_path) { should be_a(String) }
-          its(:persisted?) { should eq(false) }
-          its(:possible_access_right_codes) { should be_a(Array) }
-          its(:access_rights_answer_for_select) { should be_a(Array) }
+          its(:policy_enforcer) { is_expected.to eq Policies::SubmissionWindowPolicy }
+          its(:base_class) { is_expected.to eq Models::Work }
+          its(:default_repository) { is_expected.to respond_to :create_work! }
+          its(:default_repository) { is_expected.to respond_to :find_submission_window_by }
+          its(:processing_subject_name) { is_expected.to eq :submission_window }
+          its(:entity) { is_expected.to eq submission_window }
+          its(:to_work_area) { is_expected.to eq(work_area) }
+          its(:form_path) { is_expected.to be_a(String) }
+          its(:persisted?) { is_expected.to eq(false) }
+          its(:possible_access_right_codes) { is_expected.to be_a(Array) }
+          its(:access_rights_answer_for_select) { is_expected.to be_a(Array) }
 
           it 'will have a model name like Work' do
             expect(described_class.model_name).to be_a(ActiveModel::Name)
@@ -53,8 +53,8 @@ module Sipity
             expect(described_class.new(keywords).access_rights_answer).to be_present
           end
 
-          it { should delegate_method(:work_publication_strategy).to(:publication_and_patenting_intent_extension) }
-          it { should delegate_method(:work_publication_strategies_for_select).to(:publication_and_patenting_intent_extension) }
+          it { is_expected.to delegate_method(:work_publication_strategy).to(:publication_and_patenting_intent_extension) }
+          it { is_expected.to delegate_method(:work_publication_strategies_for_select).to(:publication_and_patenting_intent_extension) }
 
           context 'selectable answers that are an array of symbols for SimpleForm internationalization' do
             it 'will have #access_rights_answer_for_select' do
@@ -72,12 +72,16 @@ module Sipity
             let(:attributes) { { title: nil, access_rights_answer: nil, work_publication_strategy: nil } }
             subject { described_class.new(keywords) }
             include Shoulda::Matchers::ActiveModel
-            it { should validate_presence_of(:title) }
-            it { should validate_presence_of(:access_rights_answer) }
-            it { should validate_inclusion_of(:access_rights_answer).in_array(subject.send(:possible_access_right_codes)) }
-            it { should validate_presence_of(:work_publication_strategy) }
-            it { should validate_inclusion_of(:work_publication_strategy).in_array(subject.send(:possible_work_publication_strategies)) }
-            it { should validate_presence_of(:work_type) }
+            it { is_expected.to validate_presence_of(:title) }
+            it { is_expected.to validate_presence_of(:access_rights_answer) }
+            it { is_expected.to validate_inclusion_of(:access_rights_answer).in_array(subject.send(:possible_access_right_codes)) }
+            it { is_expected.to validate_presence_of(:work_publication_strategy) }
+            it do
+              is_expected.to validate_inclusion_of(:work_publication_strategy).in_array(
+                subject.send(:possible_work_publication_strategies)
+              )
+            end
+            it { is_expected.to validate_presence_of(:work_type) }
             it 'should validate submission_window_is_open' do
               expect_any_instance_of(OpenForStartingSubmissionsValidator).to receive(:validate_each)
               subject.valid?

--- a/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
+++ b/spec/forms/sipity/forms/submission_windows/ulra/start_a_submission_form_spec.rb
@@ -19,27 +19,27 @@ module Sipity
             allow(repository).to receive(:get_controlled_vocabulary_values_for_predicate_name).with(name: 'award_category').and_return([])
           end
 
-          it { should implement_processing_form_interface }
-          its(:public_methods) { should include(:to_work_area) }
+          it { is_expected.to implement_processing_form_interface }
+          its(:public_methods) { is_expected.to include(:to_work_area) }
 
           context 'its class configuration' do
             subject { described_class }
-            its(:base_class) { should eq(Models::Work) }
-            its(:model_name) { should eq(Models::Work.model_name) }
+            its(:base_class) { is_expected.to eq(Models::Work) }
+            its(:model_name) { is_expected.to eq(Models::Work.model_name) }
             it 'will delegate human_attribute_name to the base class' do
               expect(Models::Work).to receive(:human_attribute_name).and_call_original
               expect(subject.human_attribute_name(:title)).to be_a(String)
             end
           end
 
-          its(:policy_enforcer) { should eq Policies::SubmissionWindowPolicy }
-          its(:base_class) { should eq Models::Work }
-          its(:default_repository) { should respond_to :create_work! }
-          its(:default_repository) { should respond_to :find_submission_window_by }
-          its(:processing_subject_name) { should eq :submission_window }
-          its(:entity) { should eq submission_window }
-          its(:to_work_area) { should eq(work_area) }
-          its(:persisted?) { should eq(false) }
+          its(:policy_enforcer) { is_expected.to eq Policies::SubmissionWindowPolicy }
+          its(:base_class) { is_expected.to eq Models::Work }
+          its(:default_repository) { is_expected.to respond_to :create_work! }
+          its(:default_repository) { is_expected.to respond_to :find_submission_window_by }
+          its(:processing_subject_name) { is_expected.to eq :submission_window }
+          its(:entity) { is_expected.to eq submission_window }
+          its(:to_work_area) { is_expected.to eq(work_area) }
+          its(:persisted?) { is_expected.to eq(false) }
 
           it 'will delegate #to_processing_entity to the submission window' do
             expect(submission_window).to receive(:to_processing_entity)
@@ -60,12 +60,12 @@ module Sipity
             let(:attributes) { { title: nil, access_rights_answer: nil } }
             subject { described_class.new(keywords) }
             include Shoulda::Matchers::ActiveModel
-            it { should validate_presence_of(:title) }
-            it { should validate_presence_of(:advisor_netid) }
-            it { should validate_presence_of(:award_category) }
-            it { should validate_presence_of(:work_type) }
-            it { should validate_presence_of(:course_name) }
-            it { should validate_presence_of(:course_number) }
+            it { is_expected.to validate_presence_of(:title) }
+            it { is_expected.to validate_presence_of(:advisor_netid) }
+            it { is_expected.to validate_presence_of(:award_category) }
+            it { is_expected.to validate_presence_of(:work_type) }
+            it { is_expected.to validate_presence_of(:course_name) }
+            it { is_expected.to validate_presence_of(:course_number) }
             it 'should validate submission_window_is_open' do
               expect_any_instance_of(OpenForStartingSubmissionsValidator).to receive(:validate_each)
               subject.valid?

--- a/spec/forms/sipity/forms/work_areas/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/work_areas/core/show_form_spec.rb
@@ -12,20 +12,20 @@ module Sipity
           let(:user) { double }
           subject { described_class.new(work_area: work_area, requested_by: user, repository: repository) }
 
-          its(:policy_enforcer) { should eq Sipity::Policies::WorkAreaPolicy }
-          its(:processing_action_name) { should eq('show') }
-          it { should implement_processing_form_interface }
-          it { should delegate_method(:name).to(:work_area) }
-          it { should delegate_method(:slug).to(:work_area) }
+          its(:policy_enforcer) { is_expected.to eq Sipity::Policies::WorkAreaPolicy }
+          its(:processing_action_name) { is_expected.to eq('show') }
+          it { is_expected.to implement_processing_form_interface }
+          it { is_expected.to delegate_method(:name).to(:work_area) }
+          it { is_expected.to delegate_method(:slug).to(:work_area) }
 
-          its(:order_options_for_select) { should be_a(Array) }
-          its(:input_name_for_select_processing_state) { should eq('work_area[processing_state]') }
-          its(:input_name_for_select_sort_order) { should eq('work_area[order]') }
-          its(:page) { should eq(subject.send(:default_page)) }
+          its(:order_options_for_select) { is_expected.to be_a(Array) }
+          its(:input_name_for_select_processing_state) { is_expected.to eq('work_area[processing_state]') }
+          its(:input_name_for_select_sort_order) { is_expected.to eq('work_area[order]') }
+          its(:page) { is_expected.to eq(subject.send(:default_page)) }
 
-          it { should delegate_method(:default_order).to(:search_criteria_config) }
-          it { should delegate_method(:default_page).to(:search_criteria_config) }
-          it { should delegate_method(:order_options_for_select).to(:search_criteria_config) }
+          it { is_expected.to delegate_method(:default_order).to(:search_criteria_config) }
+          it { is_expected.to delegate_method(:default_page).to(:search_criteria_config) }
+          it { is_expected.to delegate_method(:order_options_for_select).to(:search_criteria_config) }
 
           it 'will expose #processing_states_for_select' do
             expect(repository).to receive(:processing_state_names_for_select_within_work_area).with(work_area: work_area).and_call_original

--- a/spec/forms/sipity/forms/work_submissions/core/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/access_policy_form_spec.rb
@@ -24,9 +24,9 @@ module Sipity
             allow(repository).to receive(:work_attachments).with(work: work, predicate_name: :all).and_return([attachment])
           end
 
-          its(:processing_action_name) { should eq('access_policy') }
-          it { should respond_to :accessible_objects_attributes= }
-          it { should respond_to :representative_attachment_id }
+          its(:processing_action_name) { is_expected.to eq('access_policy') }
+          it { is_expected.to respond_to :accessible_objects_attributes= }
+          it { is_expected.to respond_to :representative_attachment_id }
 
           it 'will expose accessible_objects' do
             expect(subject.accessible_objects.size).to eq(2)
@@ -39,7 +39,7 @@ module Sipity
           end
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:representative_attachment_id) }
+          it { is_expected.to validate_presence_of(:representative_attachment_id) }
 
           it 'will validate the presence of accessible_objects_attributes' do
             subject = described_class.new(keywords.merge(attributes: { accessible_objects_attributes: {} }))
@@ -110,9 +110,9 @@ module Sipity
           let(:persisted_object) { double('Persisted Object', entity_type: 'Hello', human_model_name: 'Work') }
           subject { described_class.new(persisted_object, attributes) }
 
-          its(:persisted?) { should be_truthy }
-          its(:human_model_name) { should eq(persisted_object.human_model_name) }
-          it { should delegate_method(:accessible_object_type).to(:persisted_object) }
+          its(:persisted?) { is_expected.to be_truthy }
+          its(:human_model_name) { is_expected.to eq(persisted_object.human_model_name) }
+          it { is_expected.to delegate_method(:accessible_object_type).to(:persisted_object) }
 
           it 'will have a public :access_right_code' do
             expect { subject.access_right_code }.to_not raise_error

--- a/spec/forms/sipity/forms/work_submissions/core/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/attach_form_spec.rb
@@ -14,15 +14,15 @@ module Sipity
           let(:attributes) { {} }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should be_present }
-          its(:processing_action_name) { should eq('attach') }
+          its(:policy_enforcer) { is_expected.to be_present }
+          its(:processing_action_name) { is_expected.to eq('attach') }
 
-          it { should respond_to :attachments }
-          it { should respond_to :representative_attachment_id }
-          it { should respond_to :files }
+          it { is_expected.to respond_to :attachments }
+          it { is_expected.to respond_to :representative_attachment_id }
+          it { is_expected.to respond_to :files }
 
-          it { should delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
-          it { should delegate_method(:attachments_associated_with_the_work?).to(:attachments_extension) }
+          it { is_expected.to delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
+          it { is_expected.to delegate_method(:attachments_associated_with_the_work?).to(:attachments_extension) }
 
           context 'validations' do
             it 'will require a work' do

--- a/spec/forms/sipity/forms/work_submissions/core/copyright_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/copyright_form_spec.rb
@@ -25,12 +25,12 @@ module Sipity
             )
           end
 
-          its(:processing_action_name) { should eq('copyright') }
-          it { should respond_to :copyright }
+          its(:processing_action_name) { is_expected.to eq('copyright') }
+          it { is_expected.to respond_to :copyright }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:copyright) }
-          it { should validate_inclusion_of(:copyright).in_array(subject.available_copyrights_for_validation) }
+          it { is_expected.to validate_presence_of(:copyright) }
+          it { is_expected.to validate_inclusion_of(:copyright).in_array(subject.available_copyrights_for_validation) }
 
           it 'will have #available_copyrights' do
             expect(repository).to receive(:get_controlled_vocabulary_entries_for_predicate_name).with(name: 'copyright').

--- a/spec/forms/sipity/forms/work_submissions/core/debug_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/debug_form_spec.rb
@@ -6,10 +6,10 @@ module Sipity
           let(:work) { double(id: true) }
           let(:processing_action_name) { 'debug' }
           subject { described_class.new(work: work, processing_action_name: processing_action_name) }
-          its(:base_class) { should eq(Models::Work) }
-          its(:policy_enforcer) { should eq(Sipity::Policies::WorkPolicy) }
+          its(:base_class) { is_expected.to eq(Models::Work) }
+          its(:policy_enforcer) { is_expected.to eq(Sipity::Policies::WorkPolicy) }
 
-          it { should delegate_method(:work_id).to(:work).as(:id) }
+          it { is_expected.to delegate_method(:work_id).to(:work).as(:id) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/show_form_spec.rb
@@ -11,11 +11,11 @@ module Sipity
           let(:work) { double(id: 1) }
           subject { described_class.new(work: work, processing_action_name: processing_action_name) }
 
-          its(:policy_enforcer) { should eq Sipity::Policies::WorkPolicy }
-          its(:processing_action_name) { should eq processing_action_name }
-          its(:work_id) { should eq work.id }
-          it { should be_decorated }
-          it { should be_a(Models::Work) }
+          its(:policy_enforcer) { is_expected.to eq Sipity::Policies::WorkPolicy }
+          its(:processing_action_name) { is_expected.to eq processing_action_name }
+          its(:work_id) { is_expected.to eq work.id }
+          it { is_expected.to be_decorated }
+          it { is_expected.to be_a(Models::Work) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
@@ -26,7 +26,7 @@ module Sipity
           end
 
           its(:comment_legend) { should be_html_safe }
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
 
           it 'will validate the presence of the :comment' do
             subject.valid?

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_requests_change_form_spec.rb
@@ -14,8 +14,8 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: user } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('advisor_requests_change') }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:processing_action_name) { is_expected.to eq('advisor_requests_change') }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           context '#render' do
             let(:f) { double }
@@ -25,7 +25,7 @@ module Sipity
             end
           end
 
-          its(:comment_legend) { should be_html_safe }
+          its(:comment_legend) { is_expected.to be_html_safe }
           it { is_expected.not_to be_persisted }
 
           it 'will validate the presence of the :comment' do

--- a/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/advisor_signoff_form_spec.rb
@@ -29,7 +29,7 @@ module Sipity
             end
           end
 
-          its(:work) { should eq work }
+          its(:work) { is_expected.to eq work }
 
           context '#render' do
             it 'will render HTML safe submission terms and confirmation' do
@@ -39,9 +39,9 @@ module Sipity
             end
           end
 
-          its(:advisor_signoff_legend) { should be_html_safe }
-          its(:signoff_agreement) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:advisor_signoff_legend) { is_expected.to be_html_safe }
+          its(:signoff_agreement) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           context 'validation' do
             it 'will require agreement to the signoff' do

--- a/spec/forms/sipity/forms/work_submissions/etd/author_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/author_form_spec.rb
@@ -17,15 +17,15 @@ module Sipity
               with(work: work, key: 'author_name', cardinality: 1).and_return(nil)
           end
 
-          its(:processing_action_name) { should eq('author') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:processing_action_name) { is_expected.to eq('author') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
-          it { should respond_to :author_name }
-          it { should respond_to :requested_by }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :author_name }
+          it { is_expected.to respond_to :requested_by }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:author_name) }
+          it { is_expected.to validate_presence_of(:author_name) }
 
           context '#submit' do
             context 'with invalid data' do

--- a/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
@@ -16,8 +16,8 @@ module Sipity
           end
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:oclc_number) }
-          it { should validate_presence_of(:catalog_system_number) }
+          it { is_expected.to validate_presence_of(:oclc_number) }
+          it { is_expected.to validate_presence_of(:catalog_system_number) }
 
           context '#catalog_system_number' do
             it "will prepend 0s for catalog_system_number's smaller than 9 digits" do
@@ -37,9 +37,9 @@ module Sipity
             end
           end
 
-          its(:legend) { should be_html_safe }
-          its(:signoff_agreement) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:legend) { is_expected.to be_html_safe }
+          its(:signoff_agreement) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           context 'with data from the repository' do
             subject { described_class.new(keywords) }

--- a/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/cataloging_complete_form_spec.rb
@@ -47,12 +47,12 @@ module Sipity
             its(:oclc_number) do
               expect(repository).to receive(:work_attribute_values_for).
                 with(work: work, key: 'oclc_number', cardinality: 1).and_return(123)
-              should eq(123)
+              is_expected.to eq(123)
             end
             its(:catalog_system_number) do
               expect(repository).to receive(:work_attribute_values_for).
                 with(work: work, key: 'catalog_system_number', cardinality: 1).and_return('abc')
-              should eq('abc')
+              is_expected.to eq('abc')
             end
           end
 

--- a/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
@@ -21,7 +21,7 @@ module Sipity
 
           it { should respond_to :work }
           its(:processing_action_name) { should eq('collaborator') }
-          its(:collaborators) { should_not be_empty }
+          its(:collaborators) { is_expected.not_to be_empty }
           its(:possible_roles) { should be_a(Hash) }
 
           it 'will require a work' do
@@ -92,23 +92,23 @@ module Sipity
                   { __sequence: { name: "Jeremy", role: "", netid: "", email: "", responsible_for_review: "false", id: 11 } }
                 end
                 its(:valid?) { should be_falsey }
-                its(:collaborators) { should_not be_empty }
-                its(:collaborators_from_input) { should_not be_empty }
+                its(:collaborators) { is_expected.not_to be_empty }
+                its(:collaborators_from_input) { is_expected.not_to be_empty }
               end
               context 'with a missing name' do
                 let(:collaborators_attributes) do
                   { __sequence: { name: "", role: "", netid: "", email: "", responsible_for_review: "false", id: 11 } }
                 end
                 its(:valid?) { should be_falsey }
-                its(:collaborators) { should_not be_empty }
-                its(:collaborators_from_input) { should_not be_empty }
+                its(:collaborators) { is_expected.not_to be_empty }
+                its(:collaborators_from_input) { is_expected.not_to be_empty }
               end
               context 'with a missing name and id' do
                 let(:collaborators_attributes) do
                   { __sequence: { name: "", role: "", netid: "", email: "", responsible_for_review: "0", id: '' } }
                 end
                 its(:valid?) { should be_falsey }
-                its(:collaborators) { should_not be_empty }
+                its(:collaborators) { is_expected.not_to be_empty }
                 its(:collaborators_from_input) { should be_empty }
               end
               context 'with empty strings' do
@@ -125,8 +125,8 @@ module Sipity
                   { __sequence: { name: "", role: "Research Director", netid: "", email: "test@test.com", responsible_for_review: "0" } }
                 end
                 its(:valid?) { should be_falsey }
-                its(:collaborators) { should_not be_empty }
-                its(:collaborators_from_input) { should_not be_empty }
+                its(:collaborators) { is_expected.not_to be_empty }
+                its(:collaborators_from_input) { is_expected.not_to be_empty }
               end
             end
 

--- a/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/collaborator_form_spec.rb
@@ -17,12 +17,12 @@ module Sipity
             allow(repository).to receive(:find_or_initialize_collaborators_by).and_return(Models::Collaborator.new)
           end
 
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
-          its(:processing_action_name) { should eq('collaborator') }
+          it { is_expected.to respond_to :work }
+          its(:processing_action_name) { is_expected.to eq('collaborator') }
           its(:collaborators) { is_expected.not_to be_empty }
-          its(:possible_roles) { should be_a(Hash) }
+          its(:possible_roles) { is_expected.to be_a(Hash) }
 
           it 'will require a work' do
             subject = described_class.new(keywords.merge(work: nil))
@@ -91,7 +91,7 @@ module Sipity
                 let(:collaborators_attributes) do
                   { __sequence: { name: "Jeremy", role: "", netid: "", email: "", responsible_for_review: "false", id: 11 } }
                 end
-                its(:valid?) { should be_falsey }
+                its(:valid?) { is_expected.to be_falsey }
                 its(:collaborators) { is_expected.not_to be_empty }
                 its(:collaborators_from_input) { is_expected.not_to be_empty }
               end
@@ -99,7 +99,7 @@ module Sipity
                 let(:collaborators_attributes) do
                   { __sequence: { name: "", role: "", netid: "", email: "", responsible_for_review: "false", id: 11 } }
                 end
-                its(:valid?) { should be_falsey }
+                its(:valid?) { is_expected.to be_falsey }
                 its(:collaborators) { is_expected.not_to be_empty }
                 its(:collaborators_from_input) { is_expected.not_to be_empty }
               end
@@ -107,9 +107,9 @@ module Sipity
                 let(:collaborators_attributes) do
                   { __sequence: { name: "", role: "", netid: "", email: "", responsible_for_review: "0", id: '' } }
                 end
-                its(:valid?) { should be_falsey }
+                its(:valid?) { is_expected.to be_falsey }
                 its(:collaborators) { is_expected.not_to be_empty }
-                its(:collaborators_from_input) { should be_empty }
+                its(:collaborators_from_input) { is_expected.to be_empty }
               end
               context 'with empty strings' do
                 let(:collaborators_attributes) do
@@ -124,7 +124,7 @@ module Sipity
                 let(:collaborators_attributes) do
                   { __sequence: { name: "", role: "Research Director", netid: "", email: "test@test.com", responsible_for_review: "0" } }
                 end
-                its(:valid?) { should be_falsey }
+                its(:valid?) { is_expected.to be_falsey }
                 its(:collaborators) { is_expected.not_to be_empty }
                 its(:collaborators_from_input) { is_expected.not_to be_empty }
               end

--- a/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
@@ -42,7 +42,7 @@ module Sipity
             end
             context 'when initial date is given is bogus' do
               subject { described_class.new(keywords.merge(attributes: { defense_date: '2014-02-31' })) }
-              its(:defense_date) { should_not be_present }
+              its(:defense_date) { is_expected.not_to be_present }
             end
           end
 

--- a/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/defense_date_form_spec.rb
@@ -15,14 +15,14 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: user, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('defense_date') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:processing_action_name) { is_expected.to eq('defense_date') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
-          it { should respond_to :defense_date }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :defense_date }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:defense_date) }
+          it { is_expected.to validate_presence_of(:defense_date) }
 
           it 'will handle Rails defense_date that was input via Rails HTML multi-field date input' do
             form = described_class.new(

--- a/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/degree_form_spec.rb
@@ -15,12 +15,12 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: double, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('degree') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:processing_action_name) { is_expected.to eq('degree') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
-          it { should respond_to :degree }
-          it { should respond_to :program_name }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :degree }
+          it { is_expected.to respond_to :program_name }
 
           it 'will require a degree' do
             subject.valid?

--- a/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/describe_form_spec.rb
@@ -19,18 +19,18 @@ module Sipity
               with(work: work, key: 'alternate_title', cardinality: 1).and_return(nil)
           end
 
-          its(:processing_action_name) { should eq('describe') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:processing_action_name) { is_expected.to eq('describe') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
-          it { should respond_to :title }
-          it { should respond_to :abstract }
-          it { should respond_to :alternate_title }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :title }
+          it { is_expected.to respond_to :abstract }
+          it { is_expected.to respond_to :alternate_title }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:title) }
-          it { should validate_presence_of(:abstract) }
-          it { should validate_presence_of(:work) }
+          it { is_expected.to validate_presence_of(:title) }
+          it { is_expected.to validate_presence_of(:abstract) }
+          it { is_expected.to validate_presence_of(:work) }
 
           context 'validations' do
             it 'will require a requested_by' do

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_final_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_final_signoff_form_spec.rb
@@ -26,9 +26,9 @@ module Sipity
             end
           end
 
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
@@ -16,7 +16,7 @@ module Sipity
           its(:processing_action_name) { should eq('grad_school_requests_change') }
           its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
           it { should implement_processing_form_interface }
 
           it 'will validate the presence of the :comment' do

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_requests_change_form_spec.rb
@@ -13,11 +13,11 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: user } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('grad_school_requests_change') }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:processing_action_name) { is_expected.to eq('grad_school_requests_change') }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           it { is_expected.not_to be_persisted }
-          it { should implement_processing_form_interface }
+          it { is_expected.to implement_processing_form_interface }
 
           it 'will validate the presence of the :comment' do
             subject.valid?
@@ -30,7 +30,7 @@ module Sipity
               expect(f).to receive(:input).with(:comment, hash_including(as: :text))
               subject.render(f: f)
             end
-            its(:grad_school_requests_change_legend) { should be_html_safe }
+            its(:grad_school_requests_change_legend) { is_expected.to be_html_safe }
           end
 
           context 'without valid data' do

--- a/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/grad_school_signoff_form_spec.rb
@@ -29,11 +29,11 @@ module Sipity
             end
           end
 
-          its(:legend) { should be_html_safe }
-          its(:signoff_agreement) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:legend) { is_expected.to be_html_safe }
+          its(:signoff_agreement) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/etd/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/ingest_completed_form_spec.rb
@@ -13,20 +13,20 @@ module Sipity
           let(:user) { double('User') }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
-          its(:processing_action_name) { should eq('ingest_completed') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+          its(:processing_action_name) { is_expected.to eq('ingest_completed') }
 
-          it { should respond_to :job_state }
+          it { is_expected.to respond_to :job_state }
 
-          it { should respond_to :work }
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_inclusion_of(:job_state).in_array([described_class::JOB_STATE_SUCCESS]) }
+          it { is_expected.to validate_inclusion_of(:job_state).in_array([described_class::JOB_STATE_SUCCESS]) }
 
           context 'with invalid data' do
             before { expect(subject).to receive(:valid?).and_return(false) }
-            its(:submit) { should eq(false) }
+            its(:submit) { is_expected.to eq(false) }
           end
 
           context 'with valid data' do

--- a/spec/forms/sipity/forms/work_submissions/etd/ingest_with_postponed_cataloging_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/ingest_with_postponed_cataloging_form_spec.rb
@@ -32,13 +32,13 @@ module Sipity
             end
           end
 
-          its(:legend) { should be_html_safe }
-          its(:signoff_agreement) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:legend) { is_expected.to be_html_safe }
+          its(:signoff_agreement) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:scheduled_time) }
-          it { should validate_acceptance_of(:agree_to_signoff) }
+          it { is_expected.to validate_presence_of(:scheduled_time) }
+          it { is_expected.to validate_acceptance_of(:agree_to_signoff) }
 
           context '#scheduled_time' do
             it 'will be set by extracting from the attributes' do

--- a/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/publishing_and_patenting_intent_form_spec.rb
@@ -19,14 +19,14 @@ module Sipity
           let(:user) { double }
           before { allow(work).to receive(:work_area).and_return(work_area) }
 
-          it { should implement_processing_form_interface }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
-          its(:base_class) { should eq Models::Work }
+          it { is_expected.to implement_processing_form_interface }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+          its(:base_class) { is_expected.to eq Models::Work }
 
-          it { should delegate_method(:work_patent_strategy).to(:publication_and_patenting_intent_extension) }
-          it { should delegate_method(:work_patent_strategies_for_select).to(:publication_and_patenting_intent_extension) }
-          it { should delegate_method(:work_publication_strategy).to(:publication_and_patenting_intent_extension) }
-          it { should delegate_method(:work_publication_strategies_for_select).to(:publication_and_patenting_intent_extension) }
+          it { is_expected.to delegate_method(:work_patent_strategy).to(:publication_and_patenting_intent_extension) }
+          it { is_expected.to delegate_method(:work_patent_strategies_for_select).to(:publication_and_patenting_intent_extension) }
+          it { is_expected.to delegate_method(:work_publication_strategy).to(:publication_and_patenting_intent_extension) }
+          it { is_expected.to delegate_method(:work_publication_strategies_for_select).to(:publication_and_patenting_intent_extension) }
 
           context 'validation' do
             before do

--- a/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/request_change_on_behalf_of_form_spec.rb
@@ -35,8 +35,8 @@ module Sipity
             end
           end
 
-          its(:comment_legend) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:comment_legend) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           context 'validations' do
             it 'will require a comment' do

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_advisor_request_form_spec.rb
@@ -21,9 +21,9 @@ module Sipity
             end
           end
 
-          its(:input_legend) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
-          it { should implement_processing_form_interface }
+          its(:input_legend) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          it { is_expected.to implement_processing_form_interface }
 
           context 'with valid data' do
             before do

--- a/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/respond_to_grad_school_request_form_spec.rb
@@ -21,8 +21,8 @@ module Sipity
             end
           end
 
-          its(:input_legend) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:input_legend) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           context 'without valid data' do
             it 'will not save the form' do

--- a/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/search_term_form_spec.rb
@@ -12,11 +12,11 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: double('User') } }
           subject { described_class.new(keywords) }
 
-          it { should respond_to :work }
-          it { should respond_to :subject }
-          it { should respond_to :language }
-          it { should respond_to :temporal_coverage }
-          it { should respond_to :spatial_coverage }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :subject }
+          it { is_expected.to respond_to :language }
+          it { is_expected.to respond_to :temporal_coverage }
+          it { is_expected.to respond_to :spatial_coverage }
 
           context 'without specified values' do
             before do

--- a/spec/forms/sipity/forms/work_submissions/etd/send_back_to_grad_school_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/send_back_to_grad_school_spec.rb
@@ -14,7 +14,7 @@ module Sipity
           its(:processing_action_name) { should eq('send_back_to_grad_school') }
           its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
           it { should implement_processing_form_interface }
 
           it 'will validate the presence of the :comment' do

--- a/spec/forms/sipity/forms/work_submissions/etd/send_back_to_grad_school_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/send_back_to_grad_school_spec.rb
@@ -11,11 +11,11 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: user } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('send_back_to_grad_school') }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:processing_action_name) { is_expected.to eq('send_back_to_grad_school') }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           it { is_expected.not_to be_persisted }
-          it { should implement_processing_form_interface }
+          it { is_expected.to implement_processing_form_interface }
 
           it 'will validate the presence of the :comment' do
             subject.valid?

--- a/spec/forms/sipity/forms/work_submissions/etd/send_to_cataloging_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/send_to_cataloging_form_spec.rb
@@ -28,11 +28,11 @@ module Sipity
             end
           end
 
-          its(:legend) { should be_html_safe }
-          its(:signoff_agreement) { should be_html_safe }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          its(:legend) { is_expected.to be_html_safe }
+          its(:signoff_agreement) { is_expected.to be_html_safe }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/signoff_on_behalf_of_form_spec.rb
@@ -14,8 +14,8 @@ module Sipity
 
           subject { described_class.new(base_options) }
 
-          it { should respond_to :work }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          it { is_expected.to respond_to :work }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
 
           let(:someone) { double(id: 'one') }
 

--- a/spec/forms/sipity/forms/work_submissions/etd/submit_for_ingest_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/submit_for_ingest_form_spec.rb
@@ -11,9 +11,9 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: double, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
+          it { is_expected.to respond_to :work }
 
           context '#submit' do
             let(:user) { double('User') }

--- a/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/submit_for_review_form_spec.rb
@@ -27,8 +27,8 @@ module Sipity
             end
           end
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/ulra/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/access_policy_form_spec.rb
@@ -15,7 +15,9 @@ module Sipity
           let(:keywords) { { work: work, requested_by: user, repository: repository, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:representative_attachment_predicate_name) { should eq(Forms::WorkSubmissions::Ulra::AttachForm.attachment_predicate_name) }
+          its(:representative_attachment_predicate_name) do
+            is_expected.to eq(Forms::WorkSubmissions::Ulra::AttachForm.attachment_predicate_name)
+          end
 
           it 'will leverage the representative_attachment_predicate_name for the #available_representative_attachments' do
             expect(repository).to receive(:work_attachments).with(

--- a/spec/forms/sipity/forms/work_submissions/ulra/assign_award_status_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/assign_award_status_form_spec.rb
@@ -14,13 +14,13 @@ module Sipity
           let(:keywords) { { requested_by: user, attributes: {}, work: work, repository: repository } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('assign_award_status') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
-          its(:base_class) { should eq(Models::Work) }
+          its(:processing_action_name) { is_expected.to eq('assign_award_status') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+          its(:base_class) { is_expected.to eq(Models::Work) }
 
           context 'class configuration' do
             subject { described_class }
-            its(:model_name) { should eq(Models::Work.model_name) }
+            its(:model_name) { is_expected.to eq(Models::Work.model_name) }
             it 'will delegate human_attribute_name to the base class' do
               expect(described_class.base_class).to receive(:human_attribute_name).and_call_original
               expect(described_class.human_attribute_name(:title)).to be_a(String)
@@ -28,12 +28,12 @@ module Sipity
           end
 
           it { is_expected.not_to be_persisted }
-          it { should respond_to :work }
-          it { should respond_to :is_an_award_winner }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :is_an_award_winner }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:is_an_award_winner) }
-          it { should validate_inclusion_of(:is_an_award_winner).in_array(subject.possible_is_an_award_winner) }
+          it { is_expected.to validate_presence_of(:is_an_award_winner) }
+          it { is_expected.to validate_inclusion_of(:is_an_award_winner).in_array(subject.possible_is_an_award_winner) }
 
           context 'retrieving values from the repository' do
             context 'with data from the database' do

--- a/spec/forms/sipity/forms/work_submissions/ulra/assign_award_status_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/assign_award_status_form_spec.rb
@@ -27,7 +27,7 @@ module Sipity
             end
           end
 
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
           it { should respond_to :work }
           it { should respond_to :is_an_award_winner }
 

--- a/spec/forms/sipity/forms/work_submissions/ulra/attach_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/attach_form_spec.rb
@@ -14,17 +14,17 @@ module Sipity
           let(:attributes) { {} }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should be_present }
-          its(:processing_action_name) { should eq('attach') }
-          its(:attachment_predicate_name) { should eq('project_file') }
+          its(:policy_enforcer) { is_expected.to be_present }
+          its(:processing_action_name) { is_expected.to eq('attach') }
+          its(:attachment_predicate_name) { is_expected.to eq('project_file') }
 
-          it { should respond_to :attachments }
-          it { should respond_to :representative_attachment_id }
-          it { should respond_to :files }
-          it { should respond_to :attached_files_completion_state }
-          it { should respond_to :project_url }
+          it { is_expected.to respond_to :attachments }
+          it { is_expected.to respond_to :representative_attachment_id }
+          it { is_expected.to respond_to :files }
+          it { is_expected.to respond_to :attached_files_completion_state }
+          it { is_expected.to respond_to :project_url }
 
-          it { should delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
+          it { is_expected.to delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
 
           context 'values from work' do
             before do
@@ -35,15 +35,19 @@ module Sipity
                 work: work, key: 'project_url', cardinality: 1
               ).and_return('existing.url')
             end
-            its(:attached_files_completion_state_from_work) { should eq('complete') }
-            its(:attached_files_completion_state) { should eq('complete') }
+            its(:attached_files_completion_state_from_work) { is_expected.to eq('complete') }
+            its(:attached_files_completion_state) { is_expected.to eq('complete') }
           end
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:work) }
-          it { should validate_presence_of(:requested_by) }
-          it { should validate_presence_of(:attached_files_completion_state) }
-          it { should validate_inclusion_of(:attached_files_completion_state).in_array(subject.possible_attached_files_completion_states) }
+          it { is_expected.to validate_presence_of(:work) }
+          it { is_expected.to validate_presence_of(:requested_by) }
+          it { is_expected.to validate_presence_of(:attached_files_completion_state) }
+          it do
+            is_expected.to validate_inclusion_of(:attached_files_completion_state).in_array(
+              subject.possible_attached_files_completion_states
+            )
+          end
 
           context 'assigning attachments attributes' do
             let(:user) { double('User') }

--- a/spec/forms/sipity/forms/work_submissions/ulra/begin_data_remediation_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/begin_data_remediation_form_spec.rb
@@ -11,13 +11,13 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: double, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
+          it { is_expected.to respond_to :work }
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
 
-          its(:render) { should be_html_safe }
+          its(:render) { is_expected.to be_html_safe }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
@@ -28,7 +28,7 @@ module Sipity
           end
 
           it { should respond_to :work }
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
 
           it { should delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
 

--- a/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/faculty_response_form_spec.rb
@@ -13,24 +13,24 @@ module Sipity
           let(:user) { double('User') }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('faculty_response') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
-          its(:base_class) { should eq(Models::Work) }
-          its(:attachment_predicate_name) { should eq('faculty_letter_of_recommendation') }
+          its(:processing_action_name) { is_expected.to eq('faculty_response') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+          its(:base_class) { is_expected.to eq(Models::Work) }
+          its(:attachment_predicate_name) { is_expected.to eq('faculty_letter_of_recommendation') }
 
           context 'class configuration' do
             subject { described_class }
-            its(:model_name) { should eq(Models::Work.model_name) }
+            its(:model_name) { is_expected.to eq(Models::Work.model_name) }
             it 'will delegate human_attribute_name to the base class' do
               expect(described_class.base_class).to receive(:human_attribute_name).and_call_original
               expect(described_class.human_attribute_name(:title)).to be_a(String)
             end
           end
 
-          it { should respond_to :work }
+          it { is_expected.to respond_to :work }
           it { is_expected.not_to be_persisted }
 
-          it { should delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
+          it { is_expected.to delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
 
           it 'will have #attachments' do
             attachment = [double('Attachment')]

--- a/spec/forms/sipity/forms/work_submissions/ulra/finish_data_remediation_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/finish_data_remediation_form_spec.rb
@@ -11,13 +11,13 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: double, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
+          it { is_expected.to respond_to :work }
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
 
-          its(:render) { should be_html_safe }
+          its(:render) { is_expected.to be_html_safe }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
@@ -42,7 +42,7 @@ module Sipity
             end
           end
 
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
           it { should respond_to :work }
           it { should respond_to :expected_graduation_term }
           it { should respond_to :majors }

--- a/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/plan_of_study_form_spec.rb
@@ -28,14 +28,14 @@ module Sipity
             allow(repository).to receive(:possible_expected_graduation_terms).and_return([expected_graduation_term])
           end
 
-          its(:processing_action_name) { should eq('plan_of_study') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
-          its(:base_class) { should eq(Models::Work) }
-          it { should delegate_method(:possible_expected_graduation_terms).to(:repository) }
+          its(:processing_action_name) { is_expected.to eq('plan_of_study') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+          its(:base_class) { is_expected.to eq(Models::Work) }
+          it { is_expected.to delegate_method(:possible_expected_graduation_terms).to(:repository) }
 
           context 'class configuration' do
             subject { described_class }
-            its(:model_name) { should eq(Models::Work.model_name) }
+            its(:model_name) { is_expected.to eq(Models::Work.model_name) }
             it 'will delegate human_attribute_name to the base class' do
               expect(described_class.base_class).to receive(:human_attribute_name).and_call_original
               expect(described_class.human_attribute_name(:title)).to be_a(String)
@@ -43,17 +43,17 @@ module Sipity
           end
 
           it { is_expected.not_to be_persisted }
-          it { should respond_to :work }
-          it { should respond_to :expected_graduation_term }
-          it { should respond_to :majors }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :expected_graduation_term }
+          it { is_expected.to respond_to :majors }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:expected_graduation_term) }
-          it { should validate_inclusion_of(:expected_graduation_term).in_array(subject.possible_expected_graduation_terms) }
-          it { should validate_presence_of(:primary_college) }
-          it { should validate_inclusion_of(:primary_college).in_array(subject.possible_primary_colleges) }
-          it { should validate_presence_of(:underclass_level) }
-          it { should validate_inclusion_of(:underclass_level).in_array(subject.possible_underclass_levels) }
+          it { is_expected.to validate_presence_of(:expected_graduation_term) }
+          it { is_expected.to validate_inclusion_of(:expected_graduation_term).in_array(subject.possible_expected_graduation_terms) }
+          it { is_expected.to validate_presence_of(:primary_college) }
+          it { is_expected.to validate_inclusion_of(:primary_college).in_array(subject.possible_primary_colleges) }
+          it { is_expected.to validate_presence_of(:underclass_level) }
+          it { is_expected.to validate_inclusion_of(:underclass_level).in_array(subject.possible_underclass_levels) }
 
           it 'will be invalid if all of the input majors are blank' do
             subject = described_class.new(keywords.merge(attributes: { majors: ['', ''] }))

--- a/spec/forms/sipity/forms/work_submissions/ulra/project_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/project_information_form_spec.rb
@@ -16,7 +16,7 @@ module Sipity
           let(:keywords) { { requested_by: user, attributes: attributes, work: work, repository: repository } }
           subject { described_class.new(keywords) }
 
-          its(:default_repository) { should respond_to(:get_controlled_vocabulary_values_for_predicate_name) }
+          its(:default_repository) { is_expected.to respond_to(:get_controlled_vocabulary_values_for_predicate_name) }
 
           before do
             allow(
@@ -27,11 +27,11 @@ module Sipity
           end
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:title) }
-          it { should validate_inclusion_of(:award_category).in_array(subject.award_categories_for_select) }
-          it { should validate_presence_of(:course_name) }
-          it { should validate_presence_of(:course_number) }
-          it { should validate_presence_of(:requested_by) }
+          it { is_expected.to validate_presence_of(:title) }
+          it { is_expected.to validate_inclusion_of(:award_category).in_array(subject.award_categories_for_select) }
+          it { is_expected.to validate_presence_of(:course_name) }
+          it { is_expected.to validate_presence_of(:course_number) }
+          it { is_expected.to validate_presence_of(:requested_by) }
 
           context '#initialization without attributes given' do
             subject { described_class.new(requested_by: user, attributes: {}, work: work, repository: repository) }
@@ -56,14 +56,14 @@ module Sipity
               before do
                 expect(subject).to receive(:valid?).and_return(false)
               end
-              its(:submit) { should eq(false) }
+              its(:submit) { is_expected.to eq(false) }
             end
             context 'with valid data' do
               before do
                 allow(subject).to receive(:valid?).and_return(true)
                 allow(subject.send(:processing_action_form)).to receive(:submit).and_yield.and_return(work)
               end
-              its(:submit) { should eq(work) }
+              its(:submit) { is_expected.to eq(work) }
 
               it 'will update the title' do
                 expect(repository).to receive(:update_work_title!).with(work: work, title: attributes.fetch(:title))

--- a/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
@@ -20,24 +20,24 @@ module Sipity
           end
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('publisher_information') }
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
-          its(:base_class) { should eq(Models::Work) }
+          its(:processing_action_name) { is_expected.to eq('publisher_information') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+          its(:base_class) { is_expected.to eq(Models::Work) }
 
           context 'class configuration' do
             subject { described_class }
-            it { should delegate_method(:model_name).to(:base_class) }
-            it { should delegate_method(:human_attribute_name).to(:base_class) }
+            it { is_expected.to delegate_method(:model_name).to(:base_class) }
+            it { is_expected.to delegate_method(:human_attribute_name).to(:base_class) }
           end
 
-          it { should respond_to :work }
-          it { should respond_to :entity }
-          it { should respond_to :publication_name }
-          it { should respond_to :publication_status_of_submission }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :entity }
+          it { is_expected.to respond_to :publication_name }
+          it { is_expected.to respond_to :publication_status_of_submission }
           it { is_expected.not_to be_persisted }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of :publication_name }
+          it { is_expected.to validate_presence_of :publication_name }
           it do
             should validate_inclusion_of(
               :publication_status_of_submission

--- a/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
@@ -34,7 +34,7 @@ module Sipity
           it { should respond_to :entity }
           it { should respond_to :publication_name }
           it { should respond_to :publication_status_of_submission }
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
 
           include Shoulda::Matchers::ActiveModel
           it { should validate_presence_of :publication_name }

--- a/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/publisher_information_form_spec.rb
@@ -39,7 +39,7 @@ module Sipity
           include Shoulda::Matchers::ActiveModel
           it { is_expected.to validate_presence_of :publication_name }
           it do
-            should validate_inclusion_of(
+            is_expected.to validate_inclusion_of(
               :publication_status_of_submission
             ).in_array(subject.possible_publication_status_of_submission)
           end

--- a/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
@@ -28,7 +28,7 @@ module Sipity
           it { should respond_to :other_resources_consulted }
           it { should respond_to :attachments }
           it { should respond_to :files }
-          it { should_not be_persisted }
+          it { is_expected.not_to be_persisted }
 
           it { should delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
           it { should delegate_method(:attachments).to(:attachments_extension) }

--- a/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/research_process_form_spec.rb
@@ -13,25 +13,25 @@ module Sipity
           let(:keywords) { { work: work, requested_by: user, repository: repository } }
           subject { described_class.new(keywords) }
 
-          its(:processing_action_name) { should eq('research_process') }
-          its(:attachment_predicate_name) { should eq('submission_essay') }
-          its(:base_class) { should eq(Models::Work) }
+          its(:processing_action_name) { is_expected.to eq('research_process') }
+          its(:attachment_predicate_name) { is_expected.to eq('submission_essay') }
+          its(:base_class) { is_expected.to eq(Models::Work) }
 
           context 'class configuration' do
             subject { described_class }
-            it { should delegate_method(:model_name).to(:base_class) }
-            it { should delegate_method(:human_attribute_name).to(:base_class) }
+            it { is_expected.to delegate_method(:model_name).to(:base_class) }
+            it { is_expected.to delegate_method(:human_attribute_name).to(:base_class) }
           end
 
-          it { should respond_to :work }
-          it { should respond_to :resources_consulted }
-          it { should respond_to :other_resources_consulted }
-          it { should respond_to :attachments }
-          it { should respond_to :files }
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :resources_consulted }
+          it { is_expected.to respond_to :other_resources_consulted }
+          it { is_expected.to respond_to :attachments }
+          it { is_expected.to respond_to :files }
           it { is_expected.not_to be_persisted }
 
-          it { should delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
-          it { should delegate_method(:attachments).to(:attachments_extension) }
+          it { is_expected.to delegate_method(:at_least_one_file_must_be_attached).to(:attachments_extension) }
+          it { is_expected.to delegate_method(:attachments).to(:attachments_extension) }
 
           include Shoulda::Matchers::ActiveModel
 

--- a/spec/forms/sipity/forms/work_submissions/ulra/submit_advisor_portion_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/submit_advisor_portion_form_spec.rb
@@ -14,9 +14,9 @@ module Sipity
           subject { described_class.new(keywords) }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:requested_by) }
-          it { should validate_presence_of(:work) }
-          it { should validate_acceptance_of(:agree_to_terms_of_deposit) }
+          it { is_expected.to validate_presence_of(:requested_by) }
+          it { is_expected.to validate_presence_of(:work) }
+          it { is_expected.to validate_acceptance_of(:agree_to_terms_of_deposit) }
 
           context '#render' do
             it 'will render HTML safe submission terms and confirmation' do
@@ -25,8 +25,8 @@ module Sipity
             end
           end
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/ulra/submit_completed_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/submit_completed_review_form_spec.rb
@@ -11,13 +11,13 @@ module Sipity
           let(:keywords) { { work: work, repository: repository, requested_by: double, attributes: attributes } }
           subject { described_class.new(keywords) }
 
-          its(:policy_enforcer) { should eq Policies::WorkPolicy }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
 
-          it { should respond_to :work }
+          it { is_expected.to respond_to :work }
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
 
-          its(:render) { should be_html_safe }
+          its(:render) { is_expected.to be_html_safe }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/ulra/submit_for_review_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/submit_for_review_form_spec.rb
@@ -27,8 +27,8 @@ module Sipity
             end
           end
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
         end
       end
     end

--- a/spec/forms/sipity/forms/work_submissions/ulra/submit_student_portion_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/ulra/submit_student_portion_form_spec.rb
@@ -14,9 +14,9 @@ module Sipity
           subject { described_class.new(keywords) }
 
           include Shoulda::Matchers::ActiveModel
-          it { should validate_presence_of(:requested_by) }
-          it { should validate_presence_of(:work) }
-          it { should validate_acceptance_of(:agree_to_terms_of_deposit) }
+          it { is_expected.to validate_presence_of(:requested_by) }
+          it { is_expected.to validate_presence_of(:work) }
+          it { is_expected.to validate_acceptance_of(:agree_to_terms_of_deposit) }
 
           context '#render' do
             it 'will render HTML safe submission terms and confirmation' do
@@ -25,8 +25,8 @@ module Sipity
             end
           end
 
-          it { should delegate_method(:submit).to(:processing_action_form) }
-          its(:template) { should eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
+          it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
+          its(:template) { is_expected.to eq(Forms::STATE_ADVANCING_ACTION_CONFIRMATION_TEMPLATE_NAME) }
         end
       end
     end

--- a/spec/jobs/sipity/jobs/etd/bulk_ingest_job_spec.rb
+++ b/spec/jobs/sipity/jobs/etd/bulk_ingest_job_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Sipity::Jobs::Etd::BulkIngestJob do
     described_class.new(work_area: work_area, repository: repository, work_ingester: work_ingester, exception_handler: exception_handler)
   end
 
-  its(:default_initial_processing_state_name) { should eq('ready_for_ingest') }
-  its(:default_work_area) { should eq('etd') }
-  its(:default_work_ingester) { should respond_to(:call) }
-  its(:default_requested_by) { should be_a(String) }
-  its(:default_search_criteria_builder) { should respond_to(:call) }
-  its(:default_processing_action_name) { should eq('submit_for_ingest') }
-  its(:default_repository) { should respond_to(:find_works_via_search) }
-  its(:default_exception_handler) { should respond_to(:call) }
+  its(:default_initial_processing_state_name) { is_expected.to eq('ready_for_ingest') }
+  its(:default_work_area) { is_expected.to eq('etd') }
+  its(:default_work_ingester) { is_expected.to respond_to(:call) }
+  its(:default_requested_by) { is_expected.to be_a(String) }
+  its(:default_search_criteria_builder) { is_expected.to respond_to(:call) }
+  its(:default_processing_action_name) { is_expected.to eq('submit_for_ingest') }
+  its(:default_repository) { is_expected.to respond_to(:find_works_via_search) }
+  its(:default_exception_handler) { is_expected.to respond_to(:call) }
 
   before { allow(Sipity::Models::Group).to receive(:find_by!).and_return('ETD Ingestor') }
 

--- a/spec/jobs/sipity/jobs/etd/perform_action_for_work_job_spec.rb
+++ b/spec/jobs/sipity/jobs/etd/perform_action_for_work_job_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Sipity::Jobs::Etd::PerformActionForWorkJob do
 
   subject { described_class.new(parameters) }
 
-  its(:attributes) { should eq({}) }
-  its(:default_context_builder) { should respond_to(:call) }
-  its(:default_runner) { should respond_to(:call) }
-  its(:default_processing_action_handler_builder) { should respond_to(:call) }
+  its(:attributes) { is_expected.to eq({}) }
+  its(:default_context_builder) { is_expected.to respond_to(:call) }
+  its(:default_runner) { is_expected.to respond_to(:call) }
+  its(:default_processing_action_handler_builder) { is_expected.to respond_to(:call) }
 
   it 'should expose .call as a convenience method' do
     expect_any_instance_of(described_class).to receive(:call)

--- a/spec/lib/hesburgh/lib/html_scrubber_spec.rb
+++ b/spec/lib/hesburgh/lib/html_scrubber_spec.rb
@@ -4,7 +4,7 @@ require 'hesburgh/lib/html_scrubber'
 RSpec.describe Hesburgh::Lib::HtmlScrubber do
   context '.build_inline_scrubber' do
     subject { described_class.build_inline_scrubber }
-    it { should respond_to(:call) }
+    it { is_expected.to respond_to(:call) }
     {
       nil => '',
       ' ' => '',
@@ -63,7 +63,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
 
   context '.build_inline_with_link_scrubber' do
     subject { described_class.build_inline_with_link_scrubber }
-    it { should respond_to(:call) }
+    it { is_expected.to respond_to(:call) }
     {
       nil => '',
       ' ' => '',
@@ -122,7 +122,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
   end
   context '.build_block_scrubber' do
     subject { described_class.build_block_scrubber }
-    it { should respond_to(:call) }
+    it { is_expected.to respond_to(:call) }
     {
       nil => '',
       ' ' => '',
@@ -144,7 +144,7 @@ RSpec.describe Hesburgh::Lib::HtmlScrubber do
 
   context '.build_meta_tag_scrubber' do
     subject { described_class.build_meta_tag_scrubber }
-    it { should respond_to(:call) }
+    it { is_expected.to respond_to(:call) }
     {
       nil => '',
       ' ' => '',

--- a/spec/mailers/sipity/mailer_builder_spec.rb
+++ b/spec/mailers/sipity/mailer_builder_spec.rb
@@ -5,10 +5,10 @@ module Sipity
   RSpec.describe MailerBuilder do
     context '.build' do
       subject { described_class.build('wookie') { email(name: 'chewbacca', as: :work) } }
-      its(:superclass) { should eq(ActionMailer::Base) }
-      its(:mailer_name) { should eq('sipity/mailers/wookie_mailer') }
-      its(:emails) { should be_a(Array) }
-      its(:instance_methods) { should include(:chewbacca) }
+      its(:superclass) { is_expected.to eq(ActionMailer::Base) }
+      its(:mailer_name) { is_expected.to eq('sipity/mailers/wookie_mailer') }
+      its(:emails) { is_expected.to be_a(Array) }
+      its(:instance_methods) { is_expected.to include(:chewbacca) }
 
       it 'will not build if given the wrong as: option for email configuration' do
         expect do

--- a/spec/mappers/sipity/mappers/etd_mapper_spec.rb
+++ b/spec/mappers/sipity/mappers/etd_mapper_spec.rb
@@ -17,9 +17,9 @@ module Sipity
 
       subject { described_class.new(work, repository: repository) }
 
-      its(:default_repository) { should be_a QueryRepository }
-      its(:default_attribute_map) { should be_a(Hash) }
-      its(:default_mount_data_path) { should be_a(String) }
+      its(:default_repository) { is_expected.to be_a QueryRepository }
+      its(:default_attribute_map) { is_expected.to be_a(Hash) }
+      its(:default_mount_data_path) { is_expected.to be_a(String) }
 
       before do
         allow(I18n).to receive(:t).and_return("TRANSLATED!")

--- a/spec/mappers/sipity/mappers/generic_file_mapper_spec.rb
+++ b/spec/mappers/sipity/mappers/generic_file_mapper_spec.rb
@@ -25,9 +25,9 @@ module Sipity
 
       subject { described_class.new(file, repository: repository) }
 
-      its(:default_repository) { should respond_to :attachment_access_right }
-      its(:default_attribute_map) { should be_a(Hash) }
-      its(:default_mount_data_path) { should be_a(String) }
+      its(:default_repository) { is_expected.to respond_to :attachment_access_right }
+      its(:default_attribute_map) { is_expected.to be_a(Hash) }
+      its(:default_mount_data_path) { is_expected.to be_a(String) }
 
       before do
         allow(file).to receive_message_chain("file.to_file") { sample_file }

--- a/spec/models/sipity/models/access_right_facade_spec.rb
+++ b/spec/models/sipity/models/access_right_facade_spec.rb
@@ -12,17 +12,17 @@ module Sipity
 
       before { allow(Models::AccessRight).to receive(:find_or_initialize_by).and_return(access_right) }
 
-      its(:id) { should eq(object.id) }
-      its(:persisted?) { should eq(object.persisted?) }
-      its(:to_s) { should eq(object.to_s) }
-      its(:entity_id) { should eq(subject.id) }
-      its(:to_param) { should eq(object.to_param) }
-      its(:entity_type) { should eq(Sipity::Models::Work) }
-      its(:access_right_code) { should eq(access_right.access_right_code) }
-      its(:release_date) { should eq(access_right.release_date) }
+      its(:id) { is_expected.to eq(object.id) }
+      its(:persisted?) { is_expected.to eq(object.persisted?) }
+      its(:to_s) { is_expected.to eq(object.to_s) }
+      its(:entity_id) { is_expected.to eq(subject.id) }
+      its(:to_param) { is_expected.to eq(object.to_param) }
+      its(:entity_type) { is_expected.to eq(Sipity::Models::Work) }
+      its(:access_right_code) { is_expected.to eq(access_right.access_right_code) }
+      its(:release_date) { is_expected.to eq(access_right.release_date) }
 
-      its(:model_name) { should eq(work.class.model_name) }
-      its(:human_model_name) { should eq(work.class.model_name.human) }
+      its(:model_name) { is_expected.to eq(work.class.model_name) }
+      its(:human_model_name) { is_expected.to eq(work.class.model_name.human) }
 
       it 'will leverage the access right to translate human_attribute_name' do
         expect(subject.send(:translator)).

--- a/spec/models/sipity/models/access_right_spec.rb
+++ b/spec/models/sipity/models/access_right_spec.rb
@@ -5,11 +5,11 @@ module Sipity
   module Models
     RSpec.describe AccessRight, type: :model do
       subject { described_class }
-      its(:column_names) { should include('entity_id') }
-      its(:column_names) { should include('entity_type') }
-      its(:column_names) { should include('access_right_code') }
-      its(:column_names) { should include('transition_date') }
-      its(:valid_access_right_codes) { should be_a(Array) }
+      its(:column_names) { is_expected.to include('entity_id') }
+      its(:column_names) { is_expected.to include('entity_type') }
+      its(:column_names) { is_expected.to include('access_right_code') }
+      its(:column_names) { is_expected.to include('transition_date') }
+      its(:valid_access_right_codes) { is_expected.to be_a(Array) }
 
       context 'conditionally assign release date' do
         subject { described_class.new(entity_id: 1) }

--- a/spec/models/sipity/models/agent_spec.rb
+++ b/spec/models/sipity/models/agent_spec.rb
@@ -6,13 +6,13 @@ module Sipity
     RSpec.describe Agent, type: :model do
       context 'class configuration' do
         subject { described_class }
-        its(:column_names) { should include('name') }
-        its(:column_names) { should include('description') }
-        its(:column_names) { should include('authentication_token') }
+        its(:column_names) { is_expected.to include('name') }
+        its(:column_names) { is_expected.to include('description') }
+        its(:column_names) { is_expected.to include('authentication_token') }
       end
 
-      it { should have_one(:processing_actor) }
-      it { should have_many(:event_logs) }
+      it { is_expected.to have_one(:processing_actor) }
+      it { is_expected.to have_many(:event_logs) }
 
       context '.create_a_named_agent!' do
         it 'creates a named agent and assigns an authentication_token' do

--- a/spec/models/sipity/models/attachment_spec.rb
+++ b/spec/models/sipity/models/attachment_spec.rb
@@ -7,12 +7,12 @@ module Sipity
       context 'class methods' do
         subject { described_class }
 
-        its(:column_names) { should include('work_id') }
-        its(:column_names) { should include('pid') }
-        its(:column_names) { should include('predicate_name') }
-        its(:column_names) { should include('file_uid') }
-        its(:column_names) { should include('file_name') }
-        its(:primary_key) { should eq('pid') }
+        its(:column_names) { is_expected.to include('work_id') }
+        its(:column_names) { is_expected.to include('pid') }
+        its(:column_names) { is_expected.to include('predicate_name') }
+        its(:column_names) { is_expected.to include('file_uid') }
+        its(:column_names) { is_expected.to include('file_name') }
+        its(:primary_key) { is_expected.to eq('pid') }
       end
 
       context 'instance methods' do

--- a/spec/models/sipity/models/event_log_spec.rb
+++ b/spec/models/sipity/models/event_log_spec.rb
@@ -5,14 +5,14 @@ module Sipity
   module Models
     RSpec.describe EventLog, type: :model do
 
-      it { should belong_to(:user) }
-      it { should belong_to(:entity) }
-      it { should belong_to(:requested_by) }
+      it { is_expected.to belong_to(:user) }
+      it { is_expected.to belong_to(:entity) }
+      it { is_expected.to belong_to(:requested_by) }
 
       # This is a "stop-gap" for validations going forward. Once the database
       # constraint is added this should go away.
-      it { should validate_presence_of(:requested_by_id).on(:create) }
-      it { should validate_presence_of(:requested_by_type).on(:create) }
+      it { is_expected.to validate_presence_of(:requested_by_id).on(:create) }
+      it { is_expected.to validate_presence_of(:requested_by_type).on(:create) }
 
       it 'relies on the database to enforce the requirement of an :event_name' do
         expect do

--- a/spec/models/sipity/models/group_spec.rb
+++ b/spec/models/sipity/models/group_spec.rb
@@ -5,11 +5,11 @@ module Sipity
   module Models
     RSpec.describe Group, type: :model do
       subject { described_class.new }
-      its(:valid?) { should be false }
+      its(:valid?) { is_expected.to be false }
 
-      it { should delegate_method(:to_s).to(:name) }
+      it { is_expected.to delegate_method(:to_s).to(:name) }
 
-      it { should have_many(:event_logs) }
+      it { is_expected.to have_many(:event_logs) }
 
       it 'will have a Group.all_registered_users' do
         expect(described_class.all_registered_users).to be_persisted

--- a/spec/models/sipity/models/notification/email_recipient_spec.rb
+++ b/spec/models/sipity/models/notification/email_recipient_spec.rb
@@ -7,9 +7,9 @@ module Sipity
       RSpec.describe EmailRecipient, type: :model do
         context 'database configuration' do
           subject { described_class }
-          its(:column_names) { should include('role_id') }
-          its(:column_names) { should include('email_id') }
-          its(:column_names) { should include('recipient_strategy') }
+          its(:column_names) { is_expected.to include('role_id') }
+          its(:column_names) { is_expected.to include('email_id') }
+          its(:column_names) { is_expected.to include('recipient_strategy') }
         end
 
         subject { described_class.new }

--- a/spec/models/sipity/models/notification/email_spec.rb
+++ b/spec/models/sipity/models/notification/email_spec.rb
@@ -7,7 +7,7 @@ module Sipity
       RSpec.describe Email, type: :model do
         context 'database configuration' do
           subject { described_class }
-          its(:column_names) { should include('method_name') }
+          its(:column_names) { is_expected.to include('method_name') }
         end
       end
     end

--- a/spec/models/sipity/models/notification/notifiable_context_spec.rb
+++ b/spec/models/sipity/models/notification/notifiable_context_spec.rb
@@ -7,10 +7,10 @@ module Sipity
       RSpec.describe NotifiableContext, type: :model do
         context 'database configuration' do
           subject { described_class }
-          its(:column_names) { should include('scope_for_notification_id') }
-          its(:column_names) { should include('scope_for_notification_type') }
-          its(:column_names) { should include('reason_for_notification') }
-          its(:column_names) { should include('email_id') }
+          its(:column_names) { is_expected.to include('scope_for_notification_id') }
+          its(:column_names) { is_expected.to include('scope_for_notification_type') }
+          its(:column_names) { is_expected.to include('reason_for_notification') }
+          its(:column_names) { is_expected.to include('email_id') }
         end
 
         subject { described_class.new }

--- a/spec/models/sipity/models/notification_spec.rb
+++ b/spec/models/sipity/models/notification_spec.rb
@@ -6,7 +6,7 @@ module Sipity
   module Models
     RSpec.describe Notification do
       subject { described_class }
-      its(:table_name_prefix) { should eq('sipity_notification_') }
+      its(:table_name_prefix) { is_expected.to eq('sipity_notification_') }
     end
   end
 end

--- a/spec/models/sipity/models/processing/actor_spec.rb
+++ b/spec/models/sipity/models/processing/actor_spec.rb
@@ -6,9 +6,9 @@ module Sipity
     module Processing
       RSpec.describe Actor, type: :model do
         subject { described_class }
-        its(:column_names) { should include("proxy_for_id") }
-        its(:column_names) { should include("proxy_for_type") }
-        its(:column_names) { should include("name_of_proxy") }
+        its(:column_names) { is_expected.to include("proxy_for_id") }
+        its(:column_names) { is_expected.to include("proxy_for_type") }
+        its(:column_names) { is_expected.to include("name_of_proxy") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/administrative_scheduled_action_spec.rb
+++ b/spec/models/sipity/models/processing/administrative_scheduled_action_spec.rb
@@ -5,9 +5,9 @@ module Sipity
     module Processing
       RSpec.describe AdministrativeScheduledAction, type: :model do
         subject { described_class }
-        its(:column_names) { should include("scheduled_time") }
-        its(:column_names) { should include("reason") }
-        its(:column_names) { should include("entity_id") }
+        its(:column_names) { is_expected.to include("scheduled_time") }
+        its(:column_names) { is_expected.to include("reason") }
+        its(:column_names) { is_expected.to include("entity_id") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/comment_spec.rb
+++ b/spec/models/sipity/models/processing/comment_spec.rb
@@ -8,12 +8,12 @@ module Sipity
 
         context 'database configuration' do
           subject { described_class }
-          its(:column_names) { should include('entity_id') }
-          its(:column_names) { should include('actor_id') }
-          its(:column_names) { should include('comment') }
-          its(:column_names) { should include('originating_strategy_action_id') }
-          its(:column_names) { should include('originating_strategy_state_id') }
-          its(:column_names) { should include('stale') }
+          its(:column_names) { is_expected.to include('entity_id') }
+          its(:column_names) { is_expected.to include('actor_id') }
+          its(:column_names) { is_expected.to include('comment') }
+          its(:column_names) { is_expected.to include('originating_strategy_action_id') }
+          its(:column_names) { is_expected.to include('originating_strategy_state_id') }
+          its(:column_names) { is_expected.to include('stale') }
         end
 
         subject { described_class.new }

--- a/spec/models/sipity/models/processing/entity_action_register_spec.rb
+++ b/spec/models/sipity/models/processing/entity_action_register_spec.rb
@@ -7,19 +7,19 @@ module Sipity
       RSpec.describe EntityActionRegister, type: :model do
         context 'class configuration' do
           subject { described_class }
-          its(:column_names) { should include("strategy_action_id") }
-          its(:column_names) { should include("entity_id") }
-          its(:column_names) { should include("on_behalf_of_actor_id") }
-          its(:column_names) { should include("requested_by_actor_id") }
-          its(:column_names) { should include("subject_id") }
-          its(:column_names) { should include("subject_type") }
+          its(:column_names) { is_expected.to include("strategy_action_id") }
+          its(:column_names) { is_expected.to include("entity_id") }
+          its(:column_names) { is_expected.to include("on_behalf_of_actor_id") }
+          its(:column_names) { is_expected.to include("requested_by_actor_id") }
+          its(:column_names) { is_expected.to include("subject_id") }
+          its(:column_names) { is_expected.to include("subject_type") }
         end
 
         context 'conversions methods' do
           subject { described_class.new }
-          it { should delegate_method(:proxy_for).to(:entity) }
-          it { should respond_to :to_processing_action }
-          it { should respond_to :to_processing_entity }
+          it { is_expected.to delegate_method(:proxy_for).to(:entity) }
+          it { is_expected.to respond_to :to_processing_action }
+          it { is_expected.to respond_to :to_processing_entity }
         end
       end
     end

--- a/spec/models/sipity/models/processing/entity_spec.rb
+++ b/spec/models/sipity/models/processing/entity_spec.rb
@@ -6,17 +6,17 @@ module Sipity
     module Processing
       RSpec.describe Entity, type: :model do
         subject { described_class }
-        its(:column_names) { should include("proxy_for_id") }
-        its(:column_names) { should include("proxy_for_type") }
-        its(:column_names) { should include("strategy_id") }
-        its(:column_names) { should include("strategy_state_id") }
+        its(:column_names) { is_expected.to include("proxy_for_id") }
+        its(:column_names) { is_expected.to include("proxy_for_type") }
+        its(:column_names) { is_expected.to include("strategy_id") }
+        its(:column_names) { is_expected.to include("strategy_state_id") }
 
         context 'an instance' do
           subject { described_class.new }
-          it { should respond_to(:processing_state) }
-          it { should respond_to(:processing_strategy) }
-          it { should delegate_method(:strategy_state_name).to(:strategy_state).as(:name) }
-          it { should delegate_method(:strategy_name).to(:strategy).as(:name) }
+          it { is_expected.to respond_to(:processing_state) }
+          it { is_expected.to respond_to(:processing_strategy) }
+          it { is_expected.to delegate_method(:strategy_state_name).to(:strategy_state).as(:name) }
+          it { is_expected.to delegate_method(:strategy_name).to(:strategy).as(:name) }
         end
       end
     end

--- a/spec/models/sipity/models/processing/entity_specific_responsibility_spec.rb
+++ b/spec/models/sipity/models/processing/entity_specific_responsibility_spec.rb
@@ -6,9 +6,9 @@ module Sipity
     module Processing
       RSpec.describe EntitySpecificResponsibility, type: :model do
         subject { described_class }
-        its(:column_names) { should include('strategy_role_id') }
-        its(:column_names) { should include('entity_id') }
-        its(:column_names) { should include('actor_id') }
+        its(:column_names) { is_expected.to include('strategy_role_id') }
+        its(:column_names) { is_expected.to include('entity_id') }
+        its(:column_names) { is_expected.to include('actor_id') }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_action_analogue_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_analogue_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyActionAnalogue, type: :model do
         subject { described_class }
-        its(:column_names) { should include("strategy_action_id") }
-        its(:column_names) { should include("analogous_to_strategy_action_id") }
+        its(:column_names) { is_expected.to include("strategy_action_id") }
+        its(:column_names) { is_expected.to include("analogous_to_strategy_action_id") }
 
         let(:an_action) { StrategyAction.new(id: 1) }
         let(:another_action) { StrategyAction.new(id: 2) }

--- a/spec/models/sipity/models/processing/strategy_action_prerequisite_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_prerequisite_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyActionPrerequisite, type: :model do
         subject { described_class }
-        its(:column_names) { should include("guarded_strategy_action_id") }
-        its(:column_names) { should include("prerequisite_strategy_action_id") }
+        its(:column_names) { is_expected.to include("guarded_strategy_action_id") }
+        its(:column_names) { is_expected.to include("prerequisite_strategy_action_id") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_action_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_action_spec.rb
@@ -7,11 +7,11 @@ module Sipity
       RSpec.describe StrategyAction, type: :model do
         context 'database configuration' do
           subject { described_class }
-          its(:column_names) { should include('strategy_id') }
-          its(:column_names) { should include('resulting_strategy_state_id') }
-          its(:column_names) { should include('name') }
-          its(:column_names) { should include('action_type') }
-          its(:column_names) { should include('allow_repeat_within_current_state') }
+          its(:column_names) { is_expected.to include('strategy_id') }
+          its(:column_names) { is_expected.to include('resulting_strategy_state_id') }
+          its(:column_names) { is_expected.to include('name') }
+          its(:column_names) { is_expected.to include('action_type') }
+          its(:column_names) { is_expected.to include('allow_repeat_within_current_state') }
         end
 
         it 'will include debug as resourceful' do
@@ -28,11 +28,11 @@ module Sipity
           end
         end
 
-        its(:default_action_type) { should be_a(String) }
+        its(:default_action_type) { is_expected.to be_a(String) }
 
-        it { should respond_to(:resourceful_action?) }
-        it { should respond_to(:state_advancing_action?) }
-        it { should respond_to(:enrichment_action?) }
+        it { is_expected.to respond_to(:resourceful_action?) }
+        it { is_expected.to respond_to(:state_advancing_action?) }
+        it { is_expected.to respond_to(:enrichment_action?) }
 
         context 'set action type' do
           it 'will set the action type if none is specified' do

--- a/spec/models/sipity/models/processing/strategy_responsibility_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_responsibility_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyResponsibility, type: :model do
         subject { described_class }
-        its(:column_names) { should include('actor_id') }
-        its(:column_names) { should include('strategy_role_id') }
+        its(:column_names) { is_expected.to include('actor_id') }
+        its(:column_names) { is_expected.to include('strategy_role_id') }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_role_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_role_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyRole, type: :model do
         subject { described_class }
-        its(:column_names) { should include('strategy_id') }
-        its(:column_names) { should include('role_id') }
+        its(:column_names) { is_expected.to include('strategy_id') }
+        its(:column_names) { is_expected.to include('role_id') }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_spec.rb
@@ -6,7 +6,7 @@ module Sipity
     module Processing
       RSpec.describe Strategy, type: :model do
         subject { described_class }
-        its(:column_names) { should include('name') }
+        its(:column_names) { is_expected.to include('name') }
 
         context '#initial_strategy_state' do
           subject { described_class.new(name: 'ETD Workflow') }

--- a/spec/models/sipity/models/processing/strategy_state_action_permission_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_action_permission_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyStateActionPermission, type: :model do
         subject { described_class }
-        its(:column_names) { should include("strategy_role_id") }
-        its(:column_names) { should include("strategy_state_action_id") }
+        its(:column_names) { is_expected.to include("strategy_role_id") }
+        its(:column_names) { is_expected.to include("strategy_state_action_id") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_state_action_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_action_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyStateAction, type: :model do
         subject { described_class }
-        its(:column_names) { should include("originating_strategy_state_id") }
-        its(:column_names) { should include("strategy_action_id") }
+        its(:column_names) { is_expected.to include("originating_strategy_state_id") }
+        its(:column_names) { is_expected.to include("strategy_action_id") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_state_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_state_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     module Processing
       RSpec.describe StrategyState, type: :model do
         subject { described_class }
-        its(:column_names) { should include("strategy_id") }
-        its(:column_names) { should include("name") }
+        its(:column_names) { is_expected.to include("strategy_id") }
+        its(:column_names) { is_expected.to include("name") }
       end
     end
   end

--- a/spec/models/sipity/models/processing/strategy_usage_spec.rb
+++ b/spec/models/sipity/models/processing/strategy_usage_spec.rb
@@ -7,9 +7,9 @@ module Sipity
       RSpec.describe StrategyUsage, type: :model do
         context 'database configuration' do
           subject { described_class }
-          its(:column_names) { should include('usage_id') }
-          its(:column_names) { should include('usage_type') }
-          its(:column_names) { should include('strategy_id') }
+          its(:column_names) { is_expected.to include('usage_id') }
+          its(:column_names) { is_expected.to include('usage_type') }
+          its(:column_names) { is_expected.to include('strategy_id') }
         end
       end
     end

--- a/spec/models/sipity/models/role_spec.rb
+++ b/spec/models/sipity/models/role_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     RSpec.describe Role, type: :model do
       context 'class methods' do
         subject { described_class }
-        its(:column_names) { should include('name') }
-        its(:column_names) { should include('description') }
+        its(:column_names) { is_expected.to include('name') }
+        its(:column_names) { is_expected.to include('description') }
         context '.[]' do
           let(:valid_name) { described_class.valid_names.first }
           it 'will find the named role' do

--- a/spec/models/sipity/models/submission_window_spec.rb
+++ b/spec/models/sipity/models/submission_window_spec.rb
@@ -6,16 +6,16 @@ module Sipity
     RSpec.describe SubmissionWindow, type: :model do
       context 'database configuration' do
         subject { described_class }
-        its(:column_names) { should include('work_area_id') }
-        its(:column_names) { should include('slug') }
+        its(:column_names) { is_expected.to include('work_area_id') }
+        its(:column_names) { is_expected.to include('slug') }
       end
 
       subject { described_class.new(slug: 'the-slug') }
 
-      it { should respond_to :processing_strategy }
-      it { should respond_to :processing_state }
-      it { should respond_to :work_area_slug }
-      it { should respond_to :work_area_partial_suffix }
+      it { is_expected.to respond_to :processing_strategy }
+      it { is_expected.to respond_to :processing_state }
+      it { is_expected.to respond_to :work_area_slug }
+      it { is_expected.to respond_to :work_area_partial_suffix }
 
       it 'will have many .submission_window_work_types' do
         expect(subject.submission_window_work_types).to be_a(ActiveRecord::Relation)
@@ -36,7 +36,7 @@ module Sipity
         end
       end
 
-      its(:to_s) { should eq(subject.slug) }
+      its(:to_s) { is_expected.to eq(subject.slug) }
 
       context '#to_processing_entity' do
         it 'will raise an exception if one has not been created' do

--- a/spec/models/sipity/models/submission_window_work_type_spec.rb
+++ b/spec/models/sipity/models/submission_window_work_type_spec.rb
@@ -6,8 +6,8 @@ module Sipity
     RSpec.describe SubmissionWindowWorkType, type: :model do
       context 'database configuration' do
         subject { described_class }
-        its(:column_names) { should include('submission_window_id') }
-        its(:column_names) { should include('work_type_id') }
+        its(:column_names) { is_expected.to include('submission_window_id') }
+        its(:column_names) { is_expected.to include('work_type_id') }
       end
     end
   end

--- a/spec/models/sipity/models/work_area_spec.rb
+++ b/spec/models/sipity/models/work_area_spec.rb
@@ -6,10 +6,10 @@ module Sipity
     RSpec.describe WorkArea, type: :model do
       context 'database configuration' do
         subject { described_class }
-        its(:column_names) { should include('slug') }
-        its(:column_names) { should include('partial_suffix') }
-        its(:column_names) { should include('demodulized_class_prefix_name') }
-        its(:column_names) { should include('name') }
+        its(:column_names) { is_expected.to include('slug') }
+        its(:column_names) { is_expected.to include('partial_suffix') }
+        its(:column_names) { is_expected.to include('demodulized_class_prefix_name') }
+        its(:column_names) { is_expected.to include('name') }
       end
 
       subject { described_class.new }
@@ -23,8 +23,8 @@ module Sipity
         expect(subject.association(:strategy_usage)).to be_a(ActiveRecord::Associations::HasOneAssociation)
       end
 
-      it { should respond_to :processing_strategy }
-      it { should respond_to :processing_state }
+      it { is_expected.to respond_to :processing_strategy }
+      it { is_expected.to respond_to :processing_state }
 
       context '#to_processing_entity' do
         it 'will raise an exception if one has not been created' do

--- a/spec/models/sipity/models/work_redirect_strategy_spec.rb
+++ b/spec/models/sipity/models/work_redirect_strategy_spec.rb
@@ -4,11 +4,11 @@ require 'sipity/models/work'
 RSpec.describe Sipity::Models::WorkRedirectStrategy, type: :model do
   context 'class configuration' do
     subject { described_class }
-    its(:table_name) { should eq('sipity_work_redirect_strategies') }
+    its(:table_name) { is_expected.to eq('sipity_work_redirect_strategies') }
   end
   context 'an instance' do
     subject { described_class.new }
-    it { should belong_to :work }
-    it { should delegate_method(:to_work_area).to(:work).as(:work_area) }
+    it { is_expected.to belong_to :work }
+    it { is_expected.to delegate_method(:to_work_area).to(:work).as(:work_area) }
   end
 end

--- a/spec/models/sipity/models/work_spec.rb
+++ b/spec/models/sipity/models/work_spec.rb
@@ -8,9 +8,9 @@ module Sipity
 
       context 'database columns' do
         subject { Work }
-        its(:column_names) { should include('work_type') }
+        its(:column_names) { is_expected.to include('work_type') }
         its(:column_names) { is_expected.not_to include('work_publication_strategy') }
-        its(:column_names) { should include('title') }
+        its(:column_names) { is_expected.to include('title') }
       end
 
       it 'will sanitize its title' do
@@ -18,14 +18,14 @@ module Sipity
         expect(subject.title).to eq('Hello')
       end
 
-      its(:to_s) { should eq(subject.title) }
+      its(:to_s) { is_expected.to eq(subject.title) }
 
-      it { should have_many :work_redirect_strategies }
-      it { should respond_to :processing_strategy }
-      it { should respond_to :processing_state }
-      it { should respond_to :work_area }
-      it { should respond_to :submission_window }
-      it { should delegate_method(:transition_date).to(:access_right).with_prefix }
+      it { is_expected.to have_many :work_redirect_strategies }
+      it { is_expected.to respond_to :processing_strategy }
+      it { is_expected.to respond_to :processing_state }
+      it { is_expected.to respond_to :work_area }
+      it { is_expected.to respond_to :submission_window }
+      it { is_expected.to delegate_method(:transition_date).to(:access_right).with_prefix }
 
       context '#to_processing_entity' do
         it 'will raise an exception if one has not been created' do

--- a/spec/models/sipity/models/work_spec.rb
+++ b/spec/models/sipity/models/work_spec.rb
@@ -9,7 +9,7 @@ module Sipity
       context 'database columns' do
         subject { Work }
         its(:column_names) { should include('work_type') }
-        its(:column_names) { should_not include('work_publication_strategy') }
+        its(:column_names) { is_expected.not_to include('work_publication_strategy') }
         its(:column_names) { should include('title') }
       end
 

--- a/spec/models/sipity/models/work_submission_spec.rb
+++ b/spec/models/sipity/models/work_submission_spec.rb
@@ -6,9 +6,9 @@ module Sipity
     RSpec.describe WorkSubmission, type: :model do
       context 'database configuration' do
         subject { described_class }
-        its(:column_names) { should include('work_id') }
-        its(:column_names) { should include('work_area_id') }
-        its(:column_names) { should include('submission_window_id') }
+        its(:column_names) { is_expected.to include('work_id') }
+        its(:column_names) { is_expected.to include('work_area_id') }
+        its(:column_names) { is_expected.to include('submission_window_id') }
       end
     end
   end

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -4,7 +4,7 @@ require 'sipity'
 
 RSpec.describe Sipity do
   subject { described_class }
-  its(:table_name_prefix) { should eq('sipity_') }
+  its(:table_name_prefix) { is_expected.to eq('sipity_') }
 
   it 'exposes #t as a helper method for translations' do
     keywords = { scope: 'hello', subject: 'world' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ describe User do
 
   subject { User.new(email: 'user@example.com', name: "Hello Somebody") }
 
-  it { should respond_to(:email) }
+  it { is_expected.to respond_to(:email) }
 
   it { expect(User.create!(username: 'bogus', email: '')).to callback(:call_on_create_user_service).after(:commit) }
 
@@ -11,6 +11,6 @@ describe User do
     expect { User.create!(username: 'two', email: '') }.to_not raise_error
   end
 
-  its(:to_s) { should eq subject.name }
+  its(:to_s) { is_expected.to eq subject.name }
 
 end

--- a/spec/parameters/sipity/parameters/action_set_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/action_set_parameter_spec.rb
@@ -8,12 +8,12 @@ module Sipity
       let(:collection) { double(any?: true, present?: true) }
       let(:entity) { double(processing_state: 'processing_state') }
       subject { described_class.new(identifier: identifier, collection: collection, entity: entity) }
-      its(:identifier) { should eq identifier }
-      its(:collection) { should eq [collection] }
-      its(:processing_state) { should eq entity.processing_state }
-      its(:entity) { should eq entity }
-      its(:any?) { should eq collection.any? }
-      its(:present?) { should eq collection.present? }
+      its(:identifier) { is_expected.to eq identifier }
+      its(:collection) { is_expected.to eq [collection] }
+      its(:processing_state) { is_expected.to eq entity.processing_state }
+      its(:entity) { is_expected.to eq entity }
+      its(:any?) { is_expected.to eq collection.any? }
+      its(:present?) { is_expected.to eq collection.present? }
     end
   end
 end

--- a/spec/parameters/sipity/parameters/entity_with_additional_attributes_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/entity_with_additional_attributes_parameter_spec.rb
@@ -13,9 +13,9 @@ module Sipity
       end
       let(:entity) { double }
       subject { described_class.new(additional_attributes: additional_attributes, entity: entity) }
-      its(:entity) { should eq entity }
-      its(:any?) { should be_truthy }
-      its(:count) { should eq(2) }
+      its(:entity) { is_expected.to eq entity }
+      its(:any?) { is_expected.to be_truthy }
+      its(:count) { is_expected.to eq(2) }
     end
   end
 end

--- a/spec/parameters/sipity/parameters/entity_with_comments_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/entity_with_comments_parameter_spec.rb
@@ -7,8 +7,8 @@ module Sipity
       let(:comments) { double }
       let(:entity) { double }
       subject { described_class.new(comments: comments, entity: entity) }
-      its(:entity) { should eq entity }
-      its(:comments) { should eq comments }
+      its(:entity) { is_expected.to eq entity }
+      its(:comments) { is_expected.to eq comments }
     end
   end
 end

--- a/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/handled_response_parameter_spec.rb
@@ -9,11 +9,11 @@ module Sipity
       let(:template) { 'named/template' }
 
       subject { described_class.new(status: status, object: object, template: template) }
-      its(:status) { should eq status }
-      its(:object) { should eq object }
-      its(:template) { should eq template }
+      its(:status) { is_expected.to eq status }
+      its(:object) { is_expected.to eq object }
+      its(:template) { is_expected.to eq template }
 
-      it { should delegate_method(:errors).to(:object) }
+      it { is_expected.to delegate_method(:errors).to(:object) }
 
       it 'will raise to initialize if the status is not a symbol' do
         expect { described_class.new(status: double, object: object, template: template) }.

--- a/spec/parameters/sipity/parameters/notification_context_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/notification_context_parameter_spec.rb
@@ -12,11 +12,11 @@ module Sipity
         described_class.new(scope: scope, the_thing: the_thing, requested_by: requested_by, on_behalf_of: on_behalf_of)
       end
 
-      its(:scope) { should eq scope }
-      its(:the_thing) { should eq the_thing }
-      its(:reason) { should be_a String }
-      it { should respond_to :requested_by }
-      it { should respond_to :on_behalf_of }
+      its(:scope) { is_expected.to eq scope }
+      its(:the_thing) { is_expected.to eq the_thing }
+      its(:reason) { is_expected.to be_a String }
+      it { is_expected.to respond_to :requested_by }
+      it { is_expected.to respond_to :on_behalf_of }
 
       it 'will set on_behalf_of to requested_by if on_behalf_of is falsey' do
         subject = described_class.new(scope: scope, the_thing: the_thing, requested_by: 'someone', on_behalf_of: on_behalf_of)

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -7,28 +7,28 @@ module Sipity
 
       context 'configuration' do
         subject { described_class }
-        its(:default_order) { should be_a(String) }
-        its(:order_options_for_select) { should be_a(Array) }
+        its(:default_order) { is_expected.to be_a(String) }
+        its(:order_options_for_select) { is_expected.to be_a(Array) }
       end
 
       context 'instance' do
         subject { described_class.new }
-        it { should respond_to(:user) }
-        it { should respond_to(:processing_state) }
-        it { should respond_to(:order) }
-        it { should respond_to(:proxy_for_type) }
-        it { should respond_to(:work_area) }
-        it { should respond_to(:page) }
-        it { should respond_to(:per) }
+        it { is_expected.to respond_to(:user) }
+        it { is_expected.to respond_to(:processing_state) }
+        it { is_expected.to respond_to(:order) }
+        it { is_expected.to respond_to(:proxy_for_type) }
+        it { is_expected.to respond_to(:work_area) }
+        it { is_expected.to respond_to(:page) }
+        it { is_expected.to respond_to(:per) }
       end
 
-      its(:default_page) { should eq(1) }
-      its(:default_per) { should eq(15) }
-      its(:default_user) { should eq(nil) }
-      its(:default_proxy_for_type) { should eq(Models::Work) }
-      its(:default_processing_state) { should eq(nil) }
-      its(:default_work_area) { should eq(nil) }
-      its(:default_order) { should eq('title'.freeze) }
+      its(:default_page) { is_expected.to eq(1) }
+      its(:default_per) { is_expected.to eq(15) }
+      its(:default_user) { is_expected.to eq(nil) }
+      its(:default_proxy_for_type) { is_expected.to eq(Models::Work) }
+      its(:default_processing_state) { is_expected.to eq(nil) }
+      its(:default_work_area) { is_expected.to eq(nil) }
+      its(:default_order) { is_expected.to eq('title'.freeze) }
 
       it 'will fallback on default order if an invalid order is given' do
         subject = described_class.new(order: 'chicken-sandwich')

--- a/spec/policies/sipity/policies/processing/processing_entity_policy_spec.rb
+++ b/spec/policies/sipity/policies/processing/processing_entity_policy_spec.rb
@@ -27,7 +27,7 @@ module Sipity
 
         context 'default configuration' do
           subject { described_class.new(user, work) }
-          its(:repository) { should respond_to(:authorized_for_processing?) }
+          its(:repository) { is_expected.to respond_to(:authorized_for_processing?) }
         end
       end
     end

--- a/spec/policies/sipity/policies/work_policy_spec.rb
+++ b/spec/policies/sipity/policies/work_policy_spec.rb
@@ -15,19 +15,19 @@ module Sipity
 
       context 'for a non-authenticated user' do
         let(:user) { nil }
-        its(:create?) { should eq(false) }
+        its(:create?) { is_expected.to eq(false) }
       end
 
       context 'for an authenticated user' do
         context 'with an new work' do
           before { allow(work).to receive(:persisted?).and_return(false) }
-          its(:create?) { should eq(true) }
+          its(:create?) { is_expected.to eq(true) }
         end
         context 'with an existing work' do
           before do
             allow(work).to receive(:persisted?).and_return(true)
           end
-          its(:create?) { should eq(false) }
+          its(:create?) { is_expected.to eq(false) }
         end
       end
     end

--- a/spec/presenters/sipity/controllers/additional_attribute_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/additional_attribute_presenter_spec.rb
@@ -8,10 +8,10 @@ module Sipity
       let(:context) { PresenterHelper::Context.new }
       subject { described_class.new(context, additional_attribute: additional_attribute) }
 
-      it { should delegate_method(:key).to(:additional_attribute) }
-      it { should delegate_method(:values).to(:additional_attribute) }
-      its(:label) { should be_a(String) }
-      its(:render_list_of_values) { should be_html_safe }
+      it { is_expected.to delegate_method(:key).to(:additional_attribute) }
+      it { is_expected.to delegate_method(:values).to(:additional_attribute) }
+      its(:label) { is_expected.to be_a(String) }
+      its(:render_list_of_values) { is_expected.to be_html_safe }
 
       it 'will translate the key into a label' do
         expect(TranslationAssistant).to receive(:call)

--- a/spec/presenters/sipity/controllers/additional_attribute_set_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/additional_attribute_set_presenter_spec.rb
@@ -7,7 +7,7 @@ module Sipity
       let(:additional_attribute_set) { double(additional_attributes: double) }
       let(:context) { PresenterHelper::Context.new }
       subject { described_class.new(context, additional_attribute_set: additional_attribute_set) }
-      it { should delegate_method(:additional_attributes).to(:additional_attribute_set) }
+      it { is_expected.to delegate_method(:additional_attributes).to(:additional_attribute_set) }
     end
   end
 end

--- a/spec/presenters/sipity/controllers/collaborator_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/collaborator_presenter_spec.rb
@@ -10,8 +10,8 @@ module Sipity
       let(:collaborator) { double(name: 'The Name', role: 'The Role') }
       subject { described_class.new(context, collaborator: collaborator) }
 
-      it { should delegate_method(:name).to(:collaborator) }
-      it { should delegate_method(:role).to(:collaborator) }
+      it { is_expected.to delegate_method(:name).to(:collaborator) }
+      it { is_expected.to delegate_method(:role).to(:collaborator) }
 
       it 'exposes a label that takes an identifier' do
         expect(subject.label('role')).to eq('Role')

--- a/spec/presenters/sipity/controllers/comment_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/comment_presenter_spec.rb
@@ -5,8 +5,8 @@ module Sipity
       let(:comment) { double(comment: 'Hello World', name_of_commentor: 'My Name') }
       subject { described_class.new(context, comment: comment) }
 
-      its(:message) { should eq(comment.comment) }
-      its(:name_of_commentor) { should eq(comment.name_of_commentor) }
+      its(:message) { is_expected.to eq(comment.comment) }
+      its(:name_of_commentor) { is_expected.to eq(comment.name_of_commentor) }
     end
   end
 end

--- a/spec/presenters/sipity/controllers/composable_elements/processing_actions_composer_spec.rb
+++ b/spec/presenters/sipity/controllers/composable_elements/processing_actions_composer_spec.rb
@@ -14,10 +14,10 @@ module Sipity
 
         subject { described_class.new(user: user, entity: entity, repository: repository) }
 
-        its(:default_repository) { should respond_to :scope_permitted_entity_strategy_actions_for_current_state }
-        its(:default_repository) { should respond_to :scope_strategy_actions_that_are_prerequisites }
-        its(:default_repository) { should respond_to :scope_strategy_actions_with_incomplete_prerequisites }
-        its(:default_action_names_to_skip) { should eq(['show']) }
+        its(:default_repository) { is_expected.to respond_to :scope_permitted_entity_strategy_actions_for_current_state }
+        its(:default_repository) { is_expected.to respond_to :scope_strategy_actions_that_are_prerequisites }
+        its(:default_repository) { is_expected.to respond_to :scope_strategy_actions_with_incomplete_prerequisites }
+        its(:default_action_names_to_skip) { is_expected.to eq(['show']) }
 
         it 'will omit the skipped action names' do
           subject = described_class.new(

--- a/spec/presenters/sipity/controllers/creator_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/creator_presenter_spec.rb
@@ -10,7 +10,7 @@ module Sipity
       let(:work) { Models::Work.new(id: '1') }
       subject { described_class.new(context, work_submission: work, creator: creator) }
 
-      its(:name) { should eq(creator.to_s) }
+      its(:name) { is_expected.to eq(creator.to_s) }
 
       it 'will translate the identified label' do
         expect(TranslationAssistant).to receive(:call).with(scope: :predicates, object: 'name', subject: work, predicate: :label).

--- a/spec/presenters/sipity/controllers/current_comments_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/current_comments_presenter_spec.rb
@@ -9,9 +9,9 @@ module Sipity
       let(:current_comments) { Parameters::EntityWithCommentsParameter.new(entity: double, comments: [double, double]) }
       subject { CurrentCommentsPresenter.new(context, current_comments: current_comments) }
 
-      its(:comments) { should eq(current_comments.comments) }
-      its(:path_to_all_comments) { should be_a(String) }
-      its(:multiple_comments?) { should == true }
+      its(:comments) { is_expected.to eq(current_comments.comments) }
+      its(:path_to_all_comments) { is_expected.to be_a(String) }
+      its(:multiple_comments?) { is_expected.to eq(true) }
     end
 
     RSpec.describe CurrentCommentsPresenter do
@@ -19,7 +19,7 @@ module Sipity
       let(:current_comments) { Parameters::EntityWithCommentsParameter.new(entity: double, comments: [double]) }
       subject { CurrentCommentsPresenter.new(context, current_comments: current_comments) }
 
-      its(:multiple_comments?) { should == false }
+      its(:multiple_comments?) { is_expected.to eq(false) }
     end
   end
 end

--- a/spec/presenters/sipity/controllers/debug_actor_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_actor_presenter_spec.rb
@@ -13,11 +13,11 @@ module Sipity
         described_class.new(context, debug_actor: actor)
       end
 
-      its(:name) { should eq(actor.proxy_for.to_s) }
-      it { should delegate_method(:proxy_for_type).to(:debug_actor) }
-      it { should delegate_method(:proxy_for_id).to(:debug_actor) }
-      it { should delegate_method(:actor_processing_relationship).to(:debug_actor) }
-      it { should delegate_method(:actor_id).to(:debug_actor).as(:id) }
+      its(:name) { is_expected.to eq(actor.proxy_for.to_s) }
+      it { is_expected.to delegate_method(:proxy_for_type).to(:debug_actor) }
+      it { is_expected.to delegate_method(:proxy_for_id).to(:debug_actor) }
+      it { is_expected.to delegate_method(:actor_processing_relationship).to(:debug_actor) }
+      it { is_expected.to delegate_method(:actor_id).to(:debug_actor).as(:id) }
 
       it 'will guard the interface of the actor' do
         expect { described_class.new(context, debug_actor: double) }.to raise_error(Exceptions::InterfaceExpectationError)

--- a/spec/presenters/sipity/controllers/debug_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_presenter_spec.rb
@@ -14,14 +14,14 @@ module Sipity
         described_class.new(context, repository: repository, view_object: view_object)
       end
 
-      its(:object_name) { should eq(view_object.to_s) }
-      its(:processing_entity_id) { should eq(processing_entity.id) }
-      its(:processing_entity_strategy_name) { should eq(processing_entity.strategy_name) }
-      its(:processing_entity_strategy_id) { should eq(processing_entity.strategy_id) }
-      its(:processing_entity_strategy_state_name) { should eq(processing_entity.strategy_state_name) }
-      its(:processing_entity_strategy_state_id) { should eq(processing_entity.strategy_state_id) }
+      its(:object_name) { is_expected.to eq(view_object.to_s) }
+      its(:processing_entity_id) { is_expected.to eq(processing_entity.id) }
+      its(:processing_entity_strategy_name) { is_expected.to eq(processing_entity.strategy_name) }
+      its(:processing_entity_strategy_id) { is_expected.to eq(processing_entity.strategy_id) }
+      its(:processing_entity_strategy_state_name) { is_expected.to eq(processing_entity.strategy_state_name) }
+      its(:processing_entity_strategy_state_id) { is_expected.to eq(processing_entity.strategy_state_id) }
 
-      its(:default_repository) { should respond_to(:scope_roles_associated_with_the_given_entity) }
+      its(:default_repository) { is_expected.to respond_to(:scope_roles_associated_with_the_given_entity) }
 
       context '#debug_roles' do
         let(:role) { double }

--- a/spec/presenters/sipity/controllers/debug_role_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_role_presenter_spec.rb
@@ -14,10 +14,10 @@ module Sipity
         described_class.new(context, debug_role: role)
       end
 
-      it { should delegate_method(:name).to(:debug_role) }
-      it { should delegate_method(:repository).to(:debug_role) }
-      it { should delegate_method(:to_processing_entity).to(:debug_role) }
-      it { should delegate_method(:role_id).to(:debug_role).as(:id) }
+      it { is_expected.to delegate_method(:name).to(:debug_role) }
+      it { is_expected.to delegate_method(:repository).to(:debug_role) }
+      it { is_expected.to delegate_method(:to_processing_entity).to(:debug_role) }
+      it { is_expected.to delegate_method(:role_id).to(:debug_role).as(:id) }
 
       it 'will guard the interface of the role' do
         expect { described_class.new(context, debug_role: double) }.to raise_error(Exceptions::InterfaceExpectationError)

--- a/spec/presenters/sipity/controllers/enrichment_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/enrichment_action_presenter_spec.rb
@@ -23,21 +23,21 @@ module Sipity
         )
       end
 
-      its(:default_repository) { should respond_to(:scope_statetegy_actions_that_have_occurred) }
-      its(:default_repository) { should respond_to(:scope_strategy_actions_that_are_prerequisites) }
+      its(:default_repository) { is_expected.to respond_to(:scope_statetegy_actions_that_have_occurred) }
+      its(:default_repository) { is_expected.to respond_to(:scope_strategy_actions_that_are_prerequisites) }
 
-      its(:identifier) { should eq(enrichment_action_set.identifier) }
-      its(:entity) { should eq(enrichment_action_set.entity) }
-      its(:action_name) { should eq(enrichment_action.name) }
-      its(:path) { should be_a(String) }
+      its(:identifier) { is_expected.to eq(enrichment_action_set.identifier) }
+      its(:entity) { is_expected.to eq(enrichment_action_set.entity) }
+      its(:action_name) { is_expected.to eq(enrichment_action.name) }
+      its(:path) { is_expected.to be_a(String) }
 
       it 'will delegate #label to the TranslationAssistant' do
         expect(TranslationAssistant).to receive(:call)
         subject.label
       end
 
-      it { should respond_to(:complete?) }
-      it { should respond_to(:a_prerequisite?) }
+      it { is_expected.to respond_to(:complete?) }
+      it { is_expected.to respond_to(:a_prerequisite?) }
 
       it 'will be a prerequisite if the associated action is a prerequisite' do
         allow(repository).to receive(:scope_strategy_actions_that_are_prerequisites).
@@ -53,13 +53,13 @@ module Sipity
             with(entity: entity, pluck: :id).and_return([enrichment_action.id])
         end
 
-        its(:completion_mark_if_applicable) { should be_present }
-        its(:completion_mark_if_applicable) { should be_html_safe }
-        its(:todo_checkbox_element) { should be_html_safe }
-        its(:todo_checkbox_element) { should have_tag('span.circle.done') }
-        its(:todo_checkbox_element) { should have_tag('svg') }
-        its(:state) { should eq('done') }
-        its(:complete?) { should be_truthy }
+        its(:completion_mark_if_applicable) { is_expected.to be_present }
+        its(:completion_mark_if_applicable) { is_expected.to be_html_safe }
+        its(:todo_checkbox_element) { is_expected.to be_html_safe }
+        its(:todo_checkbox_element) { is_expected.to have_tag('span.circle.done') }
+        its(:todo_checkbox_element) { is_expected.to have_tag('svg') }
+        its(:state) { is_expected.to eq('done') }
+        its(:complete?) { is_expected.to be_truthy }
       end
 
       context 'when incomplete' do
@@ -70,12 +70,12 @@ module Sipity
         end
 
         its(:completion_mark_if_applicable) { is_expected.not_to be_present }
-        its(:completion_mark_if_applicable) { should be_html_safe }
-        its(:todo_checkbox_element) { should be_html_safe }
-        its(:todo_checkbox_element) { should have_tag('span.circle.incomplete') }
+        its(:completion_mark_if_applicable) { is_expected.to be_html_safe }
+        its(:todo_checkbox_element) { is_expected.to be_html_safe }
+        its(:todo_checkbox_element) { is_expected.to have_tag('span.circle.incomplete') }
         its(:todo_checkbox_element) { is_expected.not_to have_tag('svg') }
-        its(:state) { should eq('incomplete') }
-        its(:complete?) { should be_falsey }
+        its(:state) { is_expected.to eq('incomplete') }
+        its(:complete?) { is_expected.to be_falsey }
       end
 
       context '#button_class' do

--- a/spec/presenters/sipity/controllers/enrichment_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/enrichment_action_presenter_spec.rb
@@ -69,11 +69,11 @@ module Sipity
             with(entity: entity, pluck: :id).and_return([enrichment_action.id])
         end
 
-        its(:completion_mark_if_applicable) { should_not be_present }
+        its(:completion_mark_if_applicable) { is_expected.not_to be_present }
         its(:completion_mark_if_applicable) { should be_html_safe }
         its(:todo_checkbox_element) { should be_html_safe }
         its(:todo_checkbox_element) { should have_tag('span.circle.incomplete') }
-        its(:todo_checkbox_element) { should_not have_tag('svg') }
+        its(:todo_checkbox_element) { is_expected.not_to have_tag('svg') }
         its(:state) { should eq('incomplete') }
         its(:complete?) { should be_falsey }
       end

--- a/spec/presenters/sipity/controllers/enrichment_action_set_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/enrichment_action_set_presenter_spec.rb
@@ -13,10 +13,10 @@ module Sipity
       end
       subject { described_class.new(context, enrichment_action_set: enrichment_action_set) }
 
-      its(:enrichment_actions) { should eq(enrichment_action_set.collection) }
-      its(:identifier) { should eq(enrichment_action_set.identifier) }
-      its(:entity) { should eq(enrichment_action_set.entity) }
-      its(:processing_state) { should eq(enrichment_action_set.processing_state) }
+      its(:enrichment_actions) { is_expected.to eq(enrichment_action_set.collection) }
+      its(:identifier) { is_expected.to eq(enrichment_action_set.identifier) }
+      its(:entity) { is_expected.to eq(enrichment_action_set.entity) }
+      its(:processing_state) { is_expected.to eq(enrichment_action_set.processing_state) }
     end
   end
 end

--- a/spec/presenters/sipity/controllers/processing_state_notice_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/processing_state_notice_presenter_spec.rb
@@ -11,8 +11,8 @@ module Sipity
       let(:processing_state_notice) { double(processing_state: 'hello', can_advance_processing_state?: true) }
       subject { described_class.new(context, processing_state_notice: processing_state_notice) }
 
-      its(:can_advance_processing_state?) { should eq(processing_state_notice.can_advance_processing_state?) }
-      its(:processing_state) { should eq(processing_state_notice.processing_state) }
+      its(:can_advance_processing_state?) { is_expected.to eq(processing_state_notice.can_advance_processing_state?) }
+      its(:processing_state) { is_expected.to eq(processing_state_notice.processing_state) }
 
       it 'exposes message?' do
         expect(I18n).to receive(:t).with(kind_of(String), default: '').and_return('')
@@ -21,17 +21,17 @@ module Sipity
 
       context 'when you can advance the processing state' do
         let(:processing_state_notice) { double(processing_state: 'hello', can_advance_processing_state?: true) }
-        its(:notice_dom_class) { should eq('alert-success') }
-        its(:message) { should be_a(String) }
-        its(:message) { should be_html_safe }
+        its(:notice_dom_class) { is_expected.to eq('alert-success') }
+        its(:message) { is_expected.to be_a(String) }
+        its(:message) { is_expected.to be_html_safe }
 
       end
 
       context 'when you cannote advance the processing state' do
         let(:processing_state_notice) { double(processing_state: 'hello', can_advance_processing_state?: false) }
-        its(:notice_dom_class) { should eq('alert-info') }
-        its(:message) { should be_a(String) }
-        its(:message) { should be_html_safe }
+        its(:notice_dom_class) { is_expected.to eq('alert-info') }
+        its(:message) { is_expected.to be_a(String) }
+        its(:message) { is_expected.to be_html_safe }
       end
     end
   end

--- a/spec/presenters/sipity/controllers/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/resourceful_action_presenter_spec.rb
@@ -13,7 +13,7 @@ module Sipity
       let(:resourceful_action) { Models::Processing::StrategyAction.new(name: 'show') }
       subject { described_class.new(context, resourceful_action: resourceful_action) }
 
-      its(:availability_state) { should be_a(String) }
+      its(:availability_state) { is_expected.to be_a(String) }
 
       it "will require you to implement a path" do
         expect { subject.path }.to raise_error(NotImplementedError)

--- a/spec/presenters/sipity/controllers/state_advancing_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/state_advancing_action_presenter_spec.rb
@@ -29,10 +29,10 @@ module Sipity
           with(entity: entity, pluck: :id).and_return(actions_with_unmet_prerequisites)
       end
 
-      its(:default_repository) { should respond_to(:scope_strategy_actions_with_incomplete_prerequisites) }
+      its(:default_repository) { is_expected.to respond_to(:scope_strategy_actions_with_incomplete_prerequisites) }
 
-      its(:action_name) { should eq(state_advancing_action.name) }
-      its(:path) { should be_a(String) }
+      its(:action_name) { is_expected.to eq(state_advancing_action.name) }
+      its(:path) { is_expected.to be_a(String) }
 
       it 'will delegate #label to the TranslationAssistant' do
         expect(TranslationAssistant).to receive(:call)
@@ -41,14 +41,14 @@ module Sipity
 
       context 'with all actions having met the prerequites' do
         let(:actions_with_unmet_prerequisites) { [] }
-        its(:available?) { should eq(true) }
-        its(:availability_state) { should eq(described_class::STATE_AVAILABLE) }
+        its(:available?) { is_expected.to eq(true) }
+        its(:availability_state) { is_expected.to eq(described_class::STATE_AVAILABLE) }
       end
 
       context 'with unmet prequisites' do
         let(:actions_with_unmet_prerequisites) { [state_advancing_action.id] }
-        its(:available?) { should eq(false) }
-        its(:availability_state) { should eq(described_class::STATE_PREREQUISITES_NOT_MET) }
+        its(:available?) { is_expected.to eq(false) }
+        its(:availability_state) { is_expected.to eq(described_class::STATE_PREREQUISITES_NOT_MET) }
       end
     end
   end

--- a/spec/presenters/sipity/controllers/state_advancing_action_set_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/state_advancing_action_set_presenter_spec.rb
@@ -13,9 +13,9 @@ module Sipity
       end
       subject { described_class.new(context, state_advancing_action_set: state_advancing_action_set) }
 
-      its(:state_advancing_actions) { should eq(state_advancing_action_set.collection) }
-      its(:entity) { should eq(state_advancing_action_set.entity) }
-      its(:processing_state) { should eq(state_advancing_action_set.processing_state) }
+      its(:state_advancing_actions) { is_expected.to eq(state_advancing_action_set.collection) }
+      its(:entity) { is_expected.to eq(state_advancing_action_set.entity) }
+      its(:processing_state) { is_expected.to eq(state_advancing_action_set.processing_state) }
     end
   end
 end

--- a/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
@@ -14,7 +14,7 @@ module Sipity
 
       its(:path) { is_expected.to eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}") }
       its(:path_to_start_a_submission) do
-        should eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}/do/start_a_submission")
+        is_expected.to eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}/do/start_a_submission")
       end
       its(:link) { is_expected.to eq(%(<a href="#{subject.path}">the-slug</a>)) }
       its(:slug) { is_expected.to eq(submission_window.slug) }

--- a/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_window_presenter_spec.rb
@@ -12,12 +12,12 @@ module Sipity
       let(:repository) { QueryRepositoryInterface.new }
       subject { described_class.new(context, submission_window: submission_window, repository: repository) }
 
-      its(:path) { should eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}") }
+      its(:path) { is_expected.to eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}") }
       its(:path_to_start_a_submission) do
         should eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}/do/start_a_submission")
       end
-      its(:link) { should eq(%(<a href="#{subject.path}">the-slug</a>)) }
-      its(:slug) { should eq(submission_window.slug) }
+      its(:link) { is_expected.to eq(%(<a href="#{subject.path}">the-slug</a>)) }
+      its(:slug) { is_expected.to eq(submission_window.slug) }
 
       it 'will compose actions for the submission window' do
         expect(ComposableElements::ProcessingActionsComposer).to receive(:new).with(user: current_user, entity: submission_window)

--- a/spec/presenters/sipity/controllers/submission_windows/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_windows/resourceful_action_presenter_spec.rb
@@ -22,8 +22,8 @@ module Sipity
           expect(subject.path).to eq("/areas/#{submission_window.work_area_slug}/#{submission_window.slug}/do/#{resourceful_action.name}")
         end
 
-        its(:work_area_slug) { should eq(submission_window.work_area_slug) }
-        its(:submission_window_slug) { should eq(submission_window.slug) }
+        its(:work_area_slug) { is_expected.to eq(submission_window.work_area_slug) }
+        its(:submission_window_slug) { is_expected.to eq(submission_window.slug) }
       end
     end
   end

--- a/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/submission_windows/show_presenter_spec.rb
@@ -12,7 +12,7 @@ module Sipity
           double(slug: 'the-slug', work_area_slug: 'another', work_area_partial_suffix: 'work_area', processing_action_name: 'hello')
         end
         subject { described_class.new(context, submission_window: submission_window) }
-        it { should be_a SubmissionWindowPresenter }
+        it { is_expected.to be_a SubmissionWindowPresenter }
 
         context '#render_submission_window' do
           context 'for a ULRA' do

--- a/spec/presenters/sipity/controllers/visitors/core/work_area_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/visitors/core/work_area_presenter_spec.rb
@@ -13,8 +13,8 @@ module Sipity
           let(:translator) { double(call: true) }
           subject { described_class.new(context, work_area: work_area, repository: repository, translator: translator) }
 
-          its(:default_translator) { should respond_to :call }
-          its(:default_repository) { should respond_to :find_submission_window_by }
+          its(:default_translator) { is_expected.to respond_to :call }
+          its(:default_repository) { is_expected.to respond_to :find_submission_window_by }
 
           let(:submission_window) { double }
           let(:processing_action) { double(name: 'start_a_submission') }
@@ -47,15 +47,15 @@ module Sipity
             subject
           end
 
-          it { should delegate_method(:name).to(:work_area) }
-          it { should delegate_method(:resourceful_actions).to(:processing_actions) }
-          it { should delegate_method(:resourceful_actions?).to(:processing_actions) }
-          it { should delegate_method(:state_advancing_actions).to(:processing_actions) }
-          it { should delegate_method(:state_advancing_actions).to(:processing_actions) }
-          it { should delegate_method(:enrichment_actions?).to(:processing_actions) }
-          it { should delegate_method(:enrichment_actions?).to(:processing_actions) }
+          it { is_expected.to delegate_method(:name).to(:work_area) }
+          it { is_expected.to delegate_method(:resourceful_actions).to(:processing_actions) }
+          it { is_expected.to delegate_method(:resourceful_actions?).to(:processing_actions) }
+          it { is_expected.to delegate_method(:state_advancing_actions).to(:processing_actions) }
+          it { is_expected.to delegate_method(:state_advancing_actions).to(:processing_actions) }
+          it { is_expected.to delegate_method(:enrichment_actions?).to(:processing_actions) }
+          it { is_expected.to delegate_method(:enrichment_actions?).to(:processing_actions) }
 
-          its(:to_work_area) { should eq(subject.send(:work_area)) }
+          its(:to_work_area) { is_expected.to eq(subject.send(:work_area)) }
 
           it 'will initialize the presumptive submission window' do
             expect(repository).to receive(:find_submission_window_by).

--- a/spec/presenters/sipity/controllers/visitors/etd/work_area_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/visitors/etd/work_area_presenter_spec.rb
@@ -21,7 +21,7 @@ module Sipity
             allow_any_instance_of(described_class).to receive(:convert_to_processing_action).and_return(processing_action)
           end
 
-          its(:view_submitted_etds_url) { should match(%r{\Ahttps://curate.nd.edu}) }
+          its(:view_submitted_etds_url) { is_expected.to match(%r{\Ahttps://curate.nd.edu}) }
         end
       end
     end

--- a/spec/presenters/sipity/controllers/visitors/ulra/work_area_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/visitors/ulra/work_area_presenter_spec.rb
@@ -20,22 +20,22 @@ module Sipity
             allow_any_instance_of(described_class).to receive(:convert_to_processing_action).and_return(processing_action)
           end
 
-          its(:initialize_submission_window_variables!) { should be_nil }
+          its(:initialize_submission_window_variables!) { is_expected.to be_nil }
 
           context 'when there are open submission windows' do
             let(:submission_window) { double }
             before do
               allow(repository).to receive(:find_open_submission_windows_by).with(work_area: work_area).and_return(submission_window)
             end
-            its(:submission_windows) { should eq([submission_window]) }
-            its(:submission_windows?) { should eq(true) }
+            its(:submission_windows) { is_expected.to eq([submission_window]) }
+            its(:submission_windows?) { is_expected.to eq(true) }
           end
           context 'when there are NO open submission windows' do
             before do
               allow(repository).to receive(:find_open_submission_windows_by).with(work_area: work_area).and_return(nil)
             end
-            its(:submission_windows) { should eq([]) }
-            its(:submission_windows?) { should eq(false) }
+            its(:submission_windows) { is_expected.to eq([]) }
+            its(:submission_windows?) { is_expected.to eq(false) }
           end
         end
       end

--- a/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
@@ -45,7 +45,7 @@ module Sipity
             subject do
               described_class.new(context, work_area: work_area, repository: repository).send(:search_criteria)
             end
-            its(:work_area) { should eq(work_area) }
+            its(:work_area) { is_expected.to eq(work_area) }
           end
         end
       end

--- a/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
@@ -20,8 +20,8 @@ module Sipity
             allow(repository).to receive(:find_submission_window_by).and_return(submission_window)
             allow_any_instance_of(described_class).to receive(:convert_to_processing_action).and_return(processing_action)
           end
-          it { should be_a(Sipity::Controllers::WorkAreas::Core::ShowPresenter) }
-          its(:view_submitted_etds_url) { should match(%r{\Ahttps://curate.nd.edu}) }
+          it { is_expected.to be_a(Sipity::Controllers::WorkAreas::Core::ShowPresenter) }
+          its(:view_submitted_etds_url) { is_expected.to match(%r{\Ahttps://curate.nd.edu}) }
         end
       end
     end

--- a/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
 
   subject { described_class.new(context, work_area: work_area) }
 
-  its(:submit_button) { should be_html_safe }
-  its(:select_tag_for_processing_state) { should be_html_safe }
+  its(:submit_button) { is_expected.to be_html_safe }
+  its(:select_tag_for_processing_state) { is_expected.to be_html_safe }
 
   it 'will expose select_tag_for_processing_state' do
     expect(subject.select_tag_for_processing_state).to have_tag('select[name="hello[world]"]') do

--- a/spec/presenters/sipity/controllers/work_areas/resourceful_action_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/resourceful_action_presenter_spec.rb
@@ -19,8 +19,8 @@ module Sipity
           expect(subject.path).to eq("/areas/#{work_area.slug}/do/#{resourceful_action.name}")
         end
 
-        its(:work_area_slug) { should eq(work_area.slug) }
-        its(:to_work_area) { should eq(work_area) }
+        its(:work_area_slug) { is_expected.to eq(work_area.slug) }
+        its(:to_work_area) { is_expected.to eq(work_area) }
       end
     end
   end

--- a/spec/presenters/sipity/controllers/work_areas/ulra/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/ulra/show_presenter_spec.rb
@@ -12,22 +12,22 @@ module Sipity
           let(:repository) { QueryRepositoryInterface.new }
           let(:translator) { double(call: true) }
           subject { described_class.new(context, work_area: work_area, repository: repository, translator: translator) }
-          it { should be_a(Sipity::Controllers::WorkAreas::Core::ShowPresenter) }
+          it { is_expected.to be_a(Sipity::Controllers::WorkAreas::Core::ShowPresenter) }
 
           context 'when there are open submission windows' do
             let(:submission_window) { double }
             before do
               allow(repository).to receive(:find_open_submission_windows_by).with(work_area: work_area).and_return(submission_window)
             end
-            its(:submission_windows) { should eq([submission_window]) }
-            its(:submission_windows?) { should eq(true) }
+            its(:submission_windows) { is_expected.to eq([submission_window]) }
+            its(:submission_windows?) { is_expected.to eq(true) }
           end
           context 'when there are NO open submission windows' do
             before do
               allow(repository).to receive(:find_open_submission_windows_by).with(work_area: work_area).and_return([])
             end
-            its(:submission_windows) { should eq([]) }
-            its(:submission_windows?) { should eq(false) }
+            its(:submission_windows) { is_expected.to eq([]) }
+            its(:submission_windows?) { is_expected.to eq(false) }
           end
         end
       end

--- a/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
@@ -9,13 +9,13 @@ module Sipity
 
         subject { described_class.new(context, work: work) }
 
-        its(:title) { should be_html_safe }
-        its(:processing_state) { should eq('New') }
-        its(:date_created) { should be_a(String) }
-        its(:creator_names_to_sentence) { should be_a(String) }
-        its(:program_names_to_sentence) { should be_a(String) }
-        its(:work_type) { should eq('Doctoral dissertation') }
-        it { should delegate_method(:submission_window).to(:work) }
+        its(:title) { is_expected.to be_html_safe }
+        its(:processing_state) { is_expected.to eq('New') }
+        its(:date_created) { is_expected.to be_a(String) }
+        its(:creator_names_to_sentence) { is_expected.to be_a(String) }
+        its(:program_names_to_sentence) { is_expected.to be_a(String) }
+        its(:work_type) { is_expected.to eq('Doctoral dissertation') }
+        it { is_expected.to delegate_method(:submission_window).to(:work) }
 
         it 'will delegate path to PowerConverter' do
           expect(PowerConverter).to receive(:convert).with(work, to: :access_path).and_return('/the/path')

--- a/spec/presenters/sipity/controllers/work_submissions/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_submissions/show_presenter_spec.rb
@@ -12,7 +12,7 @@ module Sipity
         let(:repository) { QueryRepositoryInterface.new }
         subject { described_class.new(context, work_submission: work_submission, repository: repository) }
 
-        its(:default_repository) { should respond_to :find_current_comments_for }
+        its(:default_repository) { is_expected.to respond_to :find_current_comments_for }
 
         it 'exposes processing_state' do
           allow(work_submission).to receive(:processing_state).and_return('Hello')
@@ -29,8 +29,8 @@ module Sipity
           expect(subject.collaborators?).to be_falsey
         end
 
-        it { should delegate_method(:collaborators).to(:work_submission) }
-        it { should delegate_method(:title).to(:work_submission) }
+        it { is_expected.to delegate_method(:collaborators).to(:work_submission) }
+        it { is_expected.to delegate_method(:title).to(:work_submission) }
 
         context '#render_current_comments' do
           subject { described_class.new(context, work_submission: work_submission, repository: repository) }

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_processing_hook_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/grad_school_signoff_processing_hook_spec.rb
@@ -23,8 +23,8 @@ module Sipity
               subject.call(as_fo_date: as_fo_date, entity: entity, repository: repository)
             end
 
-            its(:default_repository) { should respond_to(:update_work_attribute_values!) }
-            its(:default_as_of_date) { should be_a(Date) }
+            its(:default_repository) { is_expected.to respond_to(:update_work_attribute_values!) }
+            its(:default_as_of_date) { is_expected.to be_a(Date) }
           end
         end
       end

--- a/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/etd/works/submit_for_review_processing_hook_spec.rb
@@ -23,8 +23,8 @@ module Sipity
               subject.call(as_fo_date: as_fo_date, entity: entity, repository: repository)
             end
 
-            its(:default_repository) { should respond_to(:update_work_attribute_values!) }
-            its(:default_as_of_date) { should be_a(Date) }
+            its(:default_repository) { is_expected.to respond_to(:update_work_attribute_values!) }
+            its(:default_as_of_date) { is_expected.to be_a(Date) }
           end
         end
       end

--- a/spec/processing_hooks/sipity/processing_hooks/ulra/works/attach_processing_hook_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks/ulra/works/attach_processing_hook_spec.rb
@@ -16,7 +16,7 @@ module Sipity
 
             subject { described_class }
 
-            its(:default_repository) { should respond_to(:deliver_notification_for) }
+            its(:default_repository) { is_expected.to respond_to(:deliver_notification_for) }
 
             it 'will deliver notifications if the attachment entry is complete' do
               expect(repository).

--- a/spec/processing_hooks/sipity/processing_hooks_spec.rb
+++ b/spec/processing_hooks/sipity/processing_hooks_spec.rb
@@ -49,7 +49,7 @@ module Sipity
         expect(fallback_hook).to have_received(:call).with(keywords)
       end
 
-      its(:default_fallback_hook) { should respond_to(:call) }
+      its(:default_fallback_hook) { is_expected.to respond_to(:call) }
     end
   end
 end

--- a/spec/repositories/sipity/commands/work_commands_spec.rb
+++ b/spec/repositories/sipity/commands/work_commands_spec.rb
@@ -105,8 +105,8 @@ module Sipity
 
       context '#default_pid_minter' do
         subject { test_repository.default_pid_minter }
-        it { should respond_to(:call) }
-        its(:call) { should be_a(String) }
+        it { is_expected.to respond_to(:call) }
+        its(:call) { is_expected.to be_a(String) }
       end
 
       context '#create_sipity_user_from' do

--- a/spec/repositories/sipity/queries/account_profile_queries_spec.rb
+++ b/spec/repositories/sipity/queries/account_profile_queries_spec.rb
@@ -8,8 +8,8 @@ module Sipity
         subject { test_repository.build_account_profile_form(requested_by: user, attributes: attributes) }
         let(:user) { double(name: 'Hello') }
         let(:attributes) { { 'test' => 'test' } }
-        it { should respond_to :preferred_name }
-        it { should respond_to :agreed_to_terms_of_service }
+        it { is_expected.to respond_to :preferred_name }
+        it { is_expected.to respond_to :agreed_to_terms_of_service }
       end
     end
   end

--- a/spec/repositories/sipity/queries/collaborator_queries_spec.rb
+++ b/spec/repositories/sipity/queries/collaborator_queries_spec.rb
@@ -17,14 +17,14 @@ module Sipity
 
       context '#work_collaborators_responsible_for_review' do
         subject { test_repository.work_collaborators_responsible_for_review(work: work) }
-        it { should be_a(ActiveRecord::Relation) }
+        it { is_expected.to be_a(ActiveRecord::Relation) }
         # A bit of a sanity check that my primary table is sipity_collaborators
         it { expect(subject.arel_table.table_name).to eq('sipity_collaborators') }
       end
 
       context '#collaborators_that_can_advance_the_current_state_of' do
         subject { test_repository.collaborators_that_can_advance_the_current_state_of(work: work) }
-        it { should be_a(ActiveRecord::Relation) }
+        it { is_expected.to be_a(ActiveRecord::Relation) }
         # A bit of a sanity check that my primary table is sipity_collaborators
         it { expect(subject.arel_table.table_name).to eq('sipity_collaborators') }
       end

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -80,8 +80,8 @@ module Sipity
         let(:user) { double }
         let(:filter) { double }
         subject { test_repository.build_dashboard_view(user: user, filter: filter, page: 1) }
-        it { should respond_to :filterable_processing_states }
-        it { should respond_to :search_path }
+        it { is_expected.to respond_to :filterable_processing_states }
+        it { is_expected.to respond_to :search_path }
       end
     end
   end

--- a/spec/response_handlers/sipity/response_handlers_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers_spec.rb
@@ -67,9 +67,9 @@ module Sipity
         expect(responder).to receive(:for_command_line).with(handler: subject).and_return(:for_command_line_called)
         expect(subject.respond).to eq(:for_command_line_called)
       end
-      it { should delegate_method(:status).to(:handled_response).with_prefix(:response) }
-      it { should delegate_method(:object).to(:handled_response).with_prefix(:response) }
-      it { should delegate_method(:errors).to(:handled_response).with_prefix(:response) }
+      it { is_expected.to delegate_method(:status).to(:handled_response).with_prefix(:response) }
+      it { is_expected.to delegate_method(:object).to(:handled_response).with_prefix(:response) }
+      it { is_expected.to delegate_method(:errors).to(:handled_response).with_prefix(:response) }
     end
 
     RSpec.describe ControllerResponseHandler do
@@ -83,9 +83,9 @@ module Sipity
         expect(subject.respond).to eq(context.render)
       end
 
-      it { should delegate_method(:status).to(:handled_response).with_prefix(:response) }
-      it { should delegate_method(:object).to(:handled_response).with_prefix(:response) }
-      it { should delegate_method(:errors).to(:handled_response).with_prefix(:response) }
+      it { is_expected.to delegate_method(:status).to(:handled_response).with_prefix(:response) }
+      it { is_expected.to delegate_method(:object).to(:handled_response).with_prefix(:response) }
+      it { is_expected.to delegate_method(:errors).to(:handled_response).with_prefix(:response) }
 
       it 'will coordinate updating view path information with the context' do
         expect(handled_response).to receive(:with_each_additional_view_path_slug).and_yield('core').and_yield('ulra')

--- a/spec/runners/sipity/command_line_context_spec.rb
+++ b/spec/runners/sipity/command_line_context_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Sipity::CommandLineContext do
 
   subject { described_class.new(requested_by: requested_by, repository_strategy: :query) }
 
-  its(:default_repository_strategy) { should eq(:command) }
-  its(:current_user) { should eq(requested_by) }
-  its(:repository) { should be_a(Sipity::QueryRepository) }
+  its(:default_repository_strategy) { is_expected.to eq(:command) }
+  its(:current_user) { is_expected.to eq(requested_by) }
+  its(:repository) { is_expected.to be_a(Sipity::QueryRepository) }
 
   it 'will raise to initialize with a :bogus repository strategy' do
     expect { described_class.new(username: username, repository_strategy: :bogus) }.to raise_error(NameError)
@@ -19,16 +19,16 @@ RSpec.describe Sipity::CommandLineContext do
     expect { subject.some_random_authenticate_thing! }.to raise_error(NoMethodError)
   end
 
-  it { should respond_to(:authenticate_some_outlandish_method_that_no_one_would_ever_consider_like_I_am_batman!) }
+  it { is_expected.to respond_to(:authenticate_some_outlandish_method_that_no_one_would_ever_consider_like_I_am_batman!) }
 
   context 'without a current user' do
     before { allow(subject).to receive(:current_user).and_return(nil) }
-    its(:authenticate_user!) { should eq(false) }
-    its(:authenticate_user_for_profile_management!) { should eq(false) }
+    its(:authenticate_user!) { is_expected.to eq(false) }
+    its(:authenticate_user_for_profile_management!) { is_expected.to eq(false) }
   end
 
   context 'with a current user' do
-    its(:authenticate_user!) { should eq(true) }
-    its(:authenticate_user_for_profile_management!) { should eq(true) }
+    its(:authenticate_user!) { is_expected.to eq(true) }
+    its(:authenticate_user_for_profile_management!) { is_expected.to eq(true) }
   end
 end

--- a/spec/runners/sipity/command_line_context_spec.rb
+++ b/spec/runners/sipity/command_line_context_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Sipity::CommandLineContext do
     expect { described_class.new(username: username, repository_strategy: :bogus) }.to raise_error(NameError)
   end
 
-  it { should_not respond_to(:some_random_authenticate_thing!) }
+  it { is_expected.not_to respond_to(:some_random_authenticate_thing!) }
 
   it 'will raise an exception on other missing methods' do
     expect { subject.some_random_authenticate_thing! }.to raise_error(NoMethodError)

--- a/spec/runners/sipity/runners/base_runner_spec.rb
+++ b/spec/runners/sipity/runners/base_runner_spec.rb
@@ -33,8 +33,8 @@ module Sipity
         expect { subject.run }.to raise_error(NotImplementedError)
       end
 
-      it { should respond_to :repository }
-      it { should respond_to :current_user }
+      it { is_expected.to respond_to :repository }
+      it { is_expected.to respond_to :current_user }
 
       it 'will have an #action_name' do
         expect(subject.action_name).to eq('base_runner')

--- a/spec/runners/sipity/runners/visitors_runner_spec.rb
+++ b/spec/runners/sipity/runners/visitors_runner_spec.rb
@@ -9,8 +9,8 @@ module Sipity
       RSpec.describe WorkArea do
         context 'configuration' do
           subject { described_class }
-          its(:authentication_layer) { should eq(:none) }
-          its(:authorization_layer) { should eq(:none) }
+          its(:authentication_layer) { is_expected.to eq(:none) }
+          its(:authorization_layer) { is_expected.to eq(:none) }
         end
 
         context '#run' do

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -14,9 +14,9 @@ module Sipity
       let(:repository) { CommandRepositoryInterface.new }
 
       subject { described_class.new(entity: entity, requested_by: requested_by, action: action, repository: repository) }
-      its(:default_repository) { should respond_to(:log_event!) }
-      its(:default_repository) { should respond_to(:deliver_notification_for) }
-      its(:default_processing_hooks) { should respond_to(:call) }
+      its(:default_repository) { is_expected.to respond_to(:log_event!) }
+      its(:default_repository) { is_expected.to respond_to(:deliver_notification_for) }
+      its(:default_processing_hooks) { is_expected.to respond_to(:call) }
 
       before { allow(subject.send(:default_processing_hooks)).to receive(:call) }
 

--- a/spec/services/sipity/services/administrative/force_into_processing_state_spec.rb
+++ b/spec/services/sipity/services/administrative/force_into_processing_state_spec.rb
@@ -13,7 +13,7 @@ module Sipity
 
     subject { described_class.new(entity: entity, state: 'bacon', repository: repository) }
 
-    its(:default_repository) { should respond_to :destroy_existing_registered_state_changing_actions_for }
+    its(:default_repository) { is_expected.to respond_to :destroy_existing_registered_state_changing_actions_for }
     it 'exposes .call as a convenience method' do
       expect_any_instance_of(described_class).to receive(:call)
       described_class.call(entity: entity, state: 'bacon', repository: repository)

--- a/spec/services/sipity/services/advisor_signs_off_spec.rb
+++ b/spec/services/sipity/services/advisor_signs_off_spec.rb
@@ -89,10 +89,10 @@ module Sipity
         end
       end
 
-      its(:default_repository) { should respond_to :collaborators_that_have_taken_the_action_on_the_entity }
-      its(:default_repository) { should respond_to :work_collaborators_responsible_for_review }
-      its(:default_action) { should eq(form.to_processing_action) }
-      its(:default_also_register_as) { should be_empty }
+      its(:default_repository) { is_expected.to respond_to :collaborators_that_have_taken_the_action_on_the_entity }
+      its(:default_repository) { is_expected.to respond_to :work_collaborators_responsible_for_review }
+      its(:default_action) { is_expected.to eq(form.to_processing_action) }
+      its(:default_also_register_as) { is_expected.to be_empty }
     end
   end
 end

--- a/spec/services/sipity/services/deliver_form_submission_notifications_service_spec.rb
+++ b/spec/services/sipity/services/deliver_form_submission_notifications_service_spec.rb
@@ -23,8 +23,8 @@ module Sipity
 
       subject { described_class.new(notification_context: notification_context, repository: repository, notifier: notifier) }
 
-      its(:default_repository) { should respond_to :user_emails_for_entity_and_roles }
-      its(:default_notifier) { should respond_to :call }
+      its(:default_repository) { is_expected.to respond_to :user_emails_for_entity_and_roles }
+      its(:default_notifier) { is_expected.to respond_to :call }
 
       before do
         allow(repository).to receive(:email_notifications_for).and_return([email])

--- a/spec/services/sipity/services/grant_processing_permission_spec.rb
+++ b/spec/services/sipity/services/grant_processing_permission_spec.rb
@@ -14,7 +14,7 @@ module Sipity
       end
 
       subject { described_class.new(entity: entity, role: role, actor: actor) }
-      its(:strategy) { should eq entity.strategy }
+      its(:strategy) { is_expected.to eq entity.strategy }
 
       context '.call' do
         it 'will instantiate then call the instance' do

--- a/spec/services/sipity/services/notifier_spec.rb
+++ b/spec/services/sipity/services/notifier_spec.rb
@@ -6,7 +6,7 @@ module Sipity
     describe Notifier do
       context '.default_email_service_finder' do
         subject { described_class.send(:default_email_service_finder) }
-        its(:parameters) { should eq([[:keyreq, :entity], [:keyreq, :notification]]) }
+        its(:parameters) { is_expected.to eq([[:keyreq, :entity], [:keyreq, :notification]]) }
       end
       context '.deliver' do
         let(:missing_notification) { 'never_would_this_be_a_notification' }

--- a/spec/services/sipity/services/request_changes_via_comment_service_spec.rb
+++ b/spec/services/sipity/services/request_changes_via_comment_service_spec.rb
@@ -28,7 +28,7 @@ module Sipity
         end
       end
 
-      its(:default_repository) { should respond_to :record_processing_comment }
+      its(:default_repository) { is_expected.to respond_to :record_processing_comment }
 
       context 'with valid data' do
         subject { described_class.new(base_options) }

--- a/spec/services/sipity/services/update_entity_processing_state_spec.rb
+++ b/spec/services/sipity/services/update_entity_processing_state_spec.rb
@@ -24,7 +24,7 @@ module Sipity
         end
       end
 
-      its(:default_repository) { should respond_to :destroy_existing_registered_state_changing_actions_for }
+      its(:default_repository) { is_expected.to respond_to :destroy_existing_registered_state_changing_actions_for }
 
       context 'with a processing state object' do
         before do

--- a/spec/validators/net_id_validator_spec.rb
+++ b/spec/validators/net_id_validator_spec.rb
@@ -21,7 +21,7 @@ describe NetIdValidator do
     it { expect(:valid?).to be_truthy }
   end
 
-  its(:default_netid_remote_validator) { should respond_to :call }
+  its(:default_netid_remote_validator) { is_expected.to respond_to :call }
 
   context '#validate_each' do
     let(:a_netid) { 'a_netid' }


### PR DESCRIPTION
## Replacing `{ should` with `{ is_expected.not_to`

@9931286841f4053093edf2fc12410b73eb82c229

As per betterspecs.org

## Replacing `{ should` with `{ is_expected.to`

@172e06b71cb5cfcba7777d52ac8c72583d05acf9


## Replacing odd `should` with `is_expected.to`

@80a917669d91fb15c29f1f35177a3a800363bee0

These are the outliers for the regular search and replace.