### PR TITLE
Dltp 1642 send email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,13 +200,13 @@ GEM
       rubocop
       scss-lint
       simplecov
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.5)
     crass (1.0.4)
     database_cleaner (1.6.2)
     debug_inspector (0.0.3)
     deprecation (0.99.0)
       activesupport
-    devise (4.4.3)
+    devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -388,7 +388,7 @@ GEM
     method_source (0.9.0)
     mime-types (2.99.3)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -398,8 +398,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
     netrc (0.11.0)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.2)
+      mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
     notiffany (0.1.1)
@@ -500,9 +500,9 @@ GEM
     ref (2.0.0)
     request_store (1.4.0)
       rack (>= 1.4)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)

--- a/app/views/sipity/mailers/etd_mailer/confirmation_of_grad_school_signoff.html.erb
+++ b/app/views/sipity/mailers/etd_mailer/confirmation_of_grad_school_signoff.html.erb
@@ -19,7 +19,7 @@
 <ul>
   <li>Title: <%= @entity.title %></li>
   <li>Submitted for advisor approval: <%= @entity.submission_date.to_sentence %></li>
-  <li>ETD record access: <%= t("sipity/emails.access_controls.#{@entity.work_access.access_right_code.to_s.titleize}") %></li>
+  <li>ETD record access: <%= t("sipity/emails.access_controls.#{@entity.work_access.access_right_code.to_s}") %></li>
   <li>Publishing statement: <%= @entity.publishing_intent.to_sentence %></li>
   <li>First public disclosure of material being considered for patent protection: <%= @entity.patent_intent.to_sentence %></li>
 </ul>
@@ -28,7 +28,7 @@
 <ul class="nested-attributes-list">
   <% Array.wrap(@entity.accessible_files).each do |accessible_file| %>
     <li class="nested-attribute-list">File name: <%= link_to accessible_file.to_s.html_safe, accessible_file.access_url %></li>
-    <li class="value access-right">File access: <%= t("sipity/emails.access_controls.#{accessible_file.access_right_code.to_s.titleize}") %></li>
+    <li class="value access-right">File access: <%= t("sipity/emails.access_controls.#{accessible_file.access_right_code.to_s}") %></li>
       <% if accessible_file.release_date.present? %>
         <li class="value release-date">Release date: <%= accessible_file.release_date %></li>
       <% end %>

--- a/app/views/sipity/shared/_accessible_objects.html.erb
+++ b/app/views/sipity/shared/_accessible_objects.html.erb
@@ -8,7 +8,7 @@
         <dd class="value accessible-object-type"><%= accessible_object.accessible_object_type %></dd>
         <dt class="predicate access-right"><%= accessible_object.translate(:access_right_code) %></dt>
         <% if accessible_object.access_right_code.present? %>
-        <dd class="value access-right"><%= t("sipity/emails.access_controls.#{accessible_object.access_right_code.to_s.titleize}") %></dd>
+        <dd class="value access-right"><%= t("sipity/emails.access_controls.#{accessible_object.access_right_code.to_s}") %></dd>
         <% else %>
         <dd class="value access-right"><em>Unknown</em></dd>
         <% end %>


### PR DESCRIPTION
# Update devise dependency

Due to security vulnerability in versions under 4.6.0.

# Fix access right translation

Completes https://jira.library.nd.edu/browse/DLTP-1642

The code was attempting to translate the titlized version of the `access_right_code`, which did not exist in the translation yml file.