### PR TITLE
Dltp 974 advisor role change

### DIFF
--- a/app/repositories/sipity/commands/permission_commands.rb
+++ b/app/repositories/sipity/commands/permission_commands.rb
@@ -21,14 +21,28 @@ module Sipity
         grant_permission_for!(entity: entity, actors: actors, acting_as: acting_as)
       end
 
+      # @api public
       def grant_permission_for!(entity:, actors:, acting_as:)
         Array.wrap(actors).flatten.compact.each do |an_actor|
           grant_processing_permission_for!(entity: entity, actor: an_actor, role: acting_as)
         end
       end
 
+      # @api private
       def grant_processing_permission_for!(entity:, actor:, role:)
         Services::GrantProcessingPermission.call(entity: entity, actor: actor, role: role)
+      end
+
+      # @api public
+      def revoke_permission_for!(entity:, actors:, acting_as:)
+        Array.wrap(actors).flatten.compact.each do |an_actor|
+          revoke_processing_permission_for!(entity: entity, actor: an_actor, role: acting_as)
+        end
+      end
+
+      # @api private
+      def revoke_processing_permission_for!(entity:, actor:, role:)
+        Services::RevokeProcessingPermission.call(entity: entity, actor: actor, role: role)
       end
     end
   end

--- a/app/repositories/sipity/commands/work_commands.rb
+++ b/app/repositories/sipity/commands/work_commands.rb
@@ -7,43 +7,12 @@ module Sipity
     module WorkCommands
       # Responsible for adding collaborators to the work and removing anyone
       # else.
-      def manage_collaborators_for(work:, collaborators:, repository: self)
-        collaborators_table = Models::Collaborator.arel_table
-        Models::Collaborator.where(
-          collaborators_table[:work_id].eq(work.id).and(
-            collaborators_table[:id].not_in(Array.wrap(collaborators).flat_map(&:id))
-          )
-        ).destroy_all
-
-        assign_collaborators_to(work: work, collaborators: collaborators, repository: repository)
+      def manage_collaborators_for(work:, collaborators:)
+        Services::ManageCollaborators.manage_collaborators_for(work: work, collaborators: collaborators, repository: self)
       end
 
-      # Responsible for assigning collaborators to a work.
-      def assign_collaborators_to(work:, collaborators:, repository: self)
-        # TODO: Encapsulate this is a Service Object as there is enough logic
-        # to warrant this behavior.
-        Array.wrap(collaborators).each do |collaborator|
-          collaborator.work_id = work.id
-          collaborator.save!
-          next unless collaborator.responsible_for_review?
-          create_sipity_user_from(netid: collaborator.netid, email: collaborator.email) do |user|
-            change_processing_actor_proxy(from_proxy: collaborator, to_proxy: user)
-            # TODO: This cannot be the assumed role for the :acting_as; I wonder if it would make sense
-            # to dilineate roles on the contributor and roles in the system?
-            repository.grant_permission_for!(actors: user, entity: work, acting_as: Models::Role::ADVISING)
-          end
-        end
-      end
-
-      # In an effort to preserve processing actors, I want to expose a mechanism
-      # for transfering processing actors to another proxy.
-      #
-      # This method arises as we consider the scenario in which someone approves
-      # on behalf of a non-User collaborator (i.e. someone that has an email
-      # address). Then the collaborator is changed such that a user is created.
-      def change_processing_actor_proxy(from_proxy:, to_proxy:)
-        return unless from_proxy.respond_to?(:processing_actor) && from_proxy.processing_actor.present?
-        from_proxy.processing_actor.update(proxy_for: to_proxy)
+      def assign_collaborators_to(work:, collaborators:)
+        Services::ManageCollaborators.assign_collaborators_to(work: work, collaborators: collaborators, repository: self)
       end
 
       def create_work!(submission_window:, **attributes)
@@ -95,21 +64,6 @@ module Sipity
           update_all(is_representative_file: false)
         Models::Attachment.where(work_id: work.id, pid: attachment.pid).update_all(is_representative_file: true)
       end
-
-      def create_sipity_user_from(netid:, email: nil)
-        return false unless netid.present?
-        # This assumes a valid NetID.
-        user = User.find_or_create_by!(username: netid) do |u|
-          u.email = email || default_email_for_netid(netid)
-        end
-        yield(user) if block_given?
-        user
-      end
-
-      def default_email_for_netid(netid)
-        "#{netid}@nd.edu"
-      end
-      private :default_email_for_netid
 
       # @return [#call] A call-able object that when called will return a String
       #

