### PR TITLE
Clean blank element in Admin Unit array

### DIFF
--- a/app/views/sipity/controllers/work_submissions/etd/administrative_unit.html.erb
+++ b/app/views/sipity/controllers/work_submissions/etd/administrative_unit.html.erb
@@ -15,7 +15,7 @@
     <p class="panel-hint">Select the administrative units for which you are submitting this work</p>
     <%= f.error_notification %>
     <%= f.error :base, error_method: :to_sentence %>
-    <%= f.input :administrative_unit, collection: model.available_administrative_units, input_html: { class: 'form-control', multiple: true, selected: model.administrative_unit } %>
+    <%= f.input :administrative_unit, collection: model.available_administrative_units, include_hidden: false, input_html: { class: 'form-control', multiple: true, selected: model.administrative_unit } %>
   </fieldset>
 
   <div class="panel-footer action-pane">

--- a/spec/forms/sipity/forms/work_submissions/etd/administrative_unit_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/administrative_unit_form_spec.rb
@@ -8,7 +8,7 @@ module Sipity
       module Etd
         RSpec.describe AdministrativeUnitForm do
           let(:work) { Models::Work.new(id: '1234') }
-          let(:administrative_unit) { 'administrative_unit_name' }
+          let(:administrative_unit) { ['administrative_unit_name'] }
           let(:attributes) { {} }
           let(:repository) { CommandRepositoryInterface.new }
           let(:keywords) { { work: work, requested_by: double, repository: repository, attributes: attributes } }
@@ -47,12 +47,12 @@ module Sipity
           end
 
           context 'retrieving values from the repository' do
-            let(:administrative_unit) { 'A Specific College' }
+            let(:administrative_unit) { ['A Specific College'] }
             subject { described_class.new(keywords) }
             it 'will return the administrative_unit of the work' do
               expect(repository).to receive(:work_attribute_values_for).
                 with(work: work, key: 'administrative_unit', cardinality: :many).and_return(administrative_unit)
-              expect(subject.administrative_unit).to eq 'A Specific College'
+              expect(subject.administrative_unit).to eq ['A Specific College']
             end
           end
 


### PR DESCRIPTION
Simple-form with multiple entry elements adds an empty element at the beginning of the array. Converting admin unit to multi-element requires hiding the blank element.

See https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select

Related to https://jira.library.nd.edu/browse/DLTP-1594