### PR TITLE
Updating for SSL for Rails 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller', platforms: [:mri_21]
-  gem 'byebug', '9.0.6', require: false
+  gem 'byebug'
   gem 'capistrano', '~> 3.1'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
@@ -72,6 +72,7 @@ group :development do
   gem 'letter_opener'
   gem 'pry-byebug', '~> 3.4.0', require: false
   gem 'pry-rails', require: false
+  gem 'puma', '~> 3.11'
   gem 'rails_layout'
   gem 'rb-fchange', require: false
   gem 'rb-fsevent', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,6 +445,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.1.1)
+    puma (3.12.1)
     rack (2.0.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -691,7 +692,7 @@ DEPENDENCIES
   bootstrap-sass
   bumbler
   bundler (~> 1.17)
-  byebug (= 9.0.6)
+  byebug
   capistrano (~> 3.1)
   capistrano-bundler
   capistrano-rails
@@ -742,6 +743,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
+  puma (~> 3.11)
   rack-cache
   railroady!
   rails (~> 5.2.0)

--- a/bin/rails
+++ b/bin/rails
@@ -1,31 +1,12 @@
 #!/usr/bin/env ruby
 
-if ENV['SSL'] == "true"
-  require 'rails/commands/server'
-  require 'rack'
-  require 'webrick'
-  require 'webrick/https'
-
-  module Rails
-      class Server < ::Rack::Server
-          def default_options
-              super.merge({
-                  :Port => 3000,
-                  :environment => (ENV['RAILS_ENV'] || "development").dup,
-                  :daemonize => false,
-                  :debugger => false,
-                  :pid => File.expand_path("tmp/pids/server.pid"),
-                  :config => File.expand_path("config.ru"),
-                  :SSLEnable => true,
-                  :SSLVerifyClient => OpenSSL::SSL::VERIFY_NONE,
-                  :SSLPrivateKey => OpenSSL::PKey::RSA.new(
-                                   File.open("dev_server_keys/server.key").read),
-                  :SSLCertificate => OpenSSL::X509::Certificate.new(
-                                   File.open("dev_server_keys/server.crt").read),
-                  :SSLCertName => [["CN", WEBrick::Utils::getservername]],
-              })
-          end
-      end
+# We attempting to run the Rails server under SSL
+if ENV['SSL'] == "true" && ARGV.index("s") || ARGV.index("server")
+  if ARGV.index("-b")
+    $stdout.puts "You've specified a binding IP. I suspect it includes the SSL information"
+  else
+    $stdout.puts "Injecting SSL on port 3000. If you chose a different port than 3000, consider using port 3000 for HTTPS"
+    ARGV += ["-b", "ssl://localhost:3000?key=dev_server_keys/server.key&cert=dev_server_keys/server.crt"]
   end
 end
 


### PR DESCRIPTION
This update modifies the bin/rails command to inject the SSL directive,
as described at https://madeintandem.com/blog/rails-local-development-https-using-self-signed-ssl-certificate/