--- a/app/services/sipity/services/manage_collaborators.rb
+++ b/app/services/sipity/services/manage_collaborators.rb
@@ -1,0 +1,101 @@
+require 'active_support/core_ext/array/wrap'
+
+module Sipity
+  module Services
+    # Responsible for managing the relationship between a work and it's collaborators
+    # - Removing collaborators that are not associated with the work
+    # - Assigning permission to those reviewing the work
+    # - Removing permission to those that shifted from review to non-review role
+    class ManageCollaborators
+      # @api public
+      def self.manage_collaborators_for(work:, collaborators:, repository:)
+        new(work: work, collaborators: collaborators, repository: repository).manage_collaborators!
+      end
+
+      # @api public
+      def self.assign_collaborators_to(work:, collaborators:, repository:)
+        new(work: work, collaborators: collaborators, repository: repository).assign_given_collaborators!
+      end
+
+      def initialize(work:, collaborators:, repository:)
+        self.work = work
+        self.collaborators = collaborators
+        self.repository = repository
+      end
+
+      attr_reader :work, :collaborators, :repository
+
+      def manage_collaborators!
+        remove_orphaned_collaborators!
+        assign_given_collaborators!
+      end
+
+      def assign_given_collaborators!
+        collaborators.each do |collaborator|
+          collaborator.work_id = work.id
+          collaborator.save!
+          if collaborator.responsible_for_review?
+            assign_reviewing_permission_to(collaborator: collaborator)
+          else
+            revoke_reviewing_permission_from(collaborator: collaborator)
+          end
+        end
+      end
+
+      private
+
+      def remove_orphaned_collaborators!
+        collaborators_table = Models::Collaborator.arel_table
+        Models::Collaborator.where(
+          collaborators_table[:work_id].eq(work.id).and(
+            collaborators_table[:id].not_in(collaborators.flat_map(&:id))
+          )
+        ).destroy_all
+      end
+
+      def assign_reviewing_permission_to(collaborator:)
+        create_sipity_user_from(netid: collaborator.netid, email: collaborator.email) do |user|
+          change_processing_actor_proxy(from_proxy: collaborator, to_proxy: user)
+          # TODO: This cannot be the assumed role for the :acting_as; I wonder if it would make sense
+          # to dilineate roles on the contributor and roles in the system?
+          repository.grant_permission_for!(actors: user, entity: work, acting_as: Models::Role::ADVISING)
+        end
+      end
+
+      def revoke_reviewing_permission_from(collaborator:)
+        # TODO
+      end
+
+      # In an effort to preserve processing actors, I want to expose a mechanism
+      # for transfering processing actors to another proxy.
+      #
+      # This method arises as we consider the scenario in which someone approves
+      # on behalf of a non-User collaborator (i.e. someone that has an email
+      # address). Then the collaborator is changed such that a user is created.
+      def change_processing_actor_proxy(from_proxy:, to_proxy:)
+        return unless from_proxy.respond_to?(:processing_actor) && from_proxy.processing_actor.present?
+        from_proxy.processing_actor.update(proxy_for: to_proxy)
+      end
+
+      def create_sipity_user_from(netid:, email: nil)
+        return false unless netid.present?
+        # This assumes a valid NetID.
+        user = User.find_or_create_by!(username: netid) do |u|
+          u.email = email || default_email_for_netid(netid)
+        end
+        yield(user) if block_given?
+        user
+      end
+
+      def default_email_for_netid(netid)
+        "#{netid}@nd.edu"
+      end
+
+      attr_writer :work, :repository
+
+      def collaborators=(input)
+        @collaborators = Array.wrap(input)
+      end
+    end
+  end
+end

--- a/app/services/sipity/services/manage_collaborators.rb
+++ b/app/services/sipity/services/manage_collaborators.rb
@@ -63,7 +63,11 @@ module Sipity
       end
 
       def revoke_reviewing_permission_from(collaborator:)
-        # TODO
+        actors = [collaborator]
+        # Because of the odd relationship between collaborators and users (eg. Collaborators need not be signed into the
+        # system, nor may not exist), we need to disassociate either user or collaborator from this
+        actors << User.find_by(username: collaborator.netid) if collaborator.netid?
+        repository.revoke_permission_for!(actors: actors.compact, entity: work, acting_as: Models::Role::ADVISING)
       end
 
       # In an effort to preserve processing actors, I want to expose a mechanism

--- a/spec/repositories/sipity/commands/permission_commands_spec.rb
+++ b/spec/repositories/sipity/commands/permission_commands_spec.rb
@@ -21,6 +21,18 @@ module Sipity
           subject.grant_creating_user_permission_for!(entity: entity, user: user)
         end
       end
