### PR TITLE
Favor auto load of modules

### DIFF
--- a/app/repositories/sipity/command_repository.rb
+++ b/app/repositories/sipity/command_repository.rb
@@ -1,3 +1,8 @@
+require 'sipity/query_repository'
+Dir.glob(File.expand_path('../**/*_commands.rb', __FILE__)).each do |filename|
+  require filename
+end
+
 module Sipity
   # The module that contains various interactions with the underlying
   # persistence layer.
@@ -15,16 +20,8 @@ module Sipity
       include mod if mod.to_s =~ /Sipity::Queries::/
     end
 
-    include Commands::AccountProfileCommands
-    include Commands::AdditionalAttributeCommands
-    include Commands::AdministrativeScheduledActionCommands
-    include Commands::EventLogCommands
-    include Commands::NotificationCommands
-    include Commands::PermissionCommands
-    include Commands::ProcessingCommands
-    include Commands::RedirectCommands
-    include Commands::TodoListCommands
-    include Commands::TransientAnswerCommands
-    include Commands::WorkCommands
+    Commands.constants.each do |command_module|
+      include Commands.const_get(command_module)
+    end
   end
 end

--- a/app/repositories/sipity/command_repository.rb
+++ b/app/repositories/sipity/command_repository.rb
@@ -9,7 +9,10 @@ module Sipity
   module Commands
   end
 
-  # The object you can use to interaction with the commands.
+  # The object you can use to interact with the commands.
+  #
+  # @note In developing repository methods, do not set nor get instance variables for a repository instance.
+  # @note These methods should be stateless.
   class CommandRepository
     # I was using a delegator but was encountering a problem when attempting to
     # initialize a given form; I was losing the scope of the original

--- a/app/repositories/sipity/query_repository.rb
+++ b/app/repositories/sipity/query_repository.rb
@@ -1,3 +1,7 @@
+Dir.glob(File.expand_path('../**/*_queries.rb', __FILE__)).each do |filename|
+  require filename
+end
+
 module Sipity
   # The module that contains the various query submodules
   module Queries
@@ -5,20 +9,8 @@ module Sipity
   # Defines and exposes the query methods for interacting with the public API of
   # the persistence layer.
   class QueryRepository
-    include Queries::AccountProfileQueries
-    include Queries::AdditionalAttributeQueries
-    include Queries::AdministrativeScheduledActionQueries
-    include Queries::AttachmentQueries
-    include Queries::CollaboratorQueries
-    include Queries::CommentQueries
-    include Queries::EventLogQueries
-    include Queries::NotificationQueries
-    include Queries::ProcessingQueries
-    include Queries::RedirectQueries
-    include Queries::SimpleControlledVocabularyQueries
-    include Queries::SubmissionWindowQueries
-    include Queries::UlraQueries
-    include Queries::WorkAreaQueries
-    include Queries::WorkQueries
+    Queries.constants.each do |query_module|
+      include Queries.const_get(query_module)
+    end
   end
 end

--- a/app/repositories/sipity/query_repository.rb
+++ b/app/repositories/sipity/query_repository.rb
@@ -8,6 +8,9 @@ module Sipity
   end
   # Defines and exposes the query methods for interacting with the public API of
   # the persistence layer.
+  #
+  # @note In developing repository methods, do not set nor get instance variables for a repository instance.
+  # @note These methods should be stateless.
   class QueryRepository
     Queries.constants.each do |query_module|
       include Queries.const_get(query_module)


### PR DESCRIPTION
## Favor auto-loading of all command modules

@07a42bba96f30b1f2629a3c768f2a927ad100bdb

There are times when I forget to include the correct modules for
commands. This is a refactor to auto-include modules.

## Favor auto-loading of all query modules

@2e3e3559bf4ec35c340be36e25a3d3cba09ae7fc

There are times when I forget to include the correct modules for
queries. This is a refactor to auto-include modules.

## Adding note about stateless-ness of Repository

@34b91b86cf8df2f5a1f88ee8ec19a7dabbfb1a8e

While yes, the repository interacts with state, the object that
does the interaction should not track state, but instead require method
parameters.

[skip ci]
