### PR TITLE
Fixing curate ingesting not firing cataloging

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -436,6 +436,9 @@
       "group": "ETD Ingestors",
       "role": "batch_ingesting"
     }, {
+      "group": "Batch Ingestors",
+      "role": "batch_ingesting"
+    }, {
       "group": "Data Administrators",
       "role": "data_observing"
     }, {

--- a/app/presenters/sipity/controllers/debug_role_presenter.rb
+++ b/app/presenters/sipity/controllers/debug_role_presenter.rb
@@ -8,7 +8,7 @@ module Sipity
       presents :debug_role
 
       delegate :name, :to_processing_entity, :repository, to: :debug_role
-      delegate :id, to: :debug_role, prefix: :role
+      delegate :id, :model_name, to: :debug_role, prefix: :role
 
       def initialize(context, options = {})
         super

--- a/app/views/sipity/controllers/work_submissions/debug.html.curly
+++ b/app/views/sipity/controllers/work_submissions/debug.html.curly
@@ -14,7 +14,7 @@
         <li>
           <dl>
             <dt>Name</dt>
-            <dd>{{name}} (ID={{role_id}})</dd>
+            <dd>{{name}} ({{role_model_name}} ID={{role_id}})</dd>
             <dt>Actors</dt>
             <dd>
               <ul>

--- a/spec/presenters/sipity/controllers/debug_role_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/debug_role_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'sipity/controllers/debug_role_presenter'
 module Sipity
   module Controllers
     RSpec.describe DebugRolePresenter, type: :presenter do
-      let(:role) { double(id: '456', to_processing_entity: processing_entity, name: 'A Role', repository: repository) }
+      let(:role) { double(id: '456', to_processing_entity: processing_entity, name: 'A Role', repository: repository, model_name: 'H') }
       let(:processing_entity) do
         double(id: '123', strategy_name: 'Shoe', strategy_id: '456', strategy_state_name: 'Untied', strategy_state_id: '789')
       end
@@ -18,6 +18,7 @@ module Sipity
       it { is_expected.to delegate_method(:repository).to(:debug_role) }
       it { is_expected.to delegate_method(:to_processing_entity).to(:debug_role) }
       it { is_expected.to delegate_method(:role_id).to(:debug_role).as(:id) }
+      it { is_expected.to delegate_method(:role_model_name).to(:debug_role).as(:model_name) }
 
       it 'will guard the interface of the role' do
         expect { described_class.new(context, debug_role: double) }.to raise_error(Exceptions::InterfaceExpectationError)


### PR DESCRIPTION
## Updating ETD data generation

@81e5162bbbf1430a3df730145b2d82999dd2b3db

There was a name change to consolidate the batch ingest process to use
the same Batch Ingestor group name across multiple work areas. See
commit @1e860fd2714627700ceb0c556c690e45c6f32c01.

This was added to the Master's Thesis work flow but not to the Doctoral
Dissertation workflow. That information is now being added.

## Improving debug show page for greater clarity

@4e39ce65ef91f179997c07000b859e35603e17f4

As part of the trouble shooting, I needed to see what groups were
assigned. The debug form assists with that information. By adding the
model name to the page, I can be certain what model to query for
additional information.
