### PR TITLE
Reducing iterations through an array

### DIFF
--- a/app/decorators/sipity/decorators/dashboard_view.rb
+++ b/app/decorators/sipity/decorators/dashboard_view.rb
@@ -23,7 +23,7 @@ module Sipity
         # TODO: Move this to a repository question; After all don't we want
         # to limit the filter to only objects that are for states in which the
         # user can actually do something (ie see it, alter it, etc)
-        Models::Processing::StrategyState.all.pluck(:name).uniq.sort
+        Models::Processing::StrategyState.all.order(:name).select(:name).uniq.pluck(:name)
       end
 
       def works_scope


### PR DESCRIPTION
The previous version looped twice through the returned array. The
updated version leverages SQL's uniqueness and sorting options thus
removing the need to iterate twice through the returned array.

This was detected through `Rubocop 0.40.0`'s suggestion of moving
`.uniq` to before the `.pluck(:name)`. It does require a bit of
reworking but Huzzah for less redundant looping through arrays.