### PR TITLE
Adding "irb" gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,7 @@ group :production, :pre_production, :staging do
   gem 'dragonfly-s3_data_store'
   gem 'rack-cache', require: 'rack/cache'
   gem 'rb-readline'
+  gem 'irb'
 end
 source 'https://rails-assets.org' do
   gem 'rails-assets-readmore'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,7 @@ GEM
     inflecto (0.0.2)
     interception (0.5)
     ipaddress (0.8.3)
+    irb (0.9.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -693,6 +694,7 @@ DEPENDENCIES
   hesburgh-lib!
   i18n-debug
   inch
+  irb
   jbuilder (~> 2.0)
   jquery-rails
   jshintrb!


### PR DESCRIPTION
```console
$ bundle exec rails console production
$PATH/lib/rails/commands/console.rb:2:in `require': cannot load such file -- irb (LoadError)
	from $PATH/lib/rails/commands/console.rb:2:in `<top (required)>'
	from $PATH/lib/rails/commands/commands_tasks.rb:123:in `require'
	from $PATH/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
	from $PATH/lib/rails/commands/commands_tasks.rb:58:in `console'
	from $PATH/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from $PATH/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:34:in `require'
	from bin/rails:34:in `<main>'
```