### PR TITLE
Replacing #find_works_for with versatile method

### DIFF
--- a/app/decorators/sipity/decorators/dashboard_view.rb
+++ b/app/decorators/sipity/decorators/dashboard_view.rb
@@ -1,3 +1,5 @@
+require 'sipity/parameters/search_criteria_for_works_parameter'
+
 module Sipity
   module Decorators
     # Responsible for collecting the logic related to rendering a user's
@@ -25,7 +27,7 @@ module Sipity
       end
 
       def works_scope
-        repository.find_works_for(user: user, processing_state: processing_state, page: page)
+        repository.find_works_via_search(criteria: criteria, repository: repository)
       end
 
       def works(decorator: WorkDecorator)
@@ -37,6 +39,14 @@ module Sipity
       end
 
       private
+
+      def criteria
+        Parameters::SearchCriteriaForWorksParameter.new(
+          user: user,
+          processing_state: processing_state,
+          page: page
+        )
+      end
 
       def view_context
         Draper::ViewContext.current

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -27,15 +27,9 @@ module Sipity
         )
       end
 
-      # @todo Refactor places that use #find_works_for to leverage #find_works_via_search
-      def find_works_for(user:, processing_state: nil, repository: self, proxy_for_type: Models::Work, page: nil)
-        scope = repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
-          user: user, proxy_for_type: proxy_for_type, filter: { processing_state: processing_state }
-        )
-        return scope unless page
-        scope.page(page).per(15)
-      end
-
+      # @param criteria [Sipity::Parameters::SearchCriteriaForWorksParameter]
+      #
+      # @return [ActiveModel::Relation<Sipity::Models::Work>]
       def find_works_via_search(criteria:, repository: self)
         parameters = extract_search_paramters_from(criteria: criteria)
         scope = repository.scope_proxied_objects_for_the_user_and_proxy_for_type(**parameters)

--- a/spec/decorators/sipity/decorators/dashboard_view_spec.rb
+++ b/spec/decorators/sipity/decorators/dashboard_view_spec.rb
@@ -14,13 +14,13 @@ module Sipity
       it 'will have decorated #works' do
         decorator = double
         works = [double, double("Toil and Trouble")]
-        expect(repository).to receive(:find_works_for).and_return(works)
+        expect(repository).to receive(:find_works_via_search).and_return(works)
         allow(decorator).to receive(:new).with(works[0]).and_return(works[0])
         allow(decorator).to receive(:new).with(works[1]).and_return(works[1])
         expect(subject.works).to eq(works)
       end
 
-      its(:default_repository) { is_expected.to respond_to(:find_works_for) }
+      its(:default_repository) { is_expected.to respond_to(:find_works_via_search) }
       its(:processing_state) { is_expected.to eq(filter.fetch(:processing_state)) }
     end
   end

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -4,19 +4,6 @@ require 'sipity/queries/work_queries'
 module Sipity
   module Queries
     RSpec.describe WorkQueries, type: :isolated_repository_module do
-      context '#find_works_for' do
-        let(:repository) { QueryRepositoryInterface.new }
-        let(:user) { double }
-        let(:processing_state) { double }
-
-        it 'will leverage the underlying scope_proxied_objects_for_the_user_and_proxy_for_type method' do
-          expect(repository).to receive(:scope_proxied_objects_for_the_user_and_proxy_for_type).
-            with(user: user, proxy_for_type: Models::Work, filter: { processing_state: processing_state }).
-            and_call_original
-          test_repository.find_works_for(user: user, processing_state: processing_state, repository: repository)
-        end
-      end
-
       context '#find_works_via_search' do
         let(:repository) { QueryRepositoryInterface.new }
         let(:criteria) { Parameters::SearchCriteriaForWorksParameter.new }

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -178,10 +178,6 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def find_works_for(user:, processing_state: nil, repository: self, proxy_for_type: Models::Work, page: nil)
-    end
-
-    # @see ./app/repositories/sipity/queries/work_queries.rb
     def find_works_via_search(criteria:, repository: self)
     end
 

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -110,10 +110,6 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/work_queries.rb
-    def find_works_for(user:, processing_state: nil, repository: self, proxy_for_type: Models::Work, page: nil)
-    end
-
-    # @see ./app/repositories/sipity/queries/work_queries.rb
     def find_works_via_search(criteria:, repository: self)
     end
 


### PR DESCRIPTION
Tidying up the #find_works_for todo item (see below).

> Refactor places that use #find_works_for to leverage
> #find_works_via_search