### PR TITLE
Allow multiple administrative units

### DIFF
--- a/app/forms/sipity/forms/work_submissions/etd/administrative_unit_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/administrative_unit_form.rb
@@ -37,7 +37,7 @@ module Sipity
           private
 
           def administrative_unit_from_work
-            repository.work_attribute_values_for(work: work, key: 'administrative_unit', cardinality: 1)
+            repository.work_attribute_values_for(work: work, key: 'administrative_unit', cardinality: :many)
           end
         end
       end

--- a/app/views/sipity/controllers/work_submissions/etd/administrative_unit.html.erb
+++ b/app/views/sipity/controllers/work_submissions/etd/administrative_unit.html.erb
@@ -12,10 +12,10 @@
   </legend>
 
   <fieldset class="panel-body">
-    <p class="panel-hint">Select the administrative unit for which you are submitting this work</p>
+    <p class="panel-hint">Select the administrative units for which you are submitting this work</p>
     <%= f.error_notification %>
     <%= f.error :base, error_method: :to_sentence %>
-    <%= f.input :administrative_unit, collection: model.available_administrative_units, input_html: { class: 'form-control', selected: model.administrative_unit } %>
+    <%= f.input :administrative_unit, collection: model.available_administrative_units, input_html: { class: 'form-control', multiple: true, selected: model.administrative_unit } %>
   </fieldset>
 
   <div class="panel-footer action-pane">

--- a/spec/forms/sipity/forms/work_submissions/etd/administrative_unit_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/administrative_unit_form_spec.rb
@@ -16,7 +16,7 @@ module Sipity
 
           before do
             allow(repository).to receive(:work_attribute_values_for).
-              with(work: work, key: 'administrative_unit', cardinality: 1).and_return(nil)
+              with(work: work, key: 'administrative_unit', cardinality: :many).and_return(nil)
           end
 
           its(:processing_action_name) { is_expected.to eq('administrative_unit') }
@@ -51,7 +51,7 @@ module Sipity
             subject { described_class.new(keywords) }
             it 'will return the administrative_unit of the work' do
               expect(repository).to receive(:work_attribute_values_for).
-                with(work: work, key: 'administrative_unit', cardinality: 1).and_return(administrative_unit)
+                with(work: work, key: 'administrative_unit', cardinality: :many).and_return(administrative_unit)
               expect(subject.administrative_unit).to eq 'A Specific College'
             end
           end
@@ -72,7 +72,7 @@ module Sipity
 
             context 'with valid data' do
               subject do
-                described_class.new(keywords.merge(attributes: { administrative_unit: 'A Specific College' }, repository: repository))
+                described_class.new(keywords.merge(attributes: { administrative_unit: ['A Specific College'] }, repository: repository))
               end
               before do
                 allow(subject).to receive(:valid?).and_return(true)


### PR DESCRIPTION
Change Sipity form to allow selection and display of multiple administrative units.

Completes https://jira.library.nd.edu/browse/DLTP-1594