### PR TITLE
Removing deprecated method

### DIFF
--- a/app/response_handlers/sipity/response_handlers.rb
+++ b/app/response_handlers/sipity/response_handlers.rb
@@ -79,7 +79,7 @@ module Sipity
       end
 
       def respond
-        responder.call(handler: self)
+        responder.for_controller(handler: self)
       end
 
       delegate :render, :redirect_to, to: :context

--- a/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/submission_window_handler.rb
@@ -8,22 +8,39 @@ module Sipity
     module SubmissionWindowHandler
       # Success! Huzzah
       module SuccessResponder
-        def self.call(handler:)
+        def self.for_controller(handler:)
           handler.render(template: handler.template)
+        end
+
+        def self.for_command_line(*)
+          true
         end
       end
 
       # We have a successful form submission.
       module SubmitSuccessResponder
-        def self.call(handler:)
+        def self.for_controller(handler:)
           handler.redirect_to(PowerConverter.convert_to_access_path(handler.response_object))
+        end
+
+        def self.for_command_line(*)
+          true
         end
       end
 
       # Forms that raise to submit may have different errors.
       module SubmitFailureResponder
-        def self.call(handler:)
+        def self.for_controller(handler:)
           handler.render(template: handler.template, status: :unprocessable_entity)
+        end
+
+        def self.for_command_line(handler:)
+          raise(
+            Sipity::Exceptions::ResponseHandlerError,
+            object: handler.response_object,
+            errors: handler.response_errors,
+            status: handler.response_status
+          )
         end
       end
     end

--- a/app/response_handlers/sipity/response_handlers/work_area_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_area_handler.rb
@@ -6,15 +6,29 @@ module Sipity
     module WorkAreaHandler
       # Huzzah! Success
       module SuccessResponder
-        def self.call(handler:)
+        def self.for_controller(handler:)
           handler.render(template: handler.template)
+        end
+
+        # @review should I consider if a logger is passed?
+        def self.for_command_line(*)
+          return true
         end
       end
 
       # Forms that raise to submit may have different errors.
       module SubmitFailureResponder
-        def self.call(handler:)
+        def self.for_controller(handler:)
           handler.render(template: handler.template, status: :unprocessable_entity)
+        end
+
+        def self.for_command_line(handler:)
+          raise(
+            Sipity::Exceptions::ResponseHandlerError,
+            object: handler.response_object,
+            errors: handler.response_errors,
+            status: handler.response_status
+          )
         end
       end
     end

--- a/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
+++ b/app/response_handlers/sipity/response_handlers/work_submission_handler.rb
@@ -13,11 +13,6 @@ module Sipity
           handler.render(template: handler.template)
         end
 
-        class << self
-          alias call for_controller
-          deprecate call: "Prefer .for_controller instead"
-        end
-
         # @review should I consider if a logger is passed?
         def self.for_command_line(*)
           return true
@@ -28,11 +23,6 @@ module Sipity
       module RedirectResponder
         def self.for_controller(handler:)
           handler.redirect_to(handler.response_object.url)
-        end
-
-        class << self
-          alias call for_controller
-          deprecate call: "Prefer .for_controller instead"
         end
 
         # @review should I consider if a logger is passed?
@@ -52,11 +42,6 @@ module Sipity
           handler.redirect_to(PowerConverter.convert_to_access_path(handler.response_object))
         end
 
-        class << self
-          alias call for_controller
-          deprecate call: "Prefer .for_controller instead"
-        end
-
         # @review should I consider if a logger is passed?
         def self.for_command_line(*)
           return true
@@ -67,11 +52,6 @@ module Sipity
       module SubmitFailureResponder
         def self.for_controller(handler:)
           handler.render(template: handler.template, status: :unprocessable_entity)
-        end
-
-        class << self
-          alias call for_controller
-          deprecate call: "Prefer .for_controller instead"
         end
 
         # @review should I consider if a logger is passed?

