### PR TITLE
Standardize character used for apostrophe

### DIFF
--- a/app/conversions/sipity/conversions/to_rof/work_converters/etd_converter.rb
+++ b/app/conversions/sipity/conversions/to_rof/work_converters/etd_converter.rb
@@ -65,7 +65,7 @@ module Sipity
             # Loading translations adds a significant chunk of time to the test suite.
             {
               Models::WorkType::DOCTORAL_DISSERTATION => "Doctoral Dissertation",
-              Models::WorkType::MASTER_THESIS => "Master’s Thesis"
+              Models::WorkType::MASTER_THESIS => "Master's Thesis"
             }.fetch(work.work_type)
           end
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,8 +256,8 @@ en:
             </p>
   work_types:
     master_thesis:
-      label: "Master’s Thesis"
-      curate_nd_label: "Master’s Thesis"
+      label: "Master's Thesis"
+      curate_nd_label: "Master's Thesis"
     doctoral_dissertation:
       label: "Doctoral Dissertation"
       curate_nd_label: "Doctoral Dissertation"
@@ -356,7 +356,7 @@ en:
           material_already_published: 'Material already published'
         work_type:
           doctoral_dissertation: 'Doctoral Dissertation'
-          master_thesis: "Master’s Thesis"
+          master_thesis: "Master's Thesis"
         access_rights_answer:
           open_access_html: '<b>Public</b> — Freely viewable to the world'
           restricted_access_html: '<b>Restricted</b> — Only groups you specifiy have access'


### PR DESCRIPTION
CurateND used Master's Thesis, while Sipity used Master’s Thesis. This
discrepancy caused a split in the work type facet. Since the majority of the
items were using Curate's method, the decision was made to modify it in Sipity.

Data migration will still be needed on the 47 items that were using this apostrophe.