+
+      context '#revoke_permission_for!' do
+        let(:entity) { Models::Work.new(id: 1) }
+        let(:user) { User.new(id: 2) }
+        let(:group) { Models::Group.new(id: 3) }
+
+        it 'will revoke the given role for each of the given actors' do
+          expect(Services::RevokeProcessingPermission).to receive(:call).with(entity: entity, actor: user, role: 'A Role')
+          expect(Services::RevokeProcessingPermission).to receive(:call).with(entity: entity, actor: group, role: 'A Role')
+          subject.revoke_permission_for!(entity: entity, actors: [user, group], acting_as: 'A Role')
+        end
+      end
     end
   end
 end

--- a/spec/services/sipity/services/manage_collaborators_spec.rb
+++ b/spec/services/sipity/services/manage_collaborators_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require 'support/sipity/command_repository_interface'
+require 'sipity/services/manage_collaborators'
+
+module Sipity
+  module Services
+    RSpec.describe ManageCollaborators do
+      let(:work) { Models::Work.new(id: 123) }
+      let(:repository) { CommandRepositoryInterface.new }
+      let(:responsible_for_review?) { false }
+      let(:collaborator) do
+        Models::Collaborator.new(
+          work_id: work.id, responsible_for_review: responsible_for_review?, name: 'Jeremy', role: 'Research Director', netid: 'somebody'
+        )
+      end
+
+      it 'exposes .assign_collaborators_to as a public API convenience method' do
+        expect_any_instance_of(described_class).to receive(:assign_given_collaborators!)
+        described_class.assign_collaborators_to(work: work, repository: repository, collaborators: collaborator)
+      end
+
+      describe '.manage_collaborators_for' do
+        it 'will disassociate from the work (and destroy) collaborators and any associated processing actor not provided' do
+          collaborator.save! # Ensuring an association
+          collaborator.to_processing_actor # Ensuring a processing actor
+          expect do
+            expect do
+              described_class.manage_collaborators_for(work: work, collaborators: [], repository: repository)
+            end.to change { Models::Processing::Actor.count }.by(-1)
+          end.to change { Models::Collaborator.count }.by(-1)
+        end
+
+        context 'when a collaborator is not responsible_for_review' do
+          let(:responsible_for_review?) { false }
+          it 'will create a collaborator but not a user nor permission' do
+            expect(repository).not_to receive(:grant_permission_for!)
+            expect do
+              expect do
+                described_class.assign_collaborators_to(work: work, collaborators: collaborator, repository: repository)
+              end.to change(Models::Collaborator, :count).by(1)
+            end.to_not change(User, :count)
+          end
+        end
+
+        context 'when a collaborator is responsible_for_review' do
+          let(:responsible_for_review?) { true }
+          it 'will create a collaborator, user, and permission' do
+            expect(repository).to receive(:grant_permission_for!).and_call_original
+            expect do
+              expect do
+                described_class.manage_collaborators_for(work: work, collaborators: collaborator, repository: repository)
+              end.to change(Models::Collaborator, :count).by(1)
+            end.to change(User, :count).by(1)
+          end
+
+          it 'will transfer permissioning from the collaborator to the newly assigned user' do
+            collaborator.save!
+            processing_actor = collaborator.to_processing_actor # Ensuring a processing actor
+            expect(processing_actor.reload.proxy_for).to eq(collaborator)
+            described_class.manage_collaborators_for(work: work, collaborators: collaborator, repository: repository)
+
+            # As the user is created, we want to transfer any permission from that collaborator to the user.
+            expect(processing_actor.reload.proxy_for).to eq(User.last)
+          end
+        end
+
+        context 'when a collaborator was once responsible for review, but no longer is' do
+          before do
+            collaborator.responsible_for_review = true
+            collaborator.save!
+          end
+          xit 'will remove permissions from that collaborator' do
+            collaborator.responsible_for_review = false
+            expect(repository).to receive(:revoke_permission_for!).and_call_original
+            described_class.manage_collaborators_for(work: work, collaborators: collaborator, repository: repository)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/sipity/services/revoke_processing_permission_spec.rb
+++ b/spec/services/sipity/services/revoke_processing_permission_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+require 'sipity/services/revoke_processing_permission'
+
+module Sipity
+  module Services
+    RSpec.describe RevokeProcessingPermission do
+      let(:entity) { Models::Processing::Entity.new(id: 1, strategy_id: strategy.id, strategy: strategy) }
+      let(:strategy) { Models::Processing::Strategy.new(id: 2) }
+      let(:role) { Models::Role.new(id: 3) }
+      let(:actor) { Models::Processing::Actor.new(id: 4) }
+      let(:strategy_role) { Models::Processing::StrategyRole.new(strategy_id: strategy.id, role_id: role.id) }
+      let(:strategy_responsibility) do
+        Sipity::Models::Processing::StrategyResponsibility.new(actor_id: actor.id, strategy_role_id: strategy_role.id)
+      end
+
+      subject { described_class.new(entity: entity, role: role, actor: actor) }
+
+      context '.call' do
+        it 'will instantiate then call the instance' do
+          expect(described_class).to receive(:new).and_return(double(call: true))
+          described_class.call(entity: entity, role: role, actor: actor)
+        end
+      end
+
+      context '#call' do
+        let(:fake_relation) { double(first!: strategy_role) }
+        before do
+        end
+        it 'will return true if role is not valid for the strategy' do
+          expect(subject.call).to eq(true)
+        end
+        it 'will destroy an entity specific entry if one exists [strategy,role]' do
+          strategy_role.save!
+          Models::Processing::EntitySpecificResponsibility.create!(
+            strategy_role_id: strategy_role.id, entity_id: entity.id, actor_id: actor.id
+          )
+          expect do
+            expect do
+              subject.call
+            end.to change { Models::Processing::EntitySpecificResponsibility.count }.by(-1)
+          end.to_not change { Models::Processing::StrategyResponsibility.count }
+        end
+        it 'will not destroy anything if an entity specific entry does not exist for [strategy,role]' do
+          strategy_role.save!
+          strategy_responsibility.save!
+          allow(Sipity::Models::Processing::StrategyResponsibility).to receive(:count).and_return(1)
+          expect do
+            expect do
+              subject.call
+            end.to_not change { Models::Processing::EntitySpecificResponsibility.count }
+          end.to_not change { Models::Processing::StrategyResponsibility.count }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -34,7 +34,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def assign_collaborators_to(work:, collaborators:, repository: self)
+    def assign_collaborators_to(work:, collaborators:)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -69,10 +69,6 @@ module Sipity
     def build_work_submission_processing_action_form(work:, processing_action_name:, **keywords)
     end
 
