### PR TITLE
Adding bumbler to the doc bundle group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :doc do
   gem 'yard-activerecord', require: false
   gem 'flay', require: false
   gem 'flog', require: false
+  gem 'bumbler', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    bumbler (0.3.1)
     byebug (8.2.2)
     callsite (0.0.11)
     capistrano (3.4.1)
@@ -599,6 +600,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass
+  bumbler
   capistrano (~> 3.1)
   capistrano-bundler
   capistrano-rails


### PR DESCRIPTION
I like that bumbler can help us find the slow load times.

`bundle exec bumbler` tells us what is performing lots of requires.