### PR TITLE
New secrets management

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,15 +14,8 @@ set :repo_url, "https://github.com/ndlib/sipity.git"
 set :branch, ENV['BRANCH_NAME'] || 'master'
 set :keep_releases, 5
 set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-set :secret_repo_name, Proc.new{
-  case fetch(:rails_env)
-  when 'staging' then 'secret_staging'
-  when 'pre_production' then 'secret_pprd'
-  when 'production' then 'secret_prod'
-  end
-}
 set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:rails_env)}" }
-set :whenever_variables,    ->{ "environment=#{fetch :rails_env}" }
+set :whenever_variables, ->{ "environment=#{fetch :rails_env}" }
 
 namespace :deploy do
 
@@ -136,16 +129,16 @@ end
 
 namespace :configuration do
   desc 'Update application secrets'
-  task :copy_secrets do
+  task :update_secrets do
     on roles(:app) do
       within release_path do
-        execute "export PATH=/opt/ruby/current/bin:$PATH && cd #{release_path} && sh scripts/update_secrets.sh #{fetch(:secret_repo_name)}"
+        execute "export PATH=/opt/ruby/current/bin:$PATH && cd #{release_path} && sh scripts/update_secrets.sh #{File.join(shared_path, 'secret')}"
       end
     end
   end
 end
 
-before 'deploy:db_migrate', 'configuration:copy_secrets'
+before 'deploy:db_migrate', 'configuration:update_secrets'
 after 'deploy', 'deploy:db_migrate'
 before 'deploy:db_migrate', 'deploy:db_dump'
 after 'deploy:db_migrate', 'deploy:db_seed'

--- a/scripts/copy_secrets.sh
+++ b/scripts/copy_secrets.sh
@@ -5,16 +5,10 @@
 # TODO update script to perform the correct function
 #
 # usage:
-#   ./update_secrets.sh <name of secret repo>
+#   ./copy_secrets.sh <secret directory> <target host>
 
-secret_repo=$1
-
-if [ -d $secret_repo ]; then
-    echo "=-=-=-=-=-=-=-= delete $secret_repo"
-    rm -rf $secret_repo
-fi
-echo "=-=-=-=-=-=-=-= git clone $secret_repo"
-git clone "git@git.library.nd.edu:$secret_repo"
+secret_dir=$1
+app_host=$2
 
 files_to_copy="
     config/application.yml
@@ -27,11 +21,11 @@ files_to_copy="
 
 for f in $files_to_copy; do
     echo "=-=-=-=-=-=-=-= copy $f"
-    if [ -f $secret_repo/sipity/$f ];
+    if [ -f "$secret_dir/$f" ];
     then
-        cp $secret_repo/sipity/$f $f
+        scp -rv "$secret_dir/$f" "app@$app_host:/home/app/shared/$f"
     else
-        echo "Fatal Error: File $f does not exist in $secret_repo/sipity"
+        echo "Fatal Error: File $f does not exist in $secret_dir"
         exit 1
     fi
 done

--- a/scripts/copy_secrets.sh
+++ b/scripts/copy_secrets.sh
@@ -2,24 +2,22 @@
 #
 # Copy the relevant secrets from the build server to the app server.
 #
-# TODO update script to perform the correct function
-#
 # usage:
 #   ./copy_secrets.sh <secret directory> <target host>
 
 secret_dir=$1
 app_host=$2
 
-    if [ -d "$secret_dir" ];
-    then
-        scp -r "$secret_dir" "app@$app_host:/home/app/sipity/shared/secret"
-    else
-        echo "Fatal Error: Source directory $secret_dir does not exist"
-        exit 1
-    fi
+if [ -d "$secret_dir" ];
+then
+  scp -r "$secret_dir" "app@$app_host:/home/app/sipity/shared/secret"
+else
+  echo "Fatal Error: Source directory $secret_dir does not exist"
+  exit 1
+fi
 
-    if [ $? -ne 0 ];
-    then
-	echo "Fatal Error: scp ${secret_dir} app@${app_host}:/home/app/sipity/shared/secret failed" 
-	exit 1
-    fi
+if [ $? -ne 0 ];
+then
+  echo "Fatal Error: scp ${secret_dir} app@${app_host}:/home/app/sipity/shared/secret failed" 
+  exit 1
+fi

--- a/scripts/copy_secrets.sh
+++ b/scripts/copy_secrets.sh
@@ -10,22 +10,16 @@
 secret_dir=$1
 app_host=$2
 
