### PR TITLE
Updating graduateschool URL to reflect new website

### DIFF
--- a/app/views/sipity/mailers/etd_mailer/_etd_submission_assistance.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/_etd_submission_assistance.html.erb
@@ -1,6 +1,6 @@
 <p>
   If you have not yet submitted the other items required,
-  please refer to the Graduate School’s <a href="http://graduateschool.nd.edu/resources-for-current-students/dt/dt-checklist/">submission checklist</a>.
+  please refer to the Graduate School’s <a href="https://graduateschool.nd.edu/policies-forms/doctoral-dissertations-masters-theses/formal-submissions/">submission checklist</a>.
   If you have questions about your ETD record or the other submission materials,
   please contact me or my assistant at <%= mail_to "dteditor@nd.edu", "dteditor@nd.edu", subject: 'ETD Submission Assistance' %>
   or <a href="tel:+15746317545">574-631-7545</a> for assistance.


### PR DESCRIPTION
The graduate school cutover a new website (Congratulations!). With that
cutover the previous URL was redirected to the updated URL. The grad
school, not wanting to maintain too many of those, asked for the URL to
change within Sipity.

DLTP-1543