### PR TITLE
Fixing batch ingester

### DIFF
--- a/app/jobs/sipity/jobs/core/bulk_ingest_job.rb
+++ b/app/jobs/sipity/jobs/core/bulk_ingest_job.rb
@@ -70,7 +70,7 @@ module Sipity
 
         def set_search_criteria!
           @search_criteria = search_criteria_builder.call(
-            user: requested_by, processing_state: initial_processing_state_name, work_area: work_area_slug, page: :all
+            user: requested_by, processing_state: initial_processing_state_name, work_area: work_area_slug
           )
         end
 

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -24,7 +24,7 @@ module Sipity
 
       def initialize(**keywords)
         ATTRIBUTE_NAMES.each do |attribute_name|
-          send("#{attribute_name}=", keywords[attribute_name] || send("default_#{attribute_name}"))
+          send("#{attribute_name}=", keywords.fetch(attribute_name) { send("default_#{attribute_name}") })
         end
       end
 
@@ -38,14 +38,10 @@ module Sipity
 
       private
 
-      attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per
+      attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per, :page
 
       def order=(input)
         @order = ORDER_BY_OPTIONS.include?(input) ? input : default_order
-      end
-
-      def page=(input)
-        @page = (input == :all ? nil : input)
       end
 
       def q=(input)

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -465,7 +465,9 @@ module Sipity
 
         scope = scope.order(criteria.order) if criteria.order?
         scope = scope.page(criteria.page) if criteria.page?
-        scope = scope.per(criteria.per) if criteria.per?
+        # For Kaminari to work with `.per` page, there is a method call temporal
+        # dependency. First you must call `.page` then you may call `.per`.
+        scope = scope.per(criteria.per) if criteria.per? && criteria.page?
         scope
       end
 

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -54,11 +54,6 @@ module Sipity
         subject = described_class.new(order: 'chicken-sandwich')
         expect(subject.order).to eq(subject.send(:default_order))
       end
-
-      it 'will fallback to no page if :all is given' do
-        subject = described_class.new(page: :all)
-        expect(subject.page).to be_nil
-      end
     end
   end
 end


### PR DESCRIPTION
## Fixing batch ingester

ee725aad61abb35a0dfc1287e1787e45319dc197

For Kaminari to work with per page, there is a method call temporal
dependency. First you must call `.page` then you may call `.per`.

The processing query was violating the temporal interface. Below is
the method calls from [the source code][source_code]

```ruby
scope = scope.order(criteria.order) if criteria.order?
scope = scope.page(criteria.page) if criteria.page?
scope = scope.per(criteria.per) if criteria.per?
scope
```

Prior to this change, the `:page` for criteria parameters was nil,
meaning that `scope = scope.page(criteria.page) if criteria.page?` was
skipped. However `:per` was set, and thus
`scope = scope.per(criteria.per) if criteria.per?` was called. This
resulted in a method missing error.

The fix is to amend the batch ingester method to no longer force
pagination. This may mean that we slowly work through a list of objects
15 at a time (or however many we specify).

Addresses DLTP-1230 # Close

[source_code]:https://github.com/ndlib/sipity/blob/47b96299eef5793556cfb45d1a9af27ea1bd992a/app/repositories/sipity/queries/processing_queries.rb#L466-L470
