### PR TITLE
Adding command to ease group member management

### DIFF
--- a/app/repositories/sipity/commands/administrative_commands.rb
+++ b/app/repositories/sipity/commands/administrative_commands.rb
@@ -1,0 +1,40 @@
+require 'active_support/core_ext/array/wrap'
+
+module Sipity
+  # :nodoc:
+  module Commands
+    # Commands
+    module AdministrativeCommands
+      # @api public
+      #
+      # Responsible for:
+      #   1. Ensuring that the given :group_name exists.
+      #   2. Ensuring that each user by :username exists.
+      #   3. Ensuring that each of the given users has membership in the given group
+      #   4. If :force_membership_to_these_usernames is true, then ensure that no other
+      #      no other users have membership in the given group.
+      #
+      # @param [String] group_name - The name of the Sipity::Models::Group to which
+      #    we'll be adding group members
+      # @param [Array<String>] usernames - The name of the users
+      # @param [Boolean] force_membership_to_these_usernames - If true, only the given
+      #    users will have membership in the given group. If false, the given users
+      #    will be appended to the membership of the group.
+      #
+      # @return void
+      def set_group_membership(group_name:, usernames: [], force_membership_to_these_usernames: false)
+        # Find or create the group by name
+        group = Sipity::Models::Group.find_or_create_by!(name: group_name)
+        user_ids = Array.wrap(usernames).map do |username|
+          user = User.find_or_create_by!(username: username)
+          group.group_memberships.find_or_create_by!(user: user)
+          user.id
+        end
+        return true unless force_membership_to_these_usernames
+        group.group_memberships.each do |group_membership|
+          group_membership.destroy unless user_ids.include?(group_membership.user_id)
+        end
+      end
+    end
+  end
+end

--- a/config/environment_bootstrapper.rb
+++ b/config/environment_bootstrapper.rb
@@ -1,47 +1,40 @@
 # Don't worry, this will be obliterated by super secret environment bootstrap
 # type things.
+require 'sipity/command_repository'
+
+command_repository = Sipity::CommandRepository.new
+
 $stdout.puts "Creating User '#{ENV['USER']}' (from ENV['USER'])..."
 user = User.find_or_create_by!(username: ENV['USER'])
 
 graduate_school_reviewers = Sipity::DataGenerators::WorkTypes::EtdGenerator::GRADUATE_SCHOOL_REVIEWERS
 $stdout.puts "Finding or creating group for '#{graduate_school_reviewers}'"
-graduate_school = Sipity::Models::Group.find_or_create_by!(name: graduate_school_reviewers)
+$stdout.puts "Associating #{user.username} with #{graduate_school_reviewers}"
+command_repository.set_group_membership(group_name: graduate_school_reviewers, usernames: [user.username])
+
+catalogers = Sipity::DataGenerators::WorkTypes::EtdGenerator::CATALOGERS
+$stdout.puts "Finding or creating group for '#{catalogers}'"
+$stdout.puts "Associating #{user.username} with #{catalogers}"
+command_repository.set_group_membership(group_name: catalogers, usernames: [user.username])
+
 
 batch_ingestor_name = Sipity::Models::Group::BATCH_INGESTORS
 $stdout.puts "Finding or batch ingestors for '#{batch_ingestor_name}'"
-batch_ingestor = Sipity::Models::Group.find_or_create_by!(name: batch_ingestor_name)
+$stdout.puts "Creating User batch_ingestor"
+command_repository.set_group_membership(group_name: catalogers, usernames: ['batch_ingesting'])
+batch_ingestor = Sipity::Models::Group.find_by!(name: batch_ingestor_name)
 batch_ingestor.update!(api_key: Figaro.env.sipity_access_key_for_batch_ingester!)
 
 $stdout.puts "Finding or batch ingestors for '#{Sipity::Models::Group::ETD_INTEGRATORS}'"
 integrator = Sipity::Models::Group.find_or_create_by!(name: Sipity::Models::Group::ETD_INTEGRATORS)
 integrator.update!(api_key: Figaro.env.sipity_access_key_for_etd_integrators!)
 
-$stdout.puts "Associating #{user.username} with #{graduate_school.name}"
-graduate_school.group_memberships.find_or_create_by(user: user)
-
-catalogers = Sipity::DataGenerators::WorkTypes::EtdGenerator::CATALOGERS
-$stdout.puts "Finding or creating group for '#{catalogers}'"
-cataloging = Sipity::Models::Group.find_or_create_by!(name: catalogers)
-
-$stdout.puts "Associating #{user.username} with #{cataloging.name}"
-cataloging.group_memberships.find_or_create_by(user: user)
-
-$stdout.puts "Creating User batch_ingestor"
-batch_ingestor = User.find_or_create_by!(username: "batch_ingesting")
-
-$stdout.puts "Associating batch_ingestor with #{batch_ingestor.name}"
-batch_ingestor.group_memberships.find_or_create_by(user: batch_ingestor)
-
 ulra_review_committee_group_name = Sipity::DataGenerators::WorkTypes::UlraGenerator::ULRA_REVIEW_COMMITTEE_GROUP_NAME
 $stdout.puts "Finding or creating group for '#{ulra_review_committee_group_name}'"
