### PR TITLE
Dltp 967 remediate slow dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ SSL=true bin/rails s
 
 Then go to https://localhost:3000
 
+### Development Seeds
+
+`rake bootstrap` - reset the environment's database with basic seed data
+
+In `./lib/tasks/development.rake` you can find Rake tasks for adding data.
+
 ### Work Submission
 
 The primary feature (and complexity) is Sipity's work submission show page. Below is a diagram that helps break down its composition.

--- a/app/decorators/sipity/decorators/dashboard_view.rb
+++ b/app/decorators/sipity/decorators/dashboard_view.rb
@@ -27,7 +27,7 @@ module Sipity
       end
 
       def works_scope
-        repository.find_works_via_search(criteria: criteria, repository: repository)
+        @works_scope ||= repository.find_works_via_search(criteria: criteria, repository: repository)
       end
 
       def works(decorator: WorkDecorator)

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -8,7 +8,7 @@ module Sipity
       class_attribute(*DEFAULT_ATTRIBUTE_NAMES, instance_writer: false)
 
       self.default_page = 1
-      self.default_per = 15
+      self.default_per = 8
       self.default_user = nil
       self.default_proxy_for_type = Models::Work
       self.default_processing_state = nil

--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -1,0 +1,41 @@
+namespace :development do
+  desc 'Add development entries for ULRA (you may want to run `rake bootstrap` beforehand)'
+  task :seed_ulra => [:environment, 'db:seed'] do
+    require 'sipity/command_line_context'
+    # Making an assumption that we have a user. We could use multiple, but roles
+    # start to get far more complicated.
+    user = User.first!
+
+    # The default context is assumed to be a Rails controller. Instead use the
+    # command line context, and thus build the entries through much the same
+    # process as if it were done through the controller. Note this context
+    # skips authentication/authorization (which you'd need to use something like
+    # Sipity::Jobs::Core::PerformActionForWorkJob)
+    context = Sipity::CommandLineContext.new(requested_by: user)
+    submission_window = context.repository.find_open_submission_windows_by(work_area: 'ulra').first!
+    form_builder = Sipity::Forms::SubmissionWindows::Ulra::StartASubmissionForm
+
+    # I want to test pagination in particular
+    (1..20).each do |index|
+      setup_form = form_builder.new(
+        submission_window: submission_window,
+        requested_by: context.requested_by,
+        attributes: {}
+      )
+
+      form = form_builder.new(
+        submission_window: setup_form.submission_window,
+        requested_by: context.requested_by,
+        attributes: {
+          title: "Hello World #{index}",
+          award_category: setup_form.award_categories_for_select.sample,
+          advisor_netid: 'jfriesen',
+          advisor_name: 'Jeremy Friesen',
+          course_name: 'My Course',
+          course_number: "My Course Number"
+        }
+      )
+      form.submit
+    end
+  end
+end

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -25,7 +25,7 @@ module Sipity
 
       its(:default_page) { is_expected.to eq(1) }
       its(:page?) { is_expected.to eq(true) }
-      its(:default_per) { is_expected.to eq(15) }
+      its(:default_per) { is_expected.to eq(8) }
       its(:per?) { is_expected.to eq(true) }
       its(:default_user) { is_expected.to eq(nil) }
       its(:user?) { is_expected.to eq(false) }


### PR DESCRIPTION
## Adding `rake development:seed_ulra` task

eaae37e27fe26f55a325288964f627a16b65e47f

As I'm interested in having some rudimentary, albeit not very diverse,
data, I wanted to write up methods for seeding data.

## Reducing default pagination from 15 to 8

1b1ca5ead28f3479fe3bd6d493c81d404f9f27b4

There are underlying slowness on the index page due to the flexible data
structure of Sipity and not a direct consideration for the data-
structure necessary for rendering an index view instead of a show page.

This is a quick fix meant to address DLTP-967. If the reduced pagination
does not improve the apparent responsiveness, we'll need to look into
additional measures (e.g. define the data-structure and populate that
with query results)
