### PR TITLE
Ignoring weird URI exceptions

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -5,4 +5,5 @@ Airbrake.configure do |config|
   config.secure  = config.port == 443
   config.user_attributes = [:id, :username]
   config.ignore << "Sipity::Exceptions::AuthorizationFailureError"
+  config.ignore << "URI::InvalidComponentError"
 end


### PR DESCRIPTION
The following exception shows up with some occassion:

```ruby
URI::InvalidComponentError
```

It is the result of the following command:

```console
curl -X GET -H 'User-Agent: Netcraft SSL Server Survey - contact info@netcraft.com' https://_/
```