### PR TITLE
Dltp 1270 updating for ulra 2018

### DIFF
--- a/app/data_generators/sipity/data_generators/submission_windows/ulra_submission_windows.config.json
+++ b/app/data_generators/sipity/data_generators/submission_windows/ulra_submission_windows.config.json
@@ -75,5 +75,44 @@
         "roles": "work_submitting"
       }]
     }]
+    },{
+      "attributes": {
+        "open_for_starting_submissions_at": "2018-01-17",
+        "closed_for_starting_submissions_at": "2018-04-14 00:00:00",
+        "slug": "2018"
+      },
+      "strategy_permissions": [{
+        "group": "All Registered Users",
+        "role": "work_submitting"
+      }],
+      "work_type_config_paths": ["app/data_generators/sipity/data_generators/work_types/ulra_work_types.config.json"],
+      "actions": [{
+        "name": "show",
+        "from_states": [{
+          "name": ["new", "opened", "closed"],
+          "roles": "work_submitting"
+        }]
+      }, {
+        "name": "open",
+        "transition_to": "opened",
+        "from_states": [{
+          "name": ["new", "closed"],
+          "roles": "ulra_reviewing"
+        }]
+      }, {
+        "name": "close",
+        "transition_to": "closed",
+        "from_states": [{
+          "name": ["opened", "new"],
+          "roles": "ulra_reviewing"
+        }]
+      }, {
+        "name": "start_a_submission",
+        "from_states": [{
+          "name": ["new", "opened"],
+          "roles": "work_submitting"
+        }]
+      }]
+
   }]
 }

--- a/app/views/sipity/mailers/ulra_mailer/_important_dates.html.erb
+++ b/app/views/sipity/mailers/ulra_mailer/_important_dates.html.erb
@@ -1,8 +1,8 @@
 <h2>Important Dates</h2>
 
 <ul>
-  <li>3/27/17 Submission window opens</li>
-  <li>4/21/17 Complete application packages due</li>
-  <li>4/26/17 Award recipients notified</li>
-  <li>5/5/17 Awards given during the Undergraduate Scholars Conference Awards Reception</li>
+  <li>3/1/18 Submission window opens</li>
+  <li>4/13/18 Complete application packages due</li>
+  <li>4/24/18 Award recipients notified</li>
+  <li>5/4/18 Awards given during the Undergraduate Scholars Conference Awards Reception</li>
 </ul>


### PR DESCRIPTION
## Updating important ULRA dates for 2018

703f32f5a9481f73a70fdf2a10834606d037de7f

Following the pattern for 2017's important dates cb30e88ff607ca831fd738aad28f132db255ee82,
this commit updates the email template for 2018.

Related to DLTP-1270

## Adding 2018 ULRA submission window

ffe2212bceaa7ebbb028de832ac04a9080c8086f

Following the established pattern of SHA1 68751a7c46ba8764a154f3b29deb0d63a78e2fe6,
this commit adds the necessary submission window information for ULRA
2018.

Related to DLTP-1270
