### PR TITLE
Tidying up rakefile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'capybara-accessible', require: false
   gem 'codeclimate-test-reporter', require: nil
   gem 'database_cleaner'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,8 +175,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-accessible (0.2.1)
-      capybara (~> 2.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -580,7 +578,6 @@ DEPENDENCIES
   capistrano-rails-console
   capistrano-rvm (~> 0.1.1)
   capybara
-  capybara-accessible
   codeclimate-test-reporter
   coffee-rails (~> 4.0)
   commitment

--- a/Rakefile
+++ b/Rakefile
@@ -52,12 +52,6 @@ if defined?(RSpec)
       ENV['SPEC_OPTS'] ||= "--profile 5"
       Rake::Task[:default].invoke
     end
-
-    desc "Run all features with accessibility checks"
-    RSpec::Core::RakeTask.new(:accessible) do |t|
-      ENV['ACCESSIBLE'] = 'true'
-      t.pattern = './spec/features/**/*_spec.rb'
-    end
   end
 
   # BEGIN `commitment:install` generator

--- a/Rakefile
+++ b/Rakefile
@@ -58,17 +58,6 @@ if defined?(RSpec)
       ENV['ACCESSIBLE'] = 'true'
       t.pattern = './spec/features/**/*_spec.rb'
     end
-
-    desc "Validate the code coverage goals"
-    task validate_coverage_goals: :environment do
-      default_percentage_coverage_goal = '100'
-      json_document = Rails.root.join('coverage/.last_run.json').read
-      coverage_percentage = JSON.parse(json_document).fetch('result').fetch('covered_percent').to_i
-      goal_percentage = (Figaro.env.percent_coverage_goal || default_percentage_coverage_goal).to_i
-      if goal_percentage > coverage_percentage
-        abort("Code Coverage Goal Not Met:\n\t#{goal_percentage}%\tExpected\n\t#{coverage_percentage}%\tActual")
-      end
-    end
   end
 
   # BEGIN `commitment:install` generator

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -5,4 +5,5 @@ Airbrake.configure do |config|
   config.secure  = config.port == 443
   config.user_attributes = [:id, :username]
   config.ignore << "Sipity::Exceptions::AuthorizationFailureError"
+  config.ignore << "URI::InvalidComponentError"
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,19 +1,6 @@
 require 'capybara/poltergeist'
 
-if ENV['ACCESSIBLE']
-  require 'capybara/accessible'
-
-  RSpec.configure do |config|
-    config.around(:each, inaccessible: true) do |example|
-      Capybara::Accessible.skip_audit { example.run }
-    end
-  end
-
-  Capybara.default_driver = :accessible_poltergeist
-  Capybara.javascript_driver = :accessible_poltergeist
-else
-  Capybara.default_driver = :rack_test
-end
+Capybara.default_driver = :rack_test
 
 Capybara.ignore_hidden_elements = false
 Capybara.asset_host = 'http://localhost:3000'


### PR DESCRIPTION
## Ignoring weird URI exceptions

@7753668a5d469ac75e95bef3da31fb5b910c45f1

The following exception shows up with some occassion:

```ruby
URI::InvalidComponentError
```

It is the result of the following command:

```console
curl -X GET -H 'User-Agent: Netcraft SSL Server Survey - contact info@netcraft.com' https://_/
```

## Removing coverage goal task

@1d0bfa8c36b1c164fbd465785cb9af4215218754

This goal is set as part of Commitment; So we no longer need to include
this task.

## Removing capybara-accessible

@5f2345f2bb3fd81e12c794aa730fb3008b3177f4

While a nice consideration it is not something that I have run in the
past year, so I'm opting to remove it.
