### PR TITLE
Ensuring submission window is passed for filter

### DIFF
--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -23,7 +23,7 @@ module Sipity
             @search_criteria ||= begin
               Parameters::SearchCriteriaForWorksParameter.new(
                 user: current_user, processing_state: work_area.processing_state, page: work_area.page, order: work_area.order,
-                repository: repository, work_area: work_area, q: work_area.q
+                repository: repository, work_area: work_area, q: work_area.q, submission_window: work_area.submission_window
               )
             end
           end

--- a/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
@@ -8,7 +8,9 @@ module Sipity
         RSpec.describe ShowPresenter do
           let(:context) { PresenterHelper::ContextWithForm.new(current_user: current_user, request: double(path: '/path'), paginate: true) }
           let(:current_user) { double('Current User') }
-          let(:work_area) { double(slug: 'the-slug', title: 'The Slug', processing_state: 'new', order: 'title', page: 1, q: nil) }
+          let(:work_area) do
+            double(slug: 'the-slug', submission_window: '2016', title: 'The Slug', processing_state: 'new', order: 'title', page: 1, q: nil)
+          end
           let(:repository) { QueryRepositoryInterface.new }
           let(:processing_action) { double(name: 'start_a_submission') }
           subject { described_class.new(context, work_area: work_area, repository: repository) }


### PR DESCRIPTION
Sipity had properly configured [processing queries][processing_queries],
however when I was setting the search criteria, I overlooked setting the
submission window (see ea3e35be7b8b454b904e9e1dcc28f5f453d58a85 for
further details on the work that was done)

DLTP-1252

[processing_queries]:https://github.com/ndlib/sipity/blob/ec8204b3984f25661cda2da35fe93da10184fe66/app/repositories/sipity/queries/processing_queries.rb#L557-L569