### PR TITLE
Addressing shift to ActionController::Parameters

### DIFF
--- a/config/initializers/action_controller_parameter_hack.rb
+++ b/config/initializers/action_controller_parameter_hack.rb
@@ -1,0 +1,34 @@
+require 'action_controller/metal/strong_parameters'
+
+# In moving from Rails 4.x to 5.x, Rails adjusted the parameter object
+# from a HashWithIndifferentAccess to an ActionController::Parameters
+# object. The impact is methods that Sipity assumed no longer exist.
+# This hack address those issues.
+#
+# In a lament, I look to all of the form objects and how creating a
+# simple hash to pass to them does not reflect the reality of the
+# application's actual behavior.
+#
+# This monkey patch restores the features that I was hoping to continue
+# to leverage.
+class ActionController::Parameters
+  def with_indifferent_access
+    self
+  end
+
+  def symbolize_keys
+    self
+  end
+
+  def symbolize_keys!
+    self
+  end
+
+  def map()
+    objects = []
+    each do |*args|
+      objects << yield(*args)
+    end
+    objects
+  end
+end

--- a/spec/conversions/sipity/conversions/extract_input_date_from_input_spec.rb
+++ b/spec/conversions/sipity/conversions/extract_input_date_from_input_spec.rb
@@ -12,7 +12,7 @@ module Sipity
       end
 
       it 'will extract based on Rails convention' do
-        attributes = { 'defense_date(1i)' => '2014', 'defense_date(2i)' => '11', 'defense_date(3i)' => '28' }
+        attributes = ActionController::Parameters.new('defense_date(1i)' => '2014', 'defense_date(2i)' => '11', 'defense_date(3i)' => '28')
         expect(extract_input_date_from_input(:defense_date, attributes)).to eq('2014-11-28')
       end
 

--- a/spec/forms/sipity/forms/work_submissions/core/access_policy_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/access_policy_form_spec.rb
@@ -55,7 +55,7 @@ module Sipity
           end
 
           it 'will validate each of the given attributes' do
-            invalid_attributes = { "0" => { id: work.to_param, access_right_code: 'chici chici parm parm' } }
+            invalid_attributes = ActionController::Parameters.new("0" => { id: work.to_param, access_right_code: 'chici chici parm parm' })
             subject = described_class.new(keywords.merge(attributes: { accessible_objects_attributes: invalid_attributes }))
             subject.valid?
             expect(subject.errors[:accessible_objects_attributes]).to be_present


### PR DESCRIPTION
In moving from Rails 4.x to 5.x, Rails adjusted the parameter object
from a HashWithIndifferentAccess to an ActionController::Parameters
object. The impact is methods that Sipity assumed no longer exist.
This hack address those issues.

In a lament, I look to all of the form objects and how creating a
simple hash to pass to them does not reflect the reality of the
application's actual behavior.

This monkey patch restores the features that I was hoping to continue
to leverage.