### PR TITLE
Updating Sipity callback handling of request body

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -128,6 +128,7 @@ Metrics/AbcSize:
      - 'app/repositories/sipity/commands/processing_commands.rb'
      - app/forms/sipity/forms/processing_form.rb
      - app/mailers/sipity/mailer_builder.rb
+     - app/controllers/sipity/controllers/work_submission_callbacks_controller.rb
 Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false

--- a/app/controllers/sipity/controllers/work_submission_callbacks_controller.rb
+++ b/app/controllers/sipity/controllers/work_submission_callbacks_controller.rb
@@ -46,11 +46,24 @@ module Sipity
       #
       # @see https://github.com/ndlib/curatend-batch/blob/master/webhook.md
       def command_attributes
-        params.fetch(:work) { HashWithIndifferentAccess.new }.merge(normalized_attributes_for_existing_callback_constraints)
+        params.fetch(:work) { HashWithIndifferentAccess.new }.merge(
+          normalized_attributes_for_existing_callback_constraints
+        ).merge(
+          request_body_attributes
+        )
       end
 
       def normalized_attributes_for_existing_callback_constraints
-        params.except(:action, :controller, :work_id, :processing_action_name, :work, :work_submission)
+        params.except(:action, :controller, :work_id, :processing_action_name, :work, :work_submission, :format)
+      end
+
+      # Because not all parameters may be coming from the query params; in fact they may be raw params from the body
+      def request_body_attributes
+        return {} unless request.format.json?
+        return {} unless request.body.present?
+        JSON.parse(request.body.read)
+      ensure
+        request.body.rewind if request.body.present?
       end
     end
   end


### PR DESCRIPTION
Since deploying the Sipity v2016.16 (or the day after), the webhook
callbacks have been firing from the batch ingester, but were not being
processed via the callback mechanism.

After some debugging, the WEBHOOK posting was coming as part of the
request's raw body (as per the documentation).

I ran the test I wrote against the v2016.16 codebase, and the test
failed. So something odd has happened.

Regardless, this code change now accounts for data posted as both
query parameters and request raw body.

Also adding a hound/rubocop exclusion for method complexity; This is a
compact method that is doing a few things, but I believe it remains
legible.