### PR TITLE
Modify RestClient put_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ You can use Graphviz to view a visual representation of that graph. On OS X, use
 
 The primary feature of Sipity is state-based permissions. It can be helpful to force an object into a given state. Use `Sipity::Services::Administrative::ForceIntoProcessingState.call` via `$ rails console`
 
+Example: `Sipity::Services::Administrative::ForceIntoProcessingState.call(entity: Sipity::Models::Work.find(id), state: 'ready_for_ingest')`
+
 ### Batch Ingest Documentation
 
 #### Sipity Code-Path for Batch Ingest

--- a/app/exporters/sipity/exporters/batch_ingest_exporter/api_file_utils.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter/api_file_utils.rb
@@ -16,20 +16,9 @@ module Sipity
         end
 
         def self.put_file(path, file)
-          # The following tagged the token as part of the file:
-          # RestClient.put path, myfile: File.new(file, 'rb'), 'X-Api-Token' => Figaro.env.curate_batch_api_key!
-          # This appears to transfer the file without adding the token.
-
-          request = RestClient::Request.new(
-            method: :put,
-            url: path,
-            'X-Api-Token': Figaro.env.curate_batch_api_key!,
-            payload: {
-              multipart: true,
-              file: File.new(file, 'rb')
-            }
-          )
-          request.execute
+          # The entire file is loaded into memory prior to sending it.
+          content = File.new(file, 'rb').read
+          RestClient.put path, content, 'X-Api-Token' => Figaro.env.curate_batch_api_key!
         end
       end
     end

--- a/app/exporters/sipity/exporters/batch_ingest_exporter/api_file_utils.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter/api_file_utils.rb
@@ -16,7 +16,20 @@ module Sipity
         end
 
         def self.put_file(path, file)
-          RestClient.put path, myfile: File.new(file, 'rb'), 'X-Api-Token' => Figaro.env.curate_batch_api_key!
+          # The following tagged the token as part of the file:
+          # RestClient.put path, myfile: File.new(file, 'rb'), 'X-Api-Token' => Figaro.env.curate_batch_api_key!
+          # This appears to transfer the file without adding the token.
+
+          request = RestClient::Request.new(
+            method: :put,
+            url: path,
+            'X-Api-Token': Figaro.env.curate_batch_api_key!,
+            payload: {
+              multipart: true,
+              file: File.new(file, 'rb')
+            }
+          )
+          request.execute
         end
       end
     end


### PR DESCRIPTION
The command was sending the pdf file with the token attached as part of it. The change keeps the token separate.

Fixes DLTP-1611 garbled pdf issue