### PR TITLE
Updating Locabulary to include latest changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 gem 'kaminari'
 gem 'listen', '~> 3.0.7' # Frozen for Ruby 2.2.2; Release once updated
-gem 'locabulary', github: 'ndlib/locabulary', branch: 'master'
+gem 'locabulary', github: 'ndlib/locabulary', ref: '9d4a7c1b6a5956c5152924b1ff51d3f0798581d8'
 gem 'loofah' # Related to hesburgh-lib's dependency
 gem 'mime-types', '~> 2.6', require: 'mime/types/columnar' # Free 20% RAM by not loading ALL mime-types
 gem 'noids_client', github: 'ndlib/noids_client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,13 +55,13 @@ GIT
 
 GIT
   remote: https://github.com/ndlib/locabulary.git
-  revision: 9836ee851c5552599c9cb5c8dbd15495472ceaa3
-  branch: master
+  revision: 9d4a7c1b6a5956c5152924b1ff51d3f0798581d8
+  ref: 9d4a7c1b6a5956c5152924b1ff51d3f0798581d8
   specs:
     locabulary (0.8.1)
       activesupport (>= 4.0, < 6.0)
-      dry-configurable (~> 0.1.7)
-      json (~> 1.8)
+      dry-configurable
+      json
 
 GIT
   remote: https://github.com/ndlib/noids_client.git


### PR DESCRIPTION
Instead of referencing master, opting for an explicit SHA. Even though
the explicit SHA is part of the Gemfile.lock, it provides greater
clarity on what version of Locabulary is in use.

```console
$ bundle
```