### PR TITLE
Notifying Airbrake when batch ingest fails

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -14,6 +14,9 @@ module Sipity
     class InvalidAuthorizationCredentialsError < RuntimeError
     end
 
+    class IngestUnableToCompleteError < RuntimeError
+    end
+
     # When you can't instantiate a specific work converter, raise this exception.
     class FailedToInitializeWorkConverterError < RuntimeError
       attr_reader :work

--- a/app/forms/sipity/forms/work_submissions/core/ingest_completed_form.rb
+++ b/app/forms/sipity/forms/work_submissions/core/ingest_completed_form.rb
@@ -1,5 +1,7 @@
 require_relative '../../../forms'
 require 'sipity/conversions/convert_to_permanent_uri'
+require 'sipity/conversions/convert_to_polymorphic_type'
+require 'sipity/exceptions'
 
 module Sipity
   module Forms
@@ -9,6 +11,7 @@ module Sipity
         class IngestCompletedForm
           # @see https://github.com/ndlib/curatend-batch/blob/master/webhook.md
           JOB_STATE_SUCCESS = 'success'.freeze
+          JOB_STATE_ERROR = 'error'.freeze
 
           ProcessingForm.configure(
             form_class: self, base_class: Models::Work, processing_subject_name: :work, attribute_names: [:job_state]
@@ -25,6 +28,7 @@ module Sipity
           validates :job_state, inclusion: { in: [JOB_STATE_SUCCESS] }
 
           def submit
+            register_error if job_state == JOB_STATE_ERROR
             processing_action_form.submit { create_a_redirect }
           end
 
@@ -33,6 +37,20 @@ module Sipity
           include Conversions::ConvertToPermanentUri
           def create_a_redirect
             repository.create_redirect_for(work: work, url: convert_to_permanent_uri(work))
+          end
+
+          include Conversions::ConvertToPolymorphicType
+          def register_error
+            Airbrake.notify_or_ignore(
+              error_class: Exceptions::IngestUnableToCompleteError,
+              error_message: "#{Exceptions::IngestUnableToCompleteError}: Problem encountered in Batch Ingester. Review batch logs.",
+              parameters: {
+                work_id: work.to_param,
+                work_type: convert_to_polymorphic_type(work),
+                job_state: job_state,
+                processing_action_name: processing_action_name
+              }
+            )
           end
         end
       end


### PR DESCRIPTION
Prior to this commit, I was only handling the happy case. However, we
had silent failures in the batch ingest (in part because the batch
ingest does not report any errors, instead relying on silent logging
of work that failed).

DLTP-576