-ulra_review_committee_group = Sipity::Models::Group.find_or_create_by!(name: ulra_review_committee_group_name)
-
-$stdout.puts "Associating #{user.name} with #{ulra_review_committee_group.name}"
-ulra_review_committee_group.group_memberships.find_or_create_by(user: batch_ingestor)
+$stdout.puts "Associating #{user.name} with #{ulra_review_committee_group_name}"
+command_repository.set_group_membership(group_name: ulra_review_committee_group_name, usernames: [user.username])
 
 ulra_data_remediators = 'ULRA Data Remediators'
 $stdout.puts "Finding or creating group for '#{ulra_data_remediators}'"
-ulra_data_remediator_group = Sipity::Models::Group.find_or_create_by!(name: ulra_data_remediators)
-
-$stdout.puts "Associating #{user.name} with #{ulra_data_remediator_group.name}"
-ulra_data_remediator_group.group_memberships.find_or_create_by(user: user)
+$stdout.puts "Associating #{user.name} with #{ulra_data_remediators}"
+command_repository.set_group_membership(group_name: ulra_data_remediators, usernames: [user.username])

--- a/spec/repositories/sipity/commands/administrative_commands_spec.rb
+++ b/spec/repositories/sipity/commands/administrative_commands_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+require 'sipity/commands/administrative_commands'
+
+module Sipity
+  module Commands
+    RSpec.describe AdministrativeCommands, type: :isolated_repository_module do
+      describe "#set_group_membership" do
+        let(:group_name) { 'my group' }
+        let(:username) { 'my user' }
+        subject do
+          test_repository.set_group_membership(
+            group_name: group_name,
+            usernames: username,
+            force_membership_to_these_usernames: force_membership_to_these_usernames
+          )
+        end
+        context 'when :force_membership_to_these_usernames is false' do
+          let(:force_membership_to_these_usernames) { false }
+          it 'will create the group if none exists otherwise it will re-use it' do
+            expect { subject }.to change { Sipity::Models::Group.count }
+            expect { subject }.not_to change { Sipity::Models::Group.count }
+          end
+          it 'will create the user if none exists otherwise it will re-use it' do
+            expect { subject }.to change { User.count }
+            expect { subject }.not_to change { User.count }
+          end
+          it 'will assign the user to the given group' do
+            expect { subject }.to change { Sipity::Models::GroupMembership.count }
+            user = User.find_by!(username: username)
+            group = Sipity::Models::Group.find_by!(name: group_name)
+            expect(user.group_memberships.map(&:group)).to eq([group])
+          end
+          it 'will preserve users that are already members in the given group' do
+            other_user = User.find_or_create_by!(username: 'another username')
+            test_repository.set_group_membership(
+              group_name: group_name,
+              usernames: [other_user.username],
+              force_membership_to_these_usernames: force_membership_to_these_usernames
+            )
+            expect { subject }.not_to change { other_user.group_memberships.count }
+          end
+        end
+        context 'when :force_membership_to_these_usernames is true' do
+          let(:force_membership_to_these_usernames) { true }
+          it 'will create the group if none exists otherwise it will re-use it' do
+            expect { subject }.to change { Sipity::Models::Group.count }
+            expect { subject }.not_to change { Sipity::Models::Group.count }
+          end
+          it 'will create the user if none exists otherwise it will re-use it' do
+            expect { subject }.to change { User.count }
+            expect { subject }.not_to change { User.count }
+          end
+          it 'will assign the user to the given group' do
+            expect { subject }.to change { Sipity::Models::GroupMembership.count }
+            user = User.find_by!(username: username)
+            group = Sipity::Models::Group.find_by!(name: group_name)
+            expect(user.group_memberships.map(&:group)).to eq([group])
+          end
+          it 'will destroy users that were already members in the given group but not specified in the call' do
+            other_user = User.find_or_create_by!(username: 'another username')
+            test_repository.set_group_membership(
+              group_name: group_name,
+              usernames: [other_user.username],
+              force_membership_to_these_usernames: force_membership_to_these_usernames
+            )
+            expect { subject }.to change { other_user.group_memberships.count }.by(-1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -337,6 +337,10 @@ module Sipity
     def set_as_representative_attachment(work:, pid:)
     end
 
+    # @see ./app/repositories/sipity/commands/administrative_commands.rb
+    def set_group_membership(group_name:, usernames: [], force_membership_to_these_usernames: false)
+    end
+
     # @see ./app/repositories/sipity/queries/submission_window_queries.rb
     def submission_window_names_for_select_within_work_area(work_area:)
     end


### PR DESCRIPTION
When this is merged, I want to update the [dlt-ansible][1] secrets to
use the newly created repository method, as it encapsulates the
logic that keeps the secrets in-sync with the desired state.

Related to DLTP-1633

[1]:https://github.com/ndlib/dlt-ansible/