--- a/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/submission_window_handler_spec.rb
@@ -7,31 +7,46 @@ module Sipity
     module SubmissionWindowHandler
       RSpec.describe SuccessResponder do
         let(:handler) { double(render: 'rendered', template: 'show') }
-        context '.call' do
+        context '.for_controller' do
           it 'will coordinate the rendering of the template' do
-            described_class.call(handler: handler)
+            described_class.for_controller(handler: handler)
             expect(handler).to have_received(:render).with(template: handler.template)
           end
+        end
+        context '.for_command_line' do
+          subject { described_class.for_command_line(handler: handler) }
+          it { is_expected.to eq(true) }
         end
       end
 
       RSpec.describe SubmitSuccessResponder do
         let(:handler) { double(redirect_to: true, response_object: double(id: '123')) }
-        context '.call' do
+        context '.for_controller' do
           it 'will coordinate the rendering of the template' do
             expect(PowerConverter).to receive(:convert_to_access_path).and_return('/hello/world')
-            described_class.call(handler: handler)
+            described_class.for_controller(handler: handler)
             expect(handler).to have_received(:redirect_to).with('/hello/world')
           end
+        end
+        context '.for_command_line' do
+          subject { described_class.for_command_line(handler: handler) }
+          it { is_expected.to eq(true) }
         end
       end
 
       RSpec.describe SubmitFailureResponder do
         let(:handler) { double(render: 'rendered', template: 'show') }
-        context '.call' do
+        context '.for_controller' do
           it 'will coordinate the rendering of the template' do
-            described_class.call(handler: handler)
+            described_class.for_controller(handler: handler)
             expect(handler).to have_received(:render).with(template: handler.template, status: :unprocessable_entity)
+          end
+        end
+        context '.for_command_line' do
+          let(:handler) { double(response_object: :obj, response_errors: [], response_status: :one) }
+          subject { described_class.for_command_line(handler: handler) }
+          it 'should raise Sipity::Exceptions::ResponseHandlerError' do
+            expect { subject }.to raise_error(Sipity::Exceptions::ResponseHandlerError)
           end
         end
       end

--- a/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
+++ b/spec/response_handlers/sipity/response_handlers/work_area_handler_spec.rb
@@ -1,25 +1,37 @@
 require 'spec_helper'
 require 'sipity/response_handlers/work_area_handler'
-require 'sipity/response_handlers/work_area_handler'
 
 module Sipity
   module ResponseHandlers
     module WorkAreaHandler
       RSpec.describe SuccessResponder do
         let(:handler) { double(render: 'rendered', template: 'show') }
-
-        it 'will coordinate the rendering of the template' do
-          described_class.call(handler: handler)
-          expect(handler).to have_received(:render).with(template: handler.template)
+        context '.for_controller' do
+          it 'will coordinate the rendering of the template' do
+            described_class.for_controller(handler: handler)
+            expect(handler).to have_received(:render).with(template: handler.template)
+          end
+        end
+        context '.for_command_line' do
+          subject { described_class.for_command_line(handler: handler) }
+          it { is_expected.to eq(true) }
         end
       end
 
       RSpec.describe SubmitFailureResponder do
         let(:handler) { double(render: 'rendered', template: 'show') }
-
-        it 'will coordinate the rendering of the template' do
-          described_class.call(handler: handler)
-          expect(handler).to have_received(:render).with(template: handler.template, status: :unprocessable_entity)
+        context '.for_controller' do
+          it 'will coordinate the rendering of the template' do
+            described_class.for_controller(handler: handler)
+            expect(handler).to have_received(:render).with(template: handler.template, status: :unprocessable_entity)
+          end
+        end
+        context '.for_command_line' do
+          let(:handler) { double(response_object: :obj, response_errors: [], response_status: :one) }
+          subject { described_class.for_command_line(handler: handler) }
+          it 'should raise Sipity::Exceptions::ResponseHandlerError' do
+            expect { subject }.to raise_error(Sipity::Exceptions::ResponseHandlerError)
+          end
         end
       end
     end


### PR DESCRIPTION
Favoring the specific context (i.e. `.for_controller`) instead of the
more general `.call` method.