### PR TITLE
Clean up organization name

### DIFF
--- a/app/models/sipity/models/additional_attribute.rb
+++ b/app/models/sipity/models/additional_attribute.rb
@@ -38,7 +38,6 @@ module Sipity
       MAJORS = 'majors'.freeze
       MINORS = 'minors'.freeze
       OCLC_NUMBER = 'oclc_number'.freeze
-      ORGANIZATION_PREDICATE_NAME = 'organization'.freeze
       OTHER_RESOURCES_CONSULTED_PREDICATE_NAME = 'other_resources_consulted'.freeze
       PRIMARY_COLLEGE_PREDICATE_NAME = 'primary_college'.freeze
       PROGRAM_NAME_PREDICATE_NAME = 'program_name'.freeze
@@ -89,7 +88,6 @@ module Sipity
           MAJORS => MAJORS,
           MINORS => MINORS,
           OCLC_NUMBER => OCLC_NUMBER,
-          ORGANIZATION_PREDICATE_NAME => ORGANIZATION_PREDICATE_NAME,
           OTHER_RESOURCES_CONSULTED_PREDICATE_NAME => OTHER_RESOURCES_CONSULTED_PREDICATE_NAME,
           PRIMARY_COLLEGE_PREDICATE_NAME => PRIMARY_COLLEGE_PREDICATE_NAME,
           PROGRAM_NAME_PREDICATE_NAME => PROGRAM_NAME_PREDICATE_NAME,


### PR DESCRIPTION
Relates to https://jira.library.nd.edu/browse/DLTP-1427

Predicate `organization` is unused. Removing it here allows for the removal of the corresponding json file from locabulary.