-files_to_copy="
-    config/application.yml
-    config/database.yml
-    config/newrelic.yml
-    config/environment_bootstrapper.rb
-    config/locales/site-specific.yml
-    app/assets/stylesheets/theme/_default.scss
-    "
-
-for f in $files_to_copy; do
-    echo "=-=-=-=-=-=-=-= copy $f"
-    if [ -f "$secret_dir/$f" ];
+    if [ -d "$secret_dir" ];
     then
-        scp -rv "$secret_dir/$f" "app@$app_host:/home/app/shared/$f"
+        scp -r "$secret_dir" "app@$app_host:/home/app/sipity/shared/secret"
     else
-        echo "Fatal Error: File $f does not exist in $secret_dir"
+        echo "Fatal Error: Source directory $secret_dir does not exist"
         exit 1
     fi
-done
+
+    if [ $? -ne 0 ];
+    then
+	echo "Fatal Error: scp ${secret_dir} app@${app_host}:/home/app/sipity/shared/secret failed" 
+	exit 1
+    fi

--- a/scripts/copy_secrets.sh
+++ b/scripts/copy_secrets.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copy the relevant secrets from the build server to the app server.
+#
+# TODO update script to perform the correct function
+#
+# usage:
+#   ./update_secrets.sh <name of secret repo>
+
+secret_repo=$1
+
+if [ -d $secret_repo ]; then
+    echo "=-=-=-=-=-=-=-= delete $secret_repo"
+    rm -rf $secret_repo
+fi
+echo "=-=-=-=-=-=-=-= git clone $secret_repo"
+git clone "git@git.library.nd.edu:$secret_repo"
+
+files_to_copy="
+    config/application.yml
+    config/database.yml
+    config/newrelic.yml
+    config/environment_bootstrapper.rb
+    config/locales/site-specific.yml
+    app/assets/stylesheets/theme/_default.scss
+    "
+
+for f in $files_to_copy; do
+    echo "=-=-=-=-=-=-=-= copy $f"
+    if [ -f $secret_repo/sipity/$f ];
+    then
+        cp $secret_repo/sipity/$f $f
+    else
+        echo "Fatal Error: File $f does not exist in $secret_repo/sipity"
+        exit 1
+    fi
+done

--- a/scripts/update_secrets.sh
+++ b/scripts/update_secrets.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
 #
-# Copy the preproduction secrets to the correct place for deployment
-#
-# This runs on the worker VM and on the cluster
+# Copy the secrets from the shared capistrno directory to the release directory
 #
 # usage:
-#   ./update_secrets.sh <name of secret repo>
+#   ./update_secrets.sh <directory of secrets>
 
-secret_repo=$1
-
-if [ -d $secret_repo ]; then
-    echo "=-=-=-=-=-=-=-= delete $secret_repo"
-    rm -rf $secret_repo
-fi
-echo "=-=-=-=-=-=-=-= git clone $secret_repo"
-git clone "git@git.library.nd.edu:$secret_repo"
+secret_dir=$1
 
 files_to_copy="
     config/application.yml
@@ -27,11 +18,11 @@ files_to_copy="
 
 for f in $files_to_copy; do
     echo "=-=-=-=-=-=-=-= copy $f"
-    if [ -f $secret_repo/sipity/$f ];
+    if [ -f "$secret_dir/$f" ];
     then
-        cp $secret_repo/sipity/$f $f
+        cp "$secret_dir/$f" "$f"
     else
-        echo "Fatal Error: File $f does not exist in $secret_repo/sipity"
+        echo "Fatal Error: File $f does not exist in $secret_dir"
         exit 1
     fi
 done


### PR DESCRIPTION
We are changing how secrets get injected into the Sipity application environment.

### Old process

1. Start Jenkins job
2. Start the Capistrano deployment
3. Check out the secret repo on the app server
4. Copy the secrets out of the repo into the release directory
5. Capistrano completes deployment
6. Jenkins job completes

### New process

1. Start Jenkins job
2. Copy latest Sipity-specific secrets to shared directory set up by Capistrano, see `scripts/copy_secrets.sh`. There is some question about how exactly these files will be updated on the Jenkins server. For now, there will be a touch point with ESU when they need to be changed.
3. Run Capistrano deployment. Early in this process `scripts/update_secrets.sh` copies the secret files from the `shared_path` to the `release_path`.
4. Jenkins job completes

@ialford & @hanstra does this look good to you?