### PR TITLE
Minor tweaks

### DIFF
--- a/app/repositories/sipity/queries/collaborator_queries.rb
+++ b/app/repositories/sipity/queries/collaborator_queries.rb
@@ -1,9 +1,6 @@
 module Sipity
   module Queries
-    # Queries
-    #
-    # TODO: Remove module methods for these functions. I want them to be mixins
-    #   instead of the existing singletons.
+    # Queries related to collaborators
     module CollaboratorQueries
       def find_or_initialize_collaborators_by(work:, id:, &block)
         Models::Collaborator.find_or_initialize_by(work_id: work.id, id: id, &block)

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -5,6 +5,7 @@ module Sipity
       def find_work(work_id)
         find_work_by(id: work_id)
       end
+      deprecate :find_work
 
       def find_work_by(id:)
         Models::Work.includes(:processing_entity, work_submission: [:work_area, :submission_window]).find(id)

--- a/app/runners/sipity/runners/comment_runners.rb
+++ b/app/runners/sipity/runners/comment_runners.rb
@@ -11,7 +11,7 @@ module Sipity
 
         def run(work_id:)
           enforce_authentication!
-          work = repository.find_work(work_id)
+          work = repository.find_work_by(id: work_id)
           authorization_layer.enforce!(action_name => work) do
             callback(:success, work)
           end

--- a/spec/runners/sipity/runners/comment_runners_spec.rb
+++ b/spec/runners/sipity/runners/comment_runners_spec.rb
@@ -10,7 +10,7 @@ module Sipity
       RSpec.describe Index do
         let(:work) { double }
         let(:user) { double('User') }
-        let(:context) { TestRunnerContext.new(find_work: work, current_user: user) }
+        let(:context) { TestRunnerContext.new(find_work_by: work, current_user: user) }
         let(:handler) { double(invoked: true) }
         subject do
           described_class.new(context, authentication_layer: false, authorization_layer: false) do |on|


### PR DESCRIPTION
## Removing TODO documentation

@4e59d1e2fb144793a7df1fcdd3eb89c4410c122f

[skip ci]

## Deprecating a method that has better alias

@8279b26698aad9f4259b5abbbe4507ac3f5b39c0

The method was already a wrapper for another method. I'm preferring, to
instead pass keyword arguments.