-    # @see ./app/repositories/sipity/commands/work_commands.rb
-    def change_processing_actor_proxy(from_proxy:, to_proxy:)
-    end
-
     # @see ./app/repositories/sipity/queries/collaborator_queries.rb
     def collaborators_that_can_advance_the_current_state_of(work:, id: nil)
     end
@@ -94,19 +90,11 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def create_sipity_user_from(netid:, email: nil)
-    end
-
-    # @see ./app/repositories/sipity/commands/work_commands.rb
     def create_work!(submission_window:, **attributes)
     end
 
     # @see ./app/repositories/sipity/commands/additional_attribute_commands.rb
     def create_work_attribute_values!(work:, key:, values:)
-    end
-
-    # @see ./app/repositories/sipity/commands/work_commands.rb
-    def default_email_for_netid(netid)
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
@@ -206,7 +194,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/commands/work_commands.rb
-    def manage_collaborators_for(work:, collaborators:, repository: self)
+    def manage_collaborators_for(work:, collaborators:)
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -225,6 +225,14 @@ module Sipity
     def representative_attachment_for(work:)
     end
 
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def revoke_permission_for!(entity:, actors:, acting_as:)
+    end
+
+    # @see ./app/repositories/sipity/commands/permission_commands.rb
+    def revoke_processing_permission_for!(entity:, actor:, role:)
+    end
+
     # @see ./app/repositories/sipity/queries/administrative_scheduled_action_queries.rb
     def scheduled_time_from_work(work:, reason:)
     end


### PR DESCRIPTION
## Refactoring managing and assigning collaborators

214cad70528161ae73a8ecfedd9be5214b0ee709

In the comments, I was following a recommended TODO item: extracting a
service class. I think that this extraction helps:

* tidy up the public interface of the Repository modules
* isolate the logic related to managing and assigning collaborators
* create the space for resolving the DLTP-974 issue (e.g. When
  advisor's role changes need to synchronize processing permissions)

Note: this commit does not resolve DLTP-974, but instead makes it
easier to resolve.

## Adding logic for revoke_processing_permission

24e481d85f1e95cc13b54b3ddc51e22ebdd787a3

From the originating DLTP-971 issue:

Reported issue:

> I know I need to contact the external research director for an
> approval, but can you look into why the committee member received a
> sign-off request email? I don't think she was supposed to — she is
> showing as a Committee Member in the record.

Bug analysis:

> I've done some digging and it appears what happened is that the
> person was initially assigned as a Research Director. This created
> the permissions and associated the person with the need to perform
> reviews. Then, at a later point the person was changed from a
> Research Director to Committee Member.

The solution was to create a symmetrical method to the
`grant_processing_permission` method.

DLTP-974 # Close
Related to DLTP-971
