### PR TITLE
Updating capistrano for jenkins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'autoprefixer-rails'
+gem 'bigdecimal'
 gem 'bootstrap-sass'
 gem 'bundler', "~> 1.17"
 gem 'coffee-rails', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bigdecimal (1.4.4)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.4.1)
@@ -663,6 +664,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   better_errors
+  bigdecimal
   binding_of_caller
   bootstrap-sass
   bumbler

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for Capistrano 3.1
-lock '3.5.0'
+lock '3.11.0'
 set :default_env, {
   path: "/usr/local/bin:$PATH"
 }


### PR DESCRIPTION
## Updating lock imperative for Capistrano

1e06b406dc85b39500b70395eb2e74bff588fa11

In our deployment environment, I see an error (see below). I believe
this change should fix the error.

```console
cap aborted!
Capfile locked at 3.5.0, but 3.11.0 is loaded
```

## Restoring bigdecimal to fix deploy

03987c2f2f35263170eab84bbbd3cca0cd558918

When attempting to deploy changes via capistrano, I see the following
error:

```console
rake stderr: rake aborted!
LoadError: cannot load such file -- bigdecimal
```

In restoring bigdecimal (removed in ddb96b18b949441b1d947793f18ef5669d52da1e)
I hope to get past the blockers for Capistrano based deploys
