### PR TITLE
Removing deprecated `.find_work` method

### DIFF
--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -2,11 +2,6 @@ module Sipity
   module Queries
     # Queries
     module WorkQueries
-      def find_work(work_id)
-        find_work_by(id: work_id)
-      end
-      deprecate :find_work
-
       def find_work_by(id:)
         Models::Work.includes(:processing_entity, work_submission: [:work_area, :submission_window]).find(id)
       end

--- a/spec/repositories/sipity/queries/work_queries_spec.rb
+++ b/spec/repositories/sipity/queries/work_queries_spec.rb
@@ -26,16 +26,6 @@ module Sipity
         end
       end
 
-      context '#find_work' do
-        it 'raises an exception if nothing is found' do
-          expect { test_repository.find_work('8675309') }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-        it 'returns the Work when the object is found' do
-          work = Models::Work.create!(id: '8675309', title: "Hello")
-          expect(test_repository.find_work('8675309')).to eq(work)
-        end
-      end
-
       context '#find_work_by' do
         it 'raises an exception if nothing is found' do
           expect { test_repository.find_work_by(id: '8675309') }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -165,10 +165,6 @@ module Sipity
     def find_submission_window_by(slug:, work_area:)
     end
 
-    # @see ./app/repositories/sipity/queries/work_queries.rb
-    def find_work(work_id)
-    end
-
     # @see ./app/repositories/sipity/queries/work_area_queries.rb
     def find_work_area_by(slug:)
     end

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -97,10 +97,6 @@ module Sipity
     def find_submission_window_by(slug:, work_area:)
     end
 
-    # @see ./app/repositories/sipity/queries/work_queries.rb
-    def find_work(work_id)
-    end
-
     # @see ./app/repositories/sipity/queries/work_area_queries.rb
     def find_work_area_by(slug:)
     end


### PR DESCRIPTION
The alternate is to leverage `.find_work_by`. Its a better solution
because often when a work must be found we need additional related
information.