### PR TITLE
Removing gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,9 +61,6 @@ group :development do
   gem 'guard-scss-lint', github: 'ndlib/guard-scss-lint'
   gem 'i18n-debug'
   gem 'letter_opener'
-  # Paired with Chrome the RailsPanel plugin, you can see request information
-  # https://github.com/dejan/rails_panel
-  gem 'meta_request'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'quiet_assets'

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ group :development, :staging do
 end
 
 group :development, :test do
-  gem 'faker'
   gem 'pry-rescue', require: false
   gem 'pry-stack_explorer', require: false
   gem 'rspec-its'

--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,8 @@ group :development do
   gem 'guard-scss-lint', github: 'ndlib/guard-scss-lint'
   gem 'i18n-debug'
   gem 'letter_opener'
-  gem 'pry-byebug'
-  gem 'pry-rails'
+  gem 'pry-byebug', require: false
+  gem 'pry-rails', require: false
   gem 'quiet_assets'
   gem 'rails_layout'
   gem 'rb-fchange', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ group :test do
   gem 'shoulda-callback-matchers'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.0.1'
-  gem 'site_prism'
+  gem 'site_prism', require: false
   gem 'sqlite3'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ end
 group :development, :test do
   gem 'pry-rescue', require: false
   gem 'pry-stack_explorer', require: false
-  gem 'rspec-its'
+  gem 'rspec-its', require: false
   gem 'rspec', '~>3.4.0'
   gem 'rspec-rails', '~>3.4.0'
   gem 'commitment'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,6 @@ GEM
       terminal-table (~> 1.4)
     builder (3.2.2)
     byebug (8.2.2)
-    callsite (0.0.11)
     capistrano (3.4.1)
       i18n
       rake (>= 10.0.0)
@@ -283,7 +282,6 @@ GEM
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    git-version-bump (0.15.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     guard (2.13.0)
@@ -355,10 +353,6 @@ GEM
     lumberjack (1.0.10)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    meta_request (0.4.0)
-      callsite (~> 0.0, >= 0.0.11)
-      rack-contrib (~> 1.1)
-      railties (>= 3.0.0, < 5.1.0)
     method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile2 (2.0.0)
@@ -407,9 +401,6 @@ GEM
     rack (1.6.4)
     rack-cache (1.6.1)
       rack (>= 0.4)
-    rack-contrib (1.4.0)
-      git-version-bump (~> 0.15)
-      rack (~> 1.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -640,7 +631,6 @@ DEPENDENCIES
   letter_opener
   locabulary!
   loofah (~> 2.0.3)
-  meta_request
   mime-types (~> 2.6.1)
   mysql2
   noids_client!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,8 +257,6 @@ GEM
     erubis (2.7.0)
     excon (0.48.0)
     execjs (2.6.0)
-    faker (1.6.3)
-      i18n (~> 0.5)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -621,7 +619,6 @@ DEPENDENCIES
   dry-validation
   execjs
   ezid-client!
-  faker
   figaro
   flay
   flog

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require_relative './coverage_helper'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'rspec-html-matchers'
+require 'rspec/its'
 require_relative './support/sipity/rspec_matchers'
 require 'shoulda/matchers'
 


### PR DESCRIPTION
## Removing Faker gem

@36b207fde0b63589b71058dc90845928f9514119

While useful, this is something that has not been leveraged throughout
the code. It was brought along as part of the rails generator template.

## Removing meta_request

@b31e717c65fb58c6c2a2e54cb3f89a373758effa

I have not used this in the past years, instead falling back to console
logging. I don't know if others have used it.

## No longer auto-requiring pry-bug tooling

@90a55b51a8faa54e67a28a80376c03691e8fa407

If you need this, go ahead and require it as part of your debugging
process.

## Removing auto require of rspec-its

@31edb5ca57804ba0614e650136ad260165e9fa05

We don't need it on a Rails load for all environments.

## Site prism need not auto-load.

@c67ebc2aeed9ed1788e7cb5b670e1031881bdf14

Its being loading during the support process.
