### PR TITLE
Updating dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     ffi (1.9.14)
     figaro (1.1.1)
       thor (~> 0.14)
-    flay (2.8.0)
+    flay (2.8.1)
       erubis (~> 2.7.0)
       path_expander (~> 1.0)
       ruby_parser (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capybara (2.7.1)
+    capybara (2.8.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,7 +546,7 @@ GEM
     turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.1)
+    uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -506,7 +506,7 @@ GEM
       activesupport (>= 3)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
-    simple_form (3.2.1)
+    simple_form (3.3.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
     simplecov (0.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ GEM
     rubycas-client (2.3.9)
       activesupport
     rubyzip (1.2.0)
-    sanitize (4.1.0)
+    sanitize (4.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
-    jquery-rails (4.1.1)
+    jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,7 +434,7 @@ GEM
     rb-readline (0.5.3)
     rdiscount (2.2.0.1)
     request_store (1.3.1)
-    responders (2.2.0)
+    responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     ast (2.3.0)
-    autoprefixer-rails (6.4.0.1)
+    autoprefixer-rails (6.4.0.3)
       execjs
     bcrypt (3.1.11)
     better_errors (2.1.1)

--- a/app/inputs/multi_value_input.rb
+++ b/app/inputs/multi_value_input.rb
@@ -7,6 +7,7 @@ class MultiValueInput < SimpleForm::Inputs::CollectionInput
   def input(*)
     @rendered_first_element = false
     input_html_classes.unshift("string")
+    input_html_options[:multiple] = multiple?
     input_html_options[:type] ||= 'text'
     input_html_options[:name] ||= "#{object_name}[#{attribute_name}][]"
     markup = <<-HTML


### PR DESCRIPTION
## Updating autoprefixer-rails dependency

@c9a7bdcb88aeb45dc64f9221aa48ae2e24007e7e

`$ ./script/update-dependency autoprefixer-rails`

## Updating uglifier dependency

@7463d7c8f20c7aa50f5e7201fd2f8c0028afb1ca

`$ ./script/update-dependency uglifier`

## Updating simple_form dependency

@51f22549e7f85ea253cfb14c17174a7ec6336731

`$ ./script/update-dependency simple_form`

## Updating sanitize dependency

@2a5e063adbb62dc58557a98329570124e612959b

`$ ./script/update-dependency sanitize`

## Updating responders dependency

@a9f508605be7812992d6a1e53cb9e47678980c07

`$ ./script/update-dependency responders`

## Updating jquery-rails dependency

@b5f56b03a88e34e4491e772cabdeff177b731b4a

`$ ./script/update-dependency jquery-rails`

## Updating capybara dependency

@0b976a78f0c30b0fd32cf13b558e89504e40b377

`$ ./script/update-dependency capybara`

## Updating flay dependency

@8d4918d93a9fdd56bbc1ec0297a0fa9073cfda4b

`$ ./script/update-dependency flay`

## Accounting for changes in SimpleForm

@8305f890b2d68d69a15c4334b70c7aab3dc3d4d1

With the update of SimpleForm, the #multiple? method was no longer
being called as part of the specs. When reviewing the UI rendering, it
was not setting the multiple property and I was not getting the UI
assistance widget for multiple entries.
