### PR TITLE
Updating to leverage rails 5 2 and same db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ addons:
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+services:
+  - mysql

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'listen'
 gem 'locabulary', github: 'ndlib/locabulary', ref: 'b8ab510dce637d37229d001fedfbc6af1ab510f2'
 gem 'loofah' # Related to hesburgh-lib's dependency
 gem 'mime-types', '~> 2.6', require: 'mime/types/columnar' # Free 20% RAM by not loading ALL mime-types
+gem 'mysql2', '0.4.8'
 gem 'noids_client', github: 'ndlib/noids_client'
 gem 'nokogiri'
 gem 'power_converter'
@@ -110,7 +111,6 @@ group :test do
   gem 'shoulda-callback-matchers'
   gem 'shoulda-matchers'
   gem 'site_prism', require: false
-  gem 'sqlite3'
 end
 
 group :production, :pre_production, :staging do
@@ -121,10 +121,6 @@ group :production, :pre_production, :staging do
 end
 source 'https://rails-assets.org' do
   gem 'rails-assets-readmore'
-end
-
-group :production, :pre_production, :staging, :development do
-  gem 'mysql2', '0.4.8'
 end
 
 # Removing until I have a non-pro license

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller', platforms: [:mri_21]
-  gem 'byebug', '9.0.6', require: false
+  gem 'byebug'
   gem 'capistrano', '~> 3.1'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
@@ -72,6 +72,7 @@ group :development do
   gem 'letter_opener'
   gem 'pry-byebug', '~> 3.4.0', require: false
   gem 'pry-rails', require: false
+  gem 'puma', '~> 3.11'
   gem 'rails_layout'
   gem 'rb-fchange', require: false
   gem 'rb-fsevent', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,6 +445,7 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.1.1)
+    puma (3.12.1)
     rack (2.0.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -691,7 +692,7 @@ DEPENDENCIES
   bootstrap-sass
   bumbler
   bundler (~> 1.17)
-  byebug (= 9.0.6)
+  byebug
   capistrano (~> 3.1)
   capistrano-bundler
   capistrano-rails
@@ -742,6 +743,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
+  puma (~> 3.11)
   rack-cache
   railroady!
   rails (~> 5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -639,7 +639,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
     sshkit (1.19.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -774,7 +773,6 @@ DEPENDENCIES
   site_prism
   spring
   spring-commands-rspec
-  sqlite3
   terminal-notifier
   terminal-notifier-guard (~> 1.6.4)
   therubyracer

--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,8 @@ if defined?(RSpec)
       'commitment:rubocop',
       'commitment:jshint',
       'commitment:scss_lint',
+      'db:create',
+      'db:schema:load',
       'commitment:configure_test_for_code_coverage',
       'spec:all',
       'commitment:code_coverage',

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,7 +32,7 @@
 
   var adjustRequiredAttachements = function(){
     var attachementControl = $('#work_files');
-    if ( attachementControl.size() > 0 ){
+    if ( attachementControl.length > 0 ){
       attachementControl
         .removeClass('required')
         .removeAttr('required');
@@ -41,7 +41,7 @@
 
   var adjustRequiredCollaborators = function(){
     var collaboratorControl = $('.repeat');
-    if ( collaboratorControl.size() > 0 ){
+    if ( collaboratorControl.length > 0 ){
       collaboratorControl.last().children('td.name').first().children('div').children('input').first().removeClass('required').removeAttr('required');
       collaboratorControl.last().children('td.role').first().children('div').children('select').first().removeClass('required').removeAttr('required');
     }

--- a/app/assets/javascripts/sipity/redactor_field.js.coffee
+++ b/app/assets/javascripts/sipity/redactor_field.js.coffee
@@ -29,12 +29,12 @@ jQuery ($) ->
 
   setupRedactorTextInputs = () ->
     field = $(".redactor-input")
-    if field.size() > 0
+    if field.length > 0
       new RedactorTextInput(field)
 
   setupRedactorTextAreas = () ->
     field = $(".redactor-area")
-    if field.size() > 0
+    if field.length > 0
       new RedactorTextArea(field)
 
   ready = ->

--- a/bin/rails
+++ b/bin/rails
@@ -1,31 +1,12 @@
 #!/usr/bin/env ruby
 
-if ENV['SSL'] == "true"
-  require 'rails/commands/server'
-  require 'rack'
-  require 'webrick'
-  require 'webrick/https'
-
-  module Rails
-      class Server < ::Rack::Server
-          def default_options
-              super.merge({
-                  :Port => 3000,
-                  :environment => (ENV['RAILS_ENV'] || "development").dup,
-                  :daemonize => false,
-                  :debugger => false,
-                  :pid => File.expand_path("tmp/pids/server.pid"),
-                  :config => File.expand_path("config.ru"),
-                  :SSLEnable => true,
-                  :SSLVerifyClient => OpenSSL::SSL::VERIFY_NONE,
-                  :SSLPrivateKey => OpenSSL::PKey::RSA.new(
-                                   File.open("dev_server_keys/server.key").read),
-                  :SSLCertificate => OpenSSL::X509::Certificate.new(
-                                   File.open("dev_server_keys/server.crt").read),
-                  :SSLCertName => [["CN", WEBrick::Utils::getservername]],
-              })
-          end
-      end
+# We attempting to run the Rails server under SSL
+if ENV['SSL'] == "true" && ARGV.index("s") || ARGV.index("server")
+  if ARGV.index("-b")
+    $stdout.puts "You've specified a binding IP. I suspect it includes the SSL information"
+  else
+    $stdout.puts "Injecting SSL on port 3000. If you chose a different port than 3000, consider using port 3000 for HTTPS"
+    ARGV += ["-b", "ssl://localhost:3000?key=dev_server_keys/server.key&cert=dev_server_keys/server.crt"]
   end
 end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -39,8 +39,8 @@ development: &development
   host:     localhost
   timeout: 5000
 
-test:
-  adapter: sqlite3
-  pool: 5
+test: &test
+  <<: *local_user
+  database: sipity_test
+  host:     localhost
   timeout: 5000
-  database: db/test.sqlite3

--- a/db/data/20150629162800_update_event_log_user_to_requested_by.rb
+++ b/db/data/20150629162800_update_event_log_user_to_requested_by.rb
@@ -1,4 +1,4 @@
-class UpdateEventLogUserToRequestedBy < ActiveRecord::Migration
+class UpdateEventLogUserToRequestedBy < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::EventLog.where(requested_by_id: nil, requested_by_type: nil).find_each do |event_log|
       event_log.update!(requested_by_id: event_log.user_id, requested_by_type: User)

--- a/db/data/20150708193800_apply_all_user_group_to_users.rb
+++ b/db/data/20150708193800_apply_all_user_group_to_users.rb
@@ -1,4 +1,4 @@
-class ApplyAllUserGroupToUsers < ActiveRecord::Migration
+class ApplyAllUserGroupToUsers < ActiveRecord::Migration[4.2]
   def self.up
     #add existing users to that group (unless they are already there)
     User.find_each do |user|

--- a/db/data/20150708194433_add_submission_date_to_submitted_material.rb
+++ b/db/data/20150708194433_add_submission_date_to_submitted_material.rb
@@ -1,4 +1,4 @@
-class AddSubmissionDateToSubmittedMaterial < ActiveRecord::Migration
+class AddSubmissionDateToSubmittedMaterial < ActiveRecord::Migration[4.2]
   def self.up
     repository = Sipity::CommandRepository.new
     previous_entity = nil

--- a/db/data/20150710193841_add_etd_reviewer_signoff_date_to_submitted_material.rb
+++ b/db/data/20150710193841_add_etd_reviewer_signoff_date_to_submitted_material.rb
@@ -1,4 +1,4 @@
-class AddEtdReviewerSignoffDateToSubmittedMaterial < ActiveRecord::Migration
+class AddEtdReviewerSignoffDateToSubmittedMaterial < ActiveRecord::Migration[4.2]
   def self.up
     def self.up
       repository = Sipity::CommandRepository.new

--- a/db/data/20150909173721_migration_to_include_cataloging_workflow.rb
+++ b/db/data/20150909173721_migration_to_include_cataloging_workflow.rb
@@ -1,4 +1,4 @@
-class MigrationToIncludeCatalogingWorkflow < ActiveRecord::Migration
+class MigrationToIncludeCatalogingWorkflow < ActiveRecord::Migration[4.2]
   def self.up
     migrator = new
     migrator.migrate_target_entities!

--- a/db/data/20151106140726_remediate_html_entities.rb
+++ b/db/data/20151106140726_remediate_html_entities.rb
@@ -1,4 +1,4 @@
-class RemediateHtmlEntities < ActiveRecord::Migration
+class RemediateHtmlEntities < ActiveRecord::Migration[4.2]
   def self.up
     model = Sipity::Models::AdditionalAttribute
     model.find_each do |additional_attribute|

--- a/db/data/20151120201633_updating_author_name_for_work.rb
+++ b/db/data/20151120201633_updating_author_name_for_work.rb
@@ -1,4 +1,4 @@
-class UpdatingAuthorNameForWork < ActiveRecord::Migration
+class UpdatingAuthorNameForWork < ActiveRecord::Migration[4.2]
   def self.up
     work_area = PowerConverter.convert('etd', to: :work_area)
     repository = Sipity::CommandRepository.new

--- a/db/data/20151130142312_tidying_up_etd_workflow.rb
+++ b/db/data/20151130142312_tidying_up_etd_workflow.rb
@@ -1,4 +1,4 @@
-class TidyingUpEtdWorkflow < ActiveRecord::Migration
+class TidyingUpEtdWorkflow < ActiveRecord::Migration[4.2]
   def self.up
     # Removing deprecated states but only if all is clear
     Sipity::Models::Processing::StrategyState.where(name: 'under_grad_school_review_with_changes').each do |state|

--- a/db/data/20151201155313_remove_advisor_from_seeing_items_at_too_many_states.rb
+++ b/db/data/20151201155313_remove_advisor_from_seeing_items_at_too_many_states.rb
@@ -1,4 +1,4 @@
-class RemoveAdvisorFromSeeingItemsAtTooManyStates < ActiveRecord::Migration
+class RemoveAdvisorFromSeeingItemsAtTooManyStates < ActiveRecord::Migration[4.2]
   # Removing permission for advisors to see the ETDs at far later states
   def self.up
     [

--- a/db/data/20151202183937_removing_submit_for_review_from_ulra.rb
+++ b/db/data/20151202183937_removing_submit_for_review_from_ulra.rb
@@ -1,4 +1,4 @@
-class RemovingSubmitForReviewFromUlra < ActiveRecord::Migration
+class RemovingSubmitForReviewFromUlra < ActiveRecord::Migration[4.2]
   def self.up
     work_type = Sipity::Models::WorkType[Sipity::Models::WorkType::ULRA_SUBMISSION]
     strategy = work_type.strategy_usage.strategy

--- a/db/data/20151203141423_converting_action_registry.rb
+++ b/db/data/20151203141423_converting_action_registry.rb
@@ -1,4 +1,4 @@
-class ConvertingActionRegistry < ActiveRecord::Migration
+class ConvertingActionRegistry < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::Processing::EntityActionRegister.includes(:entity).where(subject_type: 'Sipity::Models::Work').find_each do |register|
       register.update_column(:subject_id, register.entity.proxy_for_id)

--- a/db/data/20151204140143_add_open_date_to_current_submission_windows.rb
+++ b/db/data/20151204140143_add_open_date_to_current_submission_windows.rb
@@ -1,4 +1,4 @@
-class AddOpenDateToCurrentSubmissionWindows < ActiveRecord::Migration
+class AddOpenDateToCurrentSubmissionWindows < ActiveRecord::Migration[4.2]
   def self.up
     # I'm sure there is a better date mechanism for this but its a quick fix
     Sipity::Models::SubmissionWindow.where(open_for_starting_submissions_at: nil).find_each do |submission_window|

--- a/db/data/20151211183738_remove_ulra_faculty_comments_action.rb
+++ b/db/data/20151211183738_remove_ulra_faculty_comments_action.rb
@@ -1,4 +1,4 @@
-class RemoveUlraFacultyCommentsAction < ActiveRecord::Migration
+class RemoveUlraFacultyCommentsAction < ActiveRecord::Migration[4.2]
   def self.up
     # This works for now but may not work going forward.
     Sipity::Models::Processing::StrategyAction.where(name: 'faculty_comments').destroy_all

--- a/db/data/20160121142321_updating_resource_consulted_to_resources_consulted.rb
+++ b/db/data/20160121142321_updating_resource_consulted_to_resources_consulted.rb
@@ -1,4 +1,4 @@
-class UpdatingResourceConsultedToResourcesConsulted < ActiveRecord::Migration
+class UpdatingResourceConsultedToResourcesConsulted < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::AdditionalAttribute.where(key: 'resource_consulted').update_all(key: 'resources_consulted')
     Sipity::Models::AdditionalAttribute.where(key: 'other_resource_consulted').update_all(key: 'other_resources_consulted')

--- a/db/data/20160121143031_publication_submission_status_predicate.rb
+++ b/db/data/20160121143031_publication_submission_status_predicate.rb
@@ -1,4 +1,4 @@
-class PublicationSubmissionStatusPredicate < ActiveRecord::Migration
+class PublicationSubmissionStatusPredicate < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::AdditionalAttribute.
       where(key: 'submission_accepted_for_publication').

--- a/db/data/20160121151409_update_faculty_attachment_predicate.rb
+++ b/db/data/20160121151409_update_faculty_attachment_predicate.rb
@@ -1,4 +1,4 @@
-class UpdateFacultyAttachmentPredicate < ActiveRecord::Migration
+class UpdateFacultyAttachmentPredicate < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::AdditionalAttribute.
       where(key: 'faculty_comments_attachment').

--- a/db/data/20160125134822_renaming_expected_graduation_date_to_expected_graduation_term.rb
+++ b/db/data/20160125134822_renaming_expected_graduation_date_to_expected_graduation_term.rb
@@ -1,4 +1,4 @@
-class RenamingExpectedGraduationDateToExpectedGraduationTerm < ActiveRecord::Migration
+class RenamingExpectedGraduationDateToExpectedGraduationTerm < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::AdditionalAttribute.where(key: "expected_graduation_date").update_all(key: "expected_graduation_term")
   end

--- a/db/data/20160125135332_renaming_college_to_primary_college.rb
+++ b/db/data/20160125135332_renaming_college_to_primary_college.rb
@@ -1,4 +1,4 @@
-class RenamingCollegeToPrimaryCollege < ActiveRecord::Migration
+class RenamingCollegeToPrimaryCollege < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::AdditionalAttribute.where(key: "college").update_all(key: "primary_college")
   end

--- a/db/data/20160128183836_remove_faculty_ability_to_update_access_policy.rb
+++ b/db/data/20160128183836_remove_faculty_ability_to_update_access_policy.rb
@@ -1,4 +1,4 @@
-class RemoveFacultyAbilityToUpdateAccessPolicy < ActiveRecord::Migration
+class RemoveFacultyAbilityToUpdateAccessPolicy < ActiveRecord::Migration[4.2]
   def self.up
     advising_role = Sipity::Models::Role['advising']
     advising_role.processing_strategy_roles.find_each do |strategy_role|

--- a/db/data/20160209192405_remove_release_suspended_catalog_record.rb
+++ b/db/data/20160209192405_remove_release_suspended_catalog_record.rb
@@ -1,4 +1,4 @@
-class RemoveReleaseSuspendedCatalogRecord < ActiveRecord::Migration
+class RemoveReleaseSuspendedCatalogRecord < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::Notification::Email.where(method_name: 'release_suspended_catalog_record').destroy_all
   end

--- a/db/data/20160210204153_remove_grad_school_requests_cataloging_for_action_taken.rb
+++ b/db/data/20160210204153_remove_grad_school_requests_cataloging_for_action_taken.rb
@@ -1,4 +1,4 @@
-class RemoveGradSchoolRequestsCatalogingForActionTaken < ActiveRecord::Migration
+class RemoveGradSchoolRequestsCatalogingForActionTaken < ActiveRecord::Migration[4.2]
   def self.up
     Sipity::Models::Notification::Email.where(method_name: 'grad_school_requests_cataloging').each do |email|
       email.notifiable_contexts.where(

--- a/db/data/20160217141830_add_authorname_to_etd.rb
+++ b/db/data/20160217141830_add_authorname_to_etd.rb
@@ -1,4 +1,4 @@
-class AddAuthornameToEtd < ActiveRecord::Migration
+class AddAuthornameToEtd < ActiveRecord::Migration[4.2]
   def self.up
     repository = Sipity::CommandRepository.new
 

--- a/db/migrate/20141120141206_devise_create_users.rb
+++ b/db/migrate/20141120141206_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20141120141209_add_name_to_users.rb
+++ b/db/migrate/20141120141209_add_name_to_users.rb
@@ -1,4 +1,4 @@
-class AddNameToUsers < ActiveRecord::Migration
+class AddNameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :name, :string
   end

--- a/db/migrate/20141120141215_add_role_to_users.rb
+++ b/db/migrate/20141120141215_add_role_to_users.rb
@@ -1,4 +1,4 @@
-class AddRoleToUsers < ActiveRecord::Migration
+class AddRoleToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :role, :integer
   end

--- a/db/migrate/20141120155922_create_sipity_works.rb
+++ b/db/migrate/20141120155922_create_sipity_works.rb
@@ -1,4 +1,4 @@
-class CreateSipityWorks < ActiveRecord::Migration
+class CreateSipityWorks < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_works, id: false do |t|
       t.string :id, limit: 32

--- a/db/migrate/20141120203834_create_sipity_collaborators.rb
+++ b/db/migrate/20141120203834_create_sipity_collaborators.rb
@@ -1,4 +1,4 @@
-class CreateSipityCollaborators < ActiveRecord::Migration
+class CreateSipityCollaborators < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_collaborators do |t|
       t.string :work_id, limit: 32

--- a/db/migrate/20141124162510_create_sipity_additional_attributes.rb
+++ b/db/migrate/20141124162510_create_sipity_additional_attributes.rb
@@ -1,4 +1,4 @@
-class CreateSipityAdditionalAttributes < ActiveRecord::Migration
+class CreateSipityAdditionalAttributes < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_additional_attributes do |t|
       t.string :work_id, limit: 32, null: false

--- a/db/migrate/20141125133337_create_sipity_doi_creation_requests.rb
+++ b/db/migrate/20141125133337_create_sipity_doi_creation_requests.rb
@@ -1,4 +1,4 @@
-class CreateSipityDoiCreationRequests < ActiveRecord::Migration
+class CreateSipityDoiCreationRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_doi_creation_requests do |t|
       t.string :work_id, limit: 32, null: false, unique: true

--- a/db/migrate/20141203194600_add_indices_to_sipity_additional_attributes.rb
+++ b/db/migrate/20141203194600_add_indices_to_sipity_additional_attributes.rb
@@ -1,4 +1,4 @@
-class AddIndicesToSipityAdditionalAttributes < ActiveRecord::Migration
+class AddIndicesToSipityAdditionalAttributes < ActiveRecord::Migration[4.2]
   def change
     add_index :sipity_additional_attributes, :work_id
     add_index :sipity_additional_attributes, [:work_id, :key]

--- a/db/migrate/20141204154424_create_sipity_permissions.rb
+++ b/db/migrate/20141204154424_create_sipity_permissions.rb
@@ -1,4 +1,4 @@
-class CreateSipityPermissions < ActiveRecord::Migration
+class CreateSipityPermissions < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_permissions, id: false do |t|
       t.integer :actor_id, index: true

--- a/db/migrate/20141204165259_create_sipity_event_logs.rb
+++ b/db/migrate/20141204165259_create_sipity_event_logs.rb
@@ -1,4 +1,4 @@
-class CreateSipityEventLogs < ActiveRecord::Migration
+class CreateSipityEventLogs < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_event_logs do |t|
       t.integer :user_id, index: true

--- a/db/migrate/20141211191318_add_default_to_doi_request_creation.rb
+++ b/db/migrate/20141211191318_add_default_to_doi_request_creation.rb
@@ -1,4 +1,4 @@
-class AddDefaultToDoiRequestCreation < ActiveRecord::Migration
+class AddDefaultToDoiRequestCreation < ActiveRecord::Migration[4.2]
   def change
     # I'm using a magic string because I don't want to load the class and
     # create all kinds of load issues.

--- a/db/migrate/20141215163110_create_sipity_account_placeholders.rb
+++ b/db/migrate/20141215163110_create_sipity_account_placeholders.rb
@@ -1,4 +1,4 @@
-class CreateSipityAccountPlaceholders < ActiveRecord::Migration
+class CreateSipityAccountPlaceholders < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_account_placeholders do |t|
       t.string :identifier

--- a/db/migrate/20141215194110_add_event_log_index.rb
+++ b/db/migrate/20141215194110_add_event_log_index.rb
@@ -1,4 +1,4 @@
-class AddEventLogIndex < ActiveRecord::Migration
+class AddEventLogIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :sipity_event_logs, :created_at
     add_index :sipity_event_logs, [:user_id, :created_at]

--- a/db/migrate/20141216192315_add_state_to_sipity_models_work.rb
+++ b/db/migrate/20141216192315_add_state_to_sipity_models_work.rb
@@ -1,4 +1,4 @@
-class AddStateToSipityModelsWork < ActiveRecord::Migration
+class AddStateToSipityModelsWork < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_works, :processing_state, :string, default: :new, limit: 64
     add_index :sipity_works, :processing_state

--- a/db/migrate/20141218133748_create_sipity_models_groups.rb
+++ b/db/migrate/20141218133748_create_sipity_models_groups.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsGroups < ActiveRecord::Migration
+class CreateSipityModelsGroups < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_groups do |t|
       t.string :name

--- a/db/migrate/20141218135709_create_sipity_models_group_memberships.rb
+++ b/db/migrate/20141218135709_create_sipity_models_group_memberships.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsGroupMemberships < ActiveRecord::Migration
+class CreateSipityModelsGroupMemberships < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_group_memberships do |t|
       t.integer :user_id

--- a/db/migrate/20150108164454_add_work_type_to_work.rb
+++ b/db/migrate/20150108164454_add_work_type_to_work.rb
@@ -1,4 +1,4 @@
-class AddWorkTypeToWork < ActiveRecord::Migration
+class AddWorkTypeToWork < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_works, :work_type, :string
     add_index :sipity_works, :work_type

--- a/db/migrate/20150112142919_create_sipity_models_attachments.rb
+++ b/db/migrate/20150112142919_create_sipity_models_attachments.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsAttachments < ActiveRecord::Migration
+class CreateSipityModelsAttachments < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_attachments, id: false do |t|
       t.string :work_id, limit: 32

--- a/db/migrate/20150113145636_create_sipity_models_access_rights.rb
+++ b/db/migrate/20150113145636_create_sipity_models_access_rights.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsAccessRights < ActiveRecord::Migration
+class CreateSipityModelsAccessRights < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_access_rights do |t|
       t.string :entity_id, limit: 32

--- a/db/migrate/20150113155503_create_sipity_models_transient_answers.rb
+++ b/db/migrate/20150113155503_create_sipity_models_transient_answers.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsTransientAnswers < ActiveRecord::Migration
+class CreateSipityModelsTransientAnswers < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_transient_answers do |t|
       t.string :entity_id, limit: 32

--- a/db/migrate/20150114161600_amend_sipity_additional_attributes_value.rb
+++ b/db/migrate/20150114161600_amend_sipity_additional_attributes_value.rb
@@ -1,4 +1,4 @@
-class AmendSipityAdditionalAttributesValue < ActiveRecord::Migration
+class AmendSipityAdditionalAttributesValue < ActiveRecord::Migration[4.2]
   def change
     change_column :sipity_additional_attributes, :value, :text
   end

--- a/db/migrate/20150122142820_add_net_id_to_devise.rb
+++ b/db/migrate/20150122142820_add_net_id_to_devise.rb
@@ -1,4 +1,4 @@
-class AddNetIdToDevise < ActiveRecord::Migration
+class AddNetIdToDevise < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :username, :string
     change_column_null :users, :username, false

--- a/db/migrate/20150201002853_create_sipity_models_processing_strategy.rb
+++ b/db/migrate/20150201002853_create_sipity_models_processing_strategy.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategy < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategy < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategies do |t|
       t.string :name, null: false

--- a/db/migrate/20150201002854_create_sipity_models_processing_entities.rb
+++ b/db/migrate/20150201002854_create_sipity_models_processing_entities.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingEntities < ActiveRecord::Migration
+class CreateSipityModelsProcessingEntities < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_entities do |t|
       t.string :proxy_for_id, limit: 32, null: false

--- a/db/migrate/20150201002855_create_sipity_models_processing_actors.rb
+++ b/db/migrate/20150201002855_create_sipity_models_processing_actors.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingActors < ActiveRecord::Migration
+class CreateSipityModelsProcessingActors < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_actors do |t|
       t.string :proxy_for_id, limit: 32, null: false

--- a/db/migrate/20150201002856_create_sipity_models_roles.rb
+++ b/db/migrate/20150201002856_create_sipity_models_roles.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsRoles < ActiveRecord::Migration
+class CreateSipityModelsRoles < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_roles do |t|
       t.string :name, null: false

--- a/db/migrate/20150201002857_create_sipity_models_processing_strategy_roles.rb
+++ b/db/migrate/20150201002857_create_sipity_models_processing_strategy_roles.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyRoles < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyRoles < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_roles do |t|
       t.integer :strategy_id, null: false

--- a/db/migrate/20150201002858_create_sipity_models_processing_strategy_responsibility.rb
+++ b/db/migrate/20150201002858_create_sipity_models_processing_strategy_responsibility.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyResponsibility < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyResponsibility < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_responsibilities do |t|
       t.integer :actor_id, null: false

--- a/db/migrate/20150201002859_create_sipity_models_processing_entity_specific_responsibility.rb
+++ b/db/migrate/20150201002859_create_sipity_models_processing_entity_specific_responsibility.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingEntitySpecificResponsibility < ActiveRecord::Migration
+class CreateSipityModelsProcessingEntitySpecificResponsibility < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_entity_specific_responsibilities do |t|
       t.integer :strategy_role_id, null: false

--- a/db/migrate/20150201002900_create_sipity_models_processing_strategy_state.rb
+++ b/db/migrate/20150201002900_create_sipity_models_processing_strategy_state.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyState < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyState < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_states do |t|
       t.integer :strategy_id, null: false

--- a/db/migrate/20150201002901_create_sipity_models_processing_strategy_action.rb
+++ b/db/migrate/20150201002901_create_sipity_models_processing_strategy_action.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyAction < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyAction < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_actions do |t|
       t.integer :strategy_id, null: false

--- a/db/migrate/20150201002902_create_sipity_models_processing_strategy_state_action.rb
+++ b/db/migrate/20150201002902_create_sipity_models_processing_strategy_state_action.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyStateAction < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyStateAction < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_state_actions do |t|
       t.integer :originating_strategy_state_id, null: false

--- a/db/migrate/20150201002903_create_sipity_models_processing_strategy_state_action_permission.rb
+++ b/db/migrate/20150201002903_create_sipity_models_processing_strategy_state_action_permission.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyStateActionPermission < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyStateActionPermission < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_state_action_permissions do |t|
       t.integer :strategy_role_id, null: false

--- a/db/migrate/20150201002904_create_sipity_models_processing_entity_action_register.rb
+++ b/db/migrate/20150201002904_create_sipity_models_processing_entity_action_register.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingEntityActionRegister < ActiveRecord::Migration
+class CreateSipityModelsProcessingEntityActionRegister < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_entity_action_registers do |t|
       t.integer :strategy_action_id, null: false

--- a/db/migrate/20150201173801_create_sipity_models_processing_strategy_action_prerequisites.rb
+++ b/db/migrate/20150201173801_create_sipity_models_processing_strategy_action_prerequisites.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyActionPrerequisites < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyActionPrerequisites < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_action_prerequisites do |t|
       t.integer :guarded_strategy_action_id

--- a/db/migrate/20150202142340_add_additional_collaborator_attributes.rb
+++ b/db/migrate/20150202142340_add_additional_collaborator_attributes.rb
@@ -1,4 +1,4 @@
-class AddAdditionalCollaboratorAttributes < ActiveRecord::Migration
+class AddAdditionalCollaboratorAttributes < ActiveRecord::Migration[4.2]
   def change
     # I'm opting to call it netid instead of net_id so as to not imply
     # this is a foreign key

--- a/db/migrate/20150204172806_adding_column_constraint_to_attachment.rb
+++ b/db/migrate/20150204172806_adding_column_constraint_to_attachment.rb
@@ -1,4 +1,4 @@
-class AddingColumnConstraintToAttachment < ActiveRecord::Migration
+class AddingColumnConstraintToAttachment < ActiveRecord::Migration[4.2]
   def change
     change_column_null :sipity_attachments, :pid, false
   end

--- a/db/migrate/20150205171226_create_sipity_models_work_types.rb
+++ b/db/migrate/20150205171226_create_sipity_models_work_types.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsWorkTypes < ActiveRecord::Migration
+class CreateSipityModelsWorkTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_work_types do |t|
       t.string :name, null: false

--- a/db/migrate/20150205172137_adding_work_type_to_processing_strategy.rb
+++ b/db/migrate/20150205172137_adding_work_type_to_processing_strategy.rb
@@ -1,4 +1,4 @@
-class AddingWorkTypeToProcessingStrategy < ActiveRecord::Migration
+class AddingWorkTypeToProcessingStrategy < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_processing_strategies, :proxy_for_id, :integer
     add_column :sipity_processing_strategies, :proxy_for_type, :string

--- a/db/migrate/20150205183848_amending_processing_entity_indices.rb
+++ b/db/migrate/20150205183848_amending_processing_entity_indices.rb
@@ -1,4 +1,4 @@
-class AmendingProcessingEntityIndices < ActiveRecord::Migration
+class AmendingProcessingEntityIndices < ActiveRecord::Migration[4.2]
   def change
     # These were once unique true
     remove_index :sipity_processing_entities, :strategy_id

--- a/db/migrate/20150205191116_add_representative_to_attachment.rb
+++ b/db/migrate/20150205191116_add_representative_to_attachment.rb
@@ -1,4 +1,4 @@
-class AddRepresentativeToAttachment < ActiveRecord::Migration
+class AddRepresentativeToAttachment < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_attachments, :is_representative_file, :boolean, default: false
   end

--- a/db/migrate/20150206173110_adding_action_type_to_action_processing.rb
+++ b/db/migrate/20150206173110_adding_action_type_to_action_processing.rb
@@ -1,4 +1,4 @@
-class AddingActionTypeToActionProcessing < ActiveRecord::Migration
+class AddingActionTypeToActionProcessing < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_processing_strategy_actions, :action_type, :string, default: 'task'
     add_index :sipity_processing_strategy_actions, :action_type

--- a/db/migrate/20150207132512_removing_default_action_type.rb
+++ b/db/migrate/20150207132512_removing_default_action_type.rb
@@ -1,4 +1,4 @@
-class RemovingDefaultActionType < ActiveRecord::Migration
+class RemovingDefaultActionType < ActiveRecord::Migration[4.2]
   def change
     change_column_default :sipity_processing_strategy_actions, :action_type, nil
   end

--- a/db/migrate/20150219175241_remove_processing_state_from_work.rb
+++ b/db/migrate/20150219175241_remove_processing_state_from_work.rb
@@ -1,4 +1,4 @@
-class RemoveProcessingStateFromWork < ActiveRecord::Migration
+class RemoveProcessingStateFromWork < ActiveRecord::Migration[4.2]
   def change
     remove_column :sipity_works, :processing_state
   end

--- a/db/migrate/20150219203525_remove_permissions_table.rb
+++ b/db/migrate/20150219203525_remove_permissions_table.rb
@@ -1,4 +1,4 @@
-class RemovePermissionsTable < ActiveRecord::Migration
+class RemovePermissionsTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :sipity_permissions
   end

--- a/db/migrate/20150220152602_adding_requested_by_and_on_behalf_of_to_entity_action_register.rb
+++ b/db/migrate/20150220152602_adding_requested_by_and_on_behalf_of_to_entity_action_register.rb
@@ -1,4 +1,4 @@
-class AddingRequestedByAndOnBehalfOfToEntityActionRegister < ActiveRecord::Migration
+class AddingRequestedByAndOnBehalfOfToEntityActionRegister < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_processing_entity_action_registers, :requested_by_actor_id, :integer
     add_column :sipity_processing_entity_action_registers, :on_behalf_of_actor_id, :integer

--- a/db/migrate/20150225173436_create_sipity_models_processing_comments.rb
+++ b/db/migrate/20150225173436_create_sipity_models_processing_comments.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingComments < ActiveRecord::Migration
+class CreateSipityModelsProcessingComments < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_comments do |t|
       t.string :entity_id, limit: 32

--- a/db/migrate/20150226134513_update_processing_entities_column_type.rb
+++ b/db/migrate/20150226134513_update_processing_entities_column_type.rb
@@ -1,4 +1,4 @@
-class UpdateProcessingEntitiesColumnType < ActiveRecord::Migration
+class UpdateProcessingEntitiesColumnType < ActiveRecord::Migration[4.2]
   def change
     change_column(:sipity_processing_entities, :strategy_state_id, :integer)
   end

--- a/db/migrate/20150226160732_adding_index_to_strategy_state_name.rb
+++ b/db/migrate/20150226160732_adding_index_to_strategy_state_name.rb
@@ -1,4 +1,4 @@
-class AddingIndexToStrategyStateName < ActiveRecord::Migration
+class AddingIndexToStrategyStateName < ActiveRecord::Migration[4.2]
   def change
     add_index "sipity_processing_strategy_states", "name"
   end

--- a/db/migrate/20150303152259_update_sipity_access_rights_indices.rb
+++ b/db/migrate/20150303152259_update_sipity_access_rights_indices.rb
@@ -1,4 +1,4 @@
-class UpdateSipityAccessRightsIndices < ActiveRecord::Migration
+class UpdateSipityAccessRightsIndices < ActiveRecord::Migration[4.2]
   def change
     remove_index :sipity_access_rights, [:entity_id, :entity_type]
     add_index :sipity_access_rights, [:entity_id, :entity_type]

--- a/db/migrate/20150303172902_modify_access_right.rb
+++ b/db/migrate/20150303172902_modify_access_right.rb
@@ -1,4 +1,4 @@
-class ModifyAccessRight < ActiveRecord::Migration
+class ModifyAccessRight < ActiveRecord::Migration[4.2]
   def change
     drop_table :sipity_access_rights
 

--- a/db/migrate/20150304150208_create_sipity_models_simple_controlled_vocabularies.rb
+++ b/db/migrate/20150304150208_create_sipity_models_simple_controlled_vocabularies.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsSimpleControlledVocabularies < ActiveRecord::Migration
+class CreateSipityModelsSimpleControlledVocabularies < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_simple_controlled_vocabularies do |t|
       t.string :predicate_name

--- a/db/migrate/20150305170338_adding_column_to_controlled_vocabulary.rb
+++ b/db/migrate/20150305170338_adding_column_to_controlled_vocabulary.rb
@@ -1,4 +1,4 @@
-class AddingColumnToControlledVocabulary < ActiveRecord::Migration
+class AddingColumnToControlledVocabulary < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_simple_controlled_vocabularies, :predicate_value_code, :string
     add_index :sipity_simple_controlled_vocabularies, :predicate_value_code, name: 'sipity_simple_controlled_vocabularies_predicate_code'

--- a/db/migrate/20150306195019_add_user_agreed_to_terms_of_service.rb
+++ b/db/migrate/20150306195019_add_user_agreed_to_terms_of_service.rb
@@ -1,4 +1,4 @@
-class AddUserAgreedToTermsOfService < ActiveRecord::Migration
+class AddUserAgreedToTermsOfService < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :agreed_to_terms_of_service, :boolean, default: false
     add_index :users, :agreed_to_terms_of_service

--- a/db/migrate/20150311145535_adding_presentation_sequence_to_strategy_action.rb
+++ b/db/migrate/20150311145535_adding_presentation_sequence_to_strategy_action.rb
@@ -1,4 +1,4 @@
-class AddingPresentationSequenceToStrategyAction < ActiveRecord::Migration
+class AddingPresentationSequenceToStrategyAction < ActiveRecord::Migration[4.2]
   def change
     add_column "sipity_processing_strategy_actions", "presentation_sequence", :integer
     add_index "sipity_processing_strategy_actions", ["strategy_id", "presentation_sequence"], name: "sipity_processing_strategy_actions_sequence"

--- a/db/migrate/20150318193942_add_comment_index.rb
+++ b/db/migrate/20150318193942_add_comment_index.rb
@@ -1,4 +1,4 @@
-class AddCommentIndex < ActiveRecord::Migration
+class AddCommentIndex < ActiveRecord::Migration[4.2]
   def change
     add_index :sipity_processing_comments, :created_at
   end

--- a/db/migrate/20150331143941_create_sipity_models_processing_strategy_action_analogues.rb
+++ b/db/migrate/20150331143941_create_sipity_models_processing_strategy_action_analogues.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyActionAnalogues < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyActionAnalogues < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_action_analogues, force: true do |t|
       t.integer :strategy_action_id, null: false

--- a/db/migrate/20150331155606_add_allow_to_repeat_action_within_a_given_state.rb
+++ b/db/migrate/20150331155606_add_allow_to_repeat_action_within_a_given_state.rb
@@ -1,4 +1,4 @@
-class AddAllowToRepeatActionWithinAGivenState < ActiveRecord::Migration
+class AddAllowToRepeatActionWithinAGivenState < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_processing_strategy_actions, :allow_repeat_within_current_state, :boolean, default: true, null: false
   end

--- a/db/migrate/20150402195713_adding_stale_to_processing_comment.rb
+++ b/db/migrate/20150402195713_adding_stale_to_processing_comment.rb
@@ -1,4 +1,4 @@
-class AddingStaleToProcessingComment < ActiveRecord::Migration
+class AddingStaleToProcessingComment < ActiveRecord::Migration[4.2]
   def change
     add_column 'sipity_processing_comments', 'stale', :boolean, default: false, index: true
   end

--- a/db/migrate/20150410193943_expanding_work_title_to_text.rb
+++ b/db/migrate/20150410193943_expanding_work_title_to_text.rb
@@ -1,4 +1,4 @@
-class ExpandingWorkTitleToText < ActiveRecord::Migration
+class ExpandingWorkTitleToText < ActiveRecord::Migration[4.2]
   def change
     remove_index 'sipity_works', column: ['title'] rescue true
     change_column 'sipity_works', 'title', 'text'

--- a/db/migrate/20150413125439_rename_controlled_vocabulary_columns.rb
+++ b/db/migrate/20150413125439_rename_controlled_vocabulary_columns.rb
@@ -1,4 +1,4 @@
-class RenameControlledVocabularyColumns < ActiveRecord::Migration
+class RenameControlledVocabularyColumns < ActiveRecord::Migration[4.2]
   def change
     rename_column :sipity_simple_controlled_vocabularies, :predicate_value, :term_label
     rename_column :sipity_simple_controlled_vocabularies, :predicate_value_code, :term_uri

--- a/db/migrate/20150413174323_create_sipity_models_notification_emails.rb
+++ b/db/migrate/20150413174323_create_sipity_models_notification_emails.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsNotificationEmails < ActiveRecord::Migration
+class CreateSipityModelsNotificationEmails < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_notification_emails do |t|
       t.string :method_name, null: false, index: true, unique: true

--- a/db/migrate/20150413175239_create_sipity_models_notification_email_recipients.rb
+++ b/db/migrate/20150413175239_create_sipity_models_notification_email_recipients.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsNotificationEmailRecipients < ActiveRecord::Migration
+class CreateSipityModelsNotificationEmailRecipients < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_notification_email_recipients do |t|
       t.integer :email_id, null: false

--- a/db/migrate/20150417130019_create_sipity_models_notification_notifiable_contexts.rb
+++ b/db/migrate/20150417130019_create_sipity_models_notification_notifiable_contexts.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsNotificationNotifiableContexts < ActiveRecord::Migration
+class CreateSipityModelsNotificationNotifiableContexts < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_notification_notifiable_contexts do |t|
       t.integer :scope_for_notification_id, null: false

--- a/db/migrate/20150417151334_create_sipity_models_work_areas.rb
+++ b/db/migrate/20150417151334_create_sipity_models_work_areas.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsWorkAreas < ActiveRecord::Migration
+class CreateSipityModelsWorkAreas < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_work_areas do |t|
       t.string :slug, null: false, unique: true

--- a/db/migrate/20150417180230_create_sipity_models_submission_windows.rb
+++ b/db/migrate/20150417180230_create_sipity_models_submission_windows.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsSubmissionWindows < ActiveRecord::Migration
+class CreateSipityModelsSubmissionWindows < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_submission_windows do |t|
       t.integer :work_area_id, null: false, index: true

--- a/db/migrate/20150417182120_create_sipity_models_submission_window_work_types.rb
+++ b/db/migrate/20150417182120_create_sipity_models_submission_window_work_types.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsSubmissionWindowWorkTypes < ActiveRecord::Migration
+class CreateSipityModelsSubmissionWindowWorkTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_submission_window_work_types do |t|
       t.integer :submission_window_id, null: false

--- a/db/migrate/20150423194449_create_sipity_models_application_concepts.rb
+++ b/db/migrate/20150423194449_create_sipity_models_application_concepts.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsApplicationConcepts < ActiveRecord::Migration
+class CreateSipityModelsApplicationConcepts < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_application_concepts do |t|
       t.string :name, null: false, unique: true

--- a/db/migrate/20150424183914_adding_unique_index_to_work_area_slug.rb
+++ b/db/migrate/20150424183914_adding_unique_index_to_work_area_slug.rb
@@ -1,6 +1,6 @@
-class AddingUniqueIndexToWorkAreaSlug < ActiveRecord::Migration
+class AddingUniqueIndexToWorkAreaSlug < ActiveRecord::Migration[5.2]
   def change
-    add_column 'sipity_work_areas', 'name', 'string', null: false
+    add_column 'sipity_work_areas', 'name', 'string'
     add_index 'sipity_work_areas', 'name', unique: true
     add_index 'sipity_work_areas', 'slug', unique: true
     add_index 'sipity_application_concepts', 'slug', unique: true

--- a/db/migrate/20150424183914_adding_unique_index_to_work_area_slug.rb
+++ b/db/migrate/20150424183914_adding_unique_index_to_work_area_slug.rb
@@ -1,6 +1,6 @@
-class AddingUniqueIndexToWorkAreaSlug < ActiveRecord::Migration[5.2]
+class AddingUniqueIndexToWorkAreaSlug < ActiveRecord::Migration[4.2]
   def change
-    add_column 'sipity_work_areas', 'name', 'string'
+    add_column 'sipity_work_areas', 'name', 'string', null: false
     add_index 'sipity_work_areas', 'name', unique: true
     add_index 'sipity_work_areas', 'slug', unique: true
     add_index 'sipity_application_concepts', 'slug', unique: true

--- a/db/migrate/20150427154949_create_sipity_models_processing_strategy_usages.rb
+++ b/db/migrate/20150427154949_create_sipity_models_processing_strategy_usages.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingStrategyUsages < ActiveRecord::Migration
+class CreateSipityModelsProcessingStrategyUsages < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_processing_strategy_usages do |t|
       t.integer :strategy_id, null: false

--- a/db/migrate/20150427194112_remove_application_concept.rb
+++ b/db/migrate/20150427194112_remove_application_concept.rb
@@ -1,4 +1,4 @@
-class RemoveApplicationConcept < ActiveRecord::Migration
+class RemoveApplicationConcept < ActiveRecord::Migration[4.2]
   def change
     drop_table :sipity_application_concepts
   end

--- a/db/migrate/20150427200550_remove_proxy_for_keys_from_processing_strategy.rb
+++ b/db/migrate/20150427200550_remove_proxy_for_keys_from_processing_strategy.rb
@@ -1,4 +1,4 @@
-class RemoveProxyForKeysFromProcessingStrategy < ActiveRecord::Migration
+class RemoveProxyForKeysFromProcessingStrategy < ActiveRecord::Migration[4.2]
   def change
     remove_index :sipity_processing_strategies, name: :sipity_processing_strategies_proxy_for
     remove_column :sipity_processing_strategies, :proxy_for_id

--- a/db/migrate/20150506153407_create_sipity_models_work_submissions.rb
+++ b/db/migrate/20150506153407_create_sipity_models_work_submissions.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsWorkSubmissions < ActiveRecord::Migration
+class CreateSipityModelsWorkSubmissions < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_work_submissions, id: false do |t|
       t.integer :work_area_id, null: false

--- a/db/migrate/20150528195849_adding_subject_to_entity_action_register.rb
+++ b/db/migrate/20150528195849_adding_subject_to_entity_action_register.rb
@@ -1,4 +1,4 @@
-class AddingSubjectToEntityActionRegister < ActiveRecord::Migration
+class AddingSubjectToEntityActionRegister < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_processing_entity_action_registers, :subject_id, :integer
     add_column :sipity_processing_entity_action_registers, :subject_type, :string

--- a/db/migrate/20150610170005_adding_primary_key_to_work_submissions.rb
+++ b/db/migrate/20150610170005_adding_primary_key_to_work_submissions.rb
@@ -1,4 +1,4 @@
-class AddingPrimaryKeyToWorkSubmissions < ActiveRecord::Migration
+class AddingPrimaryKeyToWorkSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_work_submissions, :id, :primary_key
   end

--- a/db/migrate/20150610193426_drop_transient_answer_table.rb
+++ b/db/migrate/20150610193426_drop_transient_answer_table.rb
@@ -1,4 +1,4 @@
-class DropTransientAnswerTable < ActiveRecord::Migration
+class DropTransientAnswerTable < ActiveRecord::Migration[4.2]
   def change
     drop_table 'sipity_transient_answers'
   end

--- a/db/migrate/20150611170421_remove_work_publishing_strategy.rb
+++ b/db/migrate/20150611170421_remove_work_publishing_strategy.rb
@@ -1,4 +1,4 @@
-class RemoveWorkPublishingStrategy < ActiveRecord::Migration
+class RemoveWorkPublishingStrategy < ActiveRecord::Migration[4.2]
   def change
     remove_column 'sipity_works', 'work_publication_strategy'
   end

--- a/db/migrate/20150611182218_add_default_presentation_sequence_to_controlled_vocabularies.rb
+++ b/db/migrate/20150611182218_add_default_presentation_sequence_to_controlled_vocabularies.rb
@@ -1,4 +1,4 @@
-class AddDefaultPresentationSequenceToControlledVocabularies < ActiveRecord::Migration
+class AddDefaultPresentationSequenceToControlledVocabularies < ActiveRecord::Migration[4.2]
   def change
     add_column 'sipity_simple_controlled_vocabularies', 'default_presentation_sequence', :integer
 

--- a/db/migrate/20150618125612_remove_controlled_vocabularies.rb
+++ b/db/migrate/20150618125612_remove_controlled_vocabularies.rb
@@ -1,4 +1,4 @@
-class RemoveControlledVocabularies < ActiveRecord::Migration
+class RemoveControlledVocabularies < ActiveRecord::Migration[4.2]
   def change
     drop_table :sipity_simple_controlled_vocabularies
   end

--- a/db/migrate/20150618170010_devise_create_sipity_agents.rb
+++ b/db/migrate/20150618170010_devise_create_sipity_agents.rb
@@ -1,4 +1,4 @@
-class DeviseCreateSipityAgents < ActiveRecord::Migration
+class DeviseCreateSipityAgents < ActiveRecord::Migration[4.2]
   def change
     create_table(:sipity_agents) do |t|
       ## Database authenticatable

--- a/db/migrate/20150629142734_add_requestor_to_event_logs.rb
+++ b/db/migrate/20150629142734_add_requestor_to_event_logs.rb
@@ -1,4 +1,4 @@
-class AddRequestorToEventLogs < ActiveRecord::Migration
+class AddRequestorToEventLogs < ActiveRecord::Migration[4.2]
   def change
     add_column 'sipity_event_logs', 'requested_by_id', 'integer'
     add_column 'sipity_event_logs', 'requested_by_type', 'string'

--- a/db/migrate/20150713172107_adding_unique_index_to_collaborators.rb
+++ b/db/migrate/20150713172107_adding_unique_index_to_collaborators.rb
@@ -1,4 +1,4 @@
-class AddingUniqueIndexToCollaborators < ActiveRecord::Migration
+class AddingUniqueIndexToCollaborators < ActiveRecord::Migration[4.2]
   def change
     Sipity::Models::Collaborator.connection.execute("UPDATE `sipity_collaborators` SET email = NULL WHERE email = '';")
     Sipity::Models::Collaborator.connection.execute("UPDATE `sipity_collaborators` SET netid = NULL WHERE netid = '';")

--- a/db/migrate/20150717153523_create_sipity_models_processing_administrative_scheduled_actions.rb
+++ b/db/migrate/20150717153523_create_sipity_models_processing_administrative_scheduled_actions.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsProcessingAdministrativeScheduledActions < ActiveRecord::Migration
+class CreateSipityModelsProcessingAdministrativeScheduledActions < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_models_processing_administrative_scheduled_actions do |t|
       t.datetime :scheduled_time, null: false

--- a/db/migrate/20151123182244_create_sipity_models_work_redirect_strategies.rb
+++ b/db/migrate/20151123182244_create_sipity_models_work_redirect_strategies.rb
@@ -1,4 +1,4 @@
-class CreateSipityModelsWorkRedirectStrategies < ActiveRecord::Migration
+class CreateSipityModelsWorkRedirectStrategies < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_work_redirect_strategies do |t|
       t.string :work_id, null: false

--- a/db/migrate/20151203140254_convert_action_register_subject_id_column.rb
+++ b/db/migrate/20151203140254_convert_action_register_subject_id_column.rb
@@ -1,4 +1,4 @@
-class ConvertActionRegisterSubjectIdColumn < ActiveRecord::Migration
+class ConvertActionRegisterSubjectIdColumn < ActiveRecord::Migration[4.2]
   def change
     change_table :sipity_processing_entity_action_registers do |t|
       t.change :subject_id, :string, default: nil

--- a/db/migrate/20151204135353_add_open_date_and_closed_date_to_submission_window.rb
+++ b/db/migrate/20151204135353_add_open_date_and_closed_date_to_submission_window.rb
@@ -1,4 +1,4 @@
-class AddOpenDateAndClosedDateToSubmissionWindow < ActiveRecord::Migration
+class AddOpenDateAndClosedDateToSubmissionWindow < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_submission_windows, :open_for_starting_submissions_at, :datetime
     add_column :sipity_submission_windows, :closed_for_starting_submissions_at, :datetime

--- a/db/migrate/20160114173904_remove_completion_required_from_strategy_action.rb
+++ b/db/migrate/20160114173904_remove_completion_required_from_strategy_action.rb
@@ -1,4 +1,4 @@
-class RemoveCompletionRequiredFromStrategyAction < ActiveRecord::Migration
+class RemoveCompletionRequiredFromStrategyAction < ActiveRecord::Migration[4.2]
   def change
     remove_column "sipity_processing_strategy_actions", "completion_required"
     remove_column "sipity_processing_strategy_actions", "form_class_name"

--- a/db/migrate/20160420133504_adding_api_key_to_group.rb
+++ b/db/migrate/20160420133504_adding_api_key_to_group.rb
@@ -1,4 +1,4 @@
-class AddingApiKeyToGroup < ActiveRecord::Migration
+class AddingApiKeyToGroup < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_groups, :api_key, :string
     add_index :sipity_groups, [:name, :api_key]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,479 +10,435 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420133504) do
-
-  create_table "data_migrations", id: false, force: :cascade do |t|
-    t.string "version", limit: 255, null: false
-  end
-
-  add_index "data_migrations", ["version"], name: "unique_data_migrations", unique: true, using: :btree
+ActiveRecord::Schema.define(version: 2016_04_20_133504) do
 
   create_table "sipity_access_rights", force: :cascade do |t|
-    t.string   "entity_id",         limit: 32,  null: false
-    t.string   "entity_type",       limit: 255, null: false
-    t.string   "access_right_code", limit: 255, null: false
-    t.date     "transition_date"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string "entity_id", limit: 32, null: false
+    t.string "entity_type", null: false
+    t.string "access_right_code", null: false
+    t.date "transition_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type", unique: true
   end
-
-  add_index "sipity_access_rights", ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type", unique: true, using: :btree
 
   create_table "sipity_account_placeholders", force: :cascade do |t|
-    t.string   "identifier",      limit: 255,                     null: false
-    t.string   "name",            limit: 255
-    t.string   "identifier_type", limit: 32,                      null: false
-    t.string   "state",           limit: 32,  default: "created", null: false
+    t.string "identifier", null: false
+    t.string "name"
+    t.string "identifier_type", limit: 32, null: false
+    t.string "state", limit: 32, default: "created", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["identifier", "identifier_type"], name: "sipity_account_placeholders_id_and_type", unique: true
+    t.index ["identifier"], name: "index_sipity_account_placeholders_on_identifier"
+    t.index ["name"], name: "index_sipity_account_placeholders_on_name"
+    t.index ["state"], name: "index_sipity_account_placeholders_on_state"
   end
-
-  add_index "sipity_account_placeholders", ["identifier", "identifier_type"], name: "sipity_account_placeholders_id_and_type", unique: true, using: :btree
-  add_index "sipity_account_placeholders", ["identifier"], name: "index_sipity_account_placeholders_on_identifier", using: :btree
-  add_index "sipity_account_placeholders", ["name"], name: "index_sipity_account_placeholders_on_name", using: :btree
-  add_index "sipity_account_placeholders", ["state"], name: "index_sipity_account_placeholders_on_state", using: :btree
 
   create_table "sipity_additional_attributes", force: :cascade do |t|
-    t.string   "work_id",    limit: 32,    null: false
-    t.string   "key",        limit: 255,   null: false
-    t.text     "value",      limit: 65535
+    t.string "work_id", limit: 32, null: false
+    t.string "key", null: false
+    t.text "value"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["work_id", "key"], name: "index_sipity_additional_attributes_on_work_id_and_key"
+    t.index ["work_id"], name: "index_sipity_additional_attributes_on_work_id"
   end
-
-  add_index "sipity_additional_attributes", ["work_id", "key"], name: "index_sipity_additional_attributes_on_work_id_and_key", using: :btree
-  add_index "sipity_additional_attributes", ["work_id"], name: "index_sipity_additional_attributes_on_work_id", using: :btree
 
   create_table "sipity_agents", force: :cascade do |t|
-    t.string   "name",                 limit: 255,               null: false
-    t.text     "description",          limit: 65535
-    t.string   "authentication_token", limit: 255,               null: false
-    t.integer  "sign_in_count",        limit: 4,     default: 0, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "authentication_token", null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",   limit: 255
-    t.string   "last_sign_in_ip",      limit: 255
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["authentication_token"], name: "index_sipity_agents_on_authentication_token", unique: true
+    t.index ["name"], name: "index_sipity_agents_on_name", unique: true
   end
-
-  add_index "sipity_agents", ["authentication_token"], name: "index_sipity_agents_on_authentication_token", unique: true, using: :btree
-  add_index "sipity_agents", ["name"], name: "index_sipity_agents_on_name", unique: true, using: :btree
 
   create_table "sipity_attachments", id: false, force: :cascade do |t|
-    t.string   "work_id",                limit: 32,                  null: false
-    t.string   "pid",                    limit: 255,                 null: false
-    t.string   "predicate_name",         limit: 255,                 null: false
-    t.string   "file_uid",               limit: 255,                 null: false
-    t.string   "file_name",              limit: 255,                 null: false
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
-    t.boolean  "is_representative_file",             default: false
+    t.string "work_id", limit: 32, null: false
+    t.string "pid", null: false
+    t.string "predicate_name", null: false
+    t.string "file_uid", null: false
+    t.string "file_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_representative_file", default: false
+    t.index ["pid"], name: "index_sipity_attachments_on_pid", unique: true
+    t.index ["work_id"], name: "index_sipity_attachments_on_work_id"
   end
-
-  add_index "sipity_attachments", ["pid"], name: "index_sipity_attachments_on_pid", unique: true, using: :btree
-  add_index "sipity_attachments", ["work_id"], name: "index_sipity_attachments_on_work_id", using: :btree
 
   create_table "sipity_collaborators", force: :cascade do |t|
-    t.string   "work_id",                limit: 32,                  null: false
-    t.integer  "sequence",               limit: 4
-    t.string   "name",                   limit: 255
-    t.string   "role",                   limit: 255,                 null: false
+    t.string "work_id", limit: 32, null: false
+    t.integer "sequence"
+    t.string "name"
+    t.string "role", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "netid",                  limit: 255
-    t.string   "email",                  limit: 255
-    t.boolean  "responsible_for_review",             default: false
+    t.string "netid"
+    t.string "email"
+    t.boolean "responsible_for_review", default: false
+    t.index ["email"], name: "index_sipity_collaborators_on_email"
+    t.index ["netid"], name: "index_sipity_collaborators_on_netid"
+    t.index ["work_id", "email"], name: "index_sipity_collaborators_on_work_id_and_email", unique: true
+    t.index ["work_id", "netid"], name: "index_sipity_collaborators_on_work_id_and_netid", unique: true
+    t.index ["work_id", "sequence"], name: "index_sipity_collaborators_on_work_id_and_sequence"
   end
-
-  add_index "sipity_collaborators", ["email"], name: "index_sipity_collaborators_on_email", using: :btree
-  add_index "sipity_collaborators", ["netid"], name: "index_sipity_collaborators_on_netid", using: :btree
-  add_index "sipity_collaborators", ["work_id", "email"], name: "index_sipity_collaborators_on_work_id_and_email", unique: true, using: :btree
-  add_index "sipity_collaborators", ["work_id", "netid"], name: "index_sipity_collaborators_on_work_id_and_netid", unique: true, using: :btree
-  add_index "sipity_collaborators", ["work_id", "sequence"], name: "index_sipity_collaborators_on_work_id_and_sequence", using: :btree
 
   create_table "sipity_doi_creation_requests", force: :cascade do |t|
-    t.string   "work_id",          limit: 32,                                        null: false
-    t.string   "state",            limit: 255, default: "request_not_yet_submitted", null: false
-    t.string   "response_message", limit: 255
+    t.string "work_id", limit: 32, null: false
+    t.string "state", default: "request_not_yet_submitted", null: false
+    t.string "response_message"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["state"], name: "index_sipity_doi_creation_requests_on_state"
+    t.index ["work_id"], name: "index_sipity_doi_creation_requests_on_work_id", unique: true
   end
-
-  add_index "sipity_doi_creation_requests", ["state"], name: "index_sipity_doi_creation_requests_on_state", using: :btree
-  add_index "sipity_doi_creation_requests", ["work_id"], name: "index_sipity_doi_creation_requests_on_work_id", unique: true, using: :btree
 
   create_table "sipity_event_logs", force: :cascade do |t|
-    t.integer  "user_id",           limit: 4,   null: false
-    t.string   "entity_id",         limit: 32,  null: false
-    t.string   "entity_type",       limit: 64,  null: false
-    t.string   "event_name",        limit: 255, null: false
+    t.integer "user_id", null: false
+    t.string "entity_id", limit: 32, null: false
+    t.string "entity_type", limit: 64, null: false
+    t.string "event_name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "requested_by_id",   limit: 4
-    t.string   "requested_by_type", limit: 255
+    t.integer "requested_by_id"
+    t.string "requested_by_type"
+    t.index ["created_at"], name: "index_sipity_event_logs_on_created_at"
+    t.index ["entity_id", "entity_type", "event_name"], name: "sipity_event_logs_entity_action_name"
+    t.index ["entity_id", "entity_type"], name: "sipity_event_logs_subject"
+    t.index ["event_name"], name: "index_sipity_event_logs_on_event_name"
+    t.index ["requested_by_type", "requested_by_id"], name: "idx_sipity_event_logs_on_requested_by"
+    t.index ["user_id", "created_at"], name: "index_sipity_event_logs_on_user_id_and_created_at"
+    t.index ["user_id", "entity_id", "entity_type"], name: "sipity_event_logs_user_subject"
+    t.index ["user_id", "event_name"], name: "sipity_event_logs_user_event_name"
+    t.index ["user_id"], name: "index_sipity_event_logs_on_user_id"
   end
-
-  add_index "sipity_event_logs", ["created_at"], name: "index_sipity_event_logs_on_created_at", using: :btree
-  add_index "sipity_event_logs", ["entity_id", "entity_type", "event_name"], name: "sipity_event_logs_entity_action_name", using: :btree
-  add_index "sipity_event_logs", ["entity_id", "entity_type"], name: "sipity_event_logs_subject", using: :btree
-  add_index "sipity_event_logs", ["event_name"], name: "index_sipity_event_logs_on_event_name", using: :btree
-  add_index "sipity_event_logs", ["requested_by_type", "requested_by_id"], name: "idx_sipity_event_logs_on_requested_by", using: :btree
-  add_index "sipity_event_logs", ["user_id", "created_at"], name: "index_sipity_event_logs_on_user_id_and_created_at", using: :btree
-  add_index "sipity_event_logs", ["user_id", "entity_id", "entity_type"], name: "sipity_event_logs_user_subject", using: :btree
-  add_index "sipity_event_logs", ["user_id", "event_name"], name: "sipity_event_logs_user_event_name", using: :btree
-  add_index "sipity_event_logs", ["user_id"], name: "index_sipity_event_logs_on_user_id", using: :btree
 
   create_table "sipity_group_memberships", force: :cascade do |t|
-    t.integer  "user_id",         limit: 4,   null: false
-    t.integer  "group_id",        limit: 4,   null: false
-    t.string   "membership_role", limit: 255, null: false
+    t.integer "user_id", null: false
+    t.integer "group_id", null: false
+    t.string "membership_role", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["group_id", "membership_role"], name: "index_sipity_group_memberships_on_group_id_and_membership_role"
+    t.index ["group_id", "user_id"], name: "index_sipity_group_memberships_on_group_id_and_user_id", unique: true
+    t.index ["group_id"], name: "index_sipity_group_memberships_on_group_id"
+    t.index ["user_id"], name: "index_sipity_group_memberships_on_user_id"
   end
-
-  add_index "sipity_group_memberships", ["group_id", "membership_role"], name: "index_sipity_group_memberships_on_group_id_and_membership_role", using: :btree
-  add_index "sipity_group_memberships", ["group_id", "user_id"], name: "index_sipity_group_memberships_on_group_id_and_user_id", unique: true, using: :btree
-  add_index "sipity_group_memberships", ["group_id"], name: "index_sipity_group_memberships_on_group_id", using: :btree
-  add_index "sipity_group_memberships", ["user_id"], name: "index_sipity_group_memberships_on_user_id", using: :btree
 
   create_table "sipity_groups", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
+    t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "api_key",    limit: 255
+    t.string "api_key"
+    t.index ["name", "api_key"], name: "index_sipity_groups_on_name_and_api_key"
+    t.index ["name"], name: "index_sipity_groups_on_name", unique: true
   end
-
-  add_index "sipity_groups", ["name", "api_key"], name: "index_sipity_groups_on_name_and_api_key", using: :btree
-  add_index "sipity_groups", ["name"], name: "index_sipity_groups_on_name", unique: true, using: :btree
 
   create_table "sipity_models_processing_administrative_scheduled_actions", force: :cascade do |t|
-    t.datetime "scheduled_time",             null: false
-    t.string   "reason",         limit: 255, null: false
-    t.string   "entity_id",      limit: 255, null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "scheduled_time", null: false
+    t.string "reason", null: false
+    t.string "entity_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id", "reason"], name: "idx_sipity_scheduled_actions_entity_id_reason"
   end
-
-  add_index "sipity_models_processing_administrative_scheduled_actions", ["entity_id", "reason"], name: "idx_sipity_scheduled_actions_entity_id_reason", using: :btree
 
   create_table "sipity_notification_email_recipients", force: :cascade do |t|
-    t.integer  "email_id",           limit: 4,   null: false
-    t.integer  "role_id",            limit: 4,   null: false
-    t.string   "recipient_strategy", limit: 255, null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.integer "email_id", null: false
+    t.integer "role_id", null: false
+    t.string "recipient_strategy", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_id", "role_id", "recipient_strategy"], name: "sipity_notification_email_recipients_surrogate"
+    t.index ["email_id"], name: "sipity_notification_email_recipients_email"
+    t.index ["recipient_strategy"], name: "sipity_notification_email_recipients_recipient_strategy"
+    t.index ["role_id"], name: "sipity_notification_email_recipients_role"
   end
-
-  add_index "sipity_notification_email_recipients", ["email_id", "role_id", "recipient_strategy"], name: "sipity_notification_email_recipients_surrogate", using: :btree
-  add_index "sipity_notification_email_recipients", ["email_id"], name: "sipity_notification_email_recipients_email", using: :btree
-  add_index "sipity_notification_email_recipients", ["recipient_strategy"], name: "sipity_notification_email_recipients_recipient_strategy", using: :btree
-  add_index "sipity_notification_email_recipients", ["role_id"], name: "sipity_notification_email_recipients_role", using: :btree
 
   create_table "sipity_notification_emails", force: :cascade do |t|
-    t.string   "method_name", limit: 255, null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.string "method_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["method_name"], name: "index_sipity_notification_emails_on_method_name"
   end
-
-  add_index "sipity_notification_emails", ["method_name"], name: "index_sipity_notification_emails_on_method_name", using: :btree
 
   create_table "sipity_notification_notifiable_contexts", force: :cascade do |t|
-    t.integer  "scope_for_notification_id",   limit: 4,   null: false
-    t.string   "scope_for_notification_type", limit: 255, null: false
-    t.string   "reason_for_notification",     limit: 255, null: false
-    t.integer  "email_id",                    limit: 4,   null: false
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
+    t.integer "scope_for_notification_id", null: false
+    t.string "scope_for_notification_type", null: false
+    t.string "reason_for_notification", null: false
+    t.integer "email_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_id"], name: "idx_sipity_notification_notifiable_contexts_email_id"
+    t.index ["scope_for_notification_id", "scope_for_notification_type", "reason_for_notification", "email_id"], name: "idx_sipity_notification_notifiable_contexts_concern_surrogate", unique: true
+    t.index ["scope_for_notification_id", "scope_for_notification_type", "reason_for_notification"], name: "idx_sipity_notification_notifiable_contexts_concern_context"
+    t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "idx_sipity_notification_notifiable_contexts_concern"
   end
-
-  add_index "sipity_notification_notifiable_contexts", ["email_id"], name: "idx_sipity_notification_notifiable_contexts_email_id", using: :btree
-  add_index "sipity_notification_notifiable_contexts", ["scope_for_notification_id", "scope_for_notification_type", "reason_for_notification", "email_id"], name: "idx_sipity_notification_notifiable_contexts_concern_surrogate", unique: true, using: :btree
-  add_index "sipity_notification_notifiable_contexts", ["scope_for_notification_id", "scope_for_notification_type", "reason_for_notification"], name: "idx_sipity_notification_notifiable_contexts_concern_context", using: :btree
-  add_index "sipity_notification_notifiable_contexts", ["scope_for_notification_id", "scope_for_notification_type"], name: "idx_sipity_notification_notifiable_contexts_concern", using: :btree
 
   create_table "sipity_processing_actors", force: :cascade do |t|
-    t.string   "proxy_for_id",   limit: 32,  null: false
-    t.string   "proxy_for_type", limit: 255, null: false
-    t.string   "name_of_proxy",  limit: 255
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.string "proxy_for_id", limit: 32, null: false
+    t.string "proxy_for_type", null: false
+    t.string "name_of_proxy"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_actors_proxy_for", unique: true
   end
-
-  add_index "sipity_processing_actors", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_actors_proxy_for", unique: true, using: :btree
 
   create_table "sipity_processing_comments", force: :cascade do |t|
-    t.string   "entity_id",                      limit: 32,                    null: false
-    t.integer  "actor_id",                       limit: 4,                     null: false
-    t.text     "comment",                        limit: 65535
-    t.integer  "originating_strategy_action_id", limit: 4,                     null: false
-    t.integer  "originating_strategy_state_id",  limit: 4,                     null: false
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
-    t.boolean  "stale",                                        default: false
+    t.string "entity_id", limit: 32, null: false
+    t.integer "actor_id", null: false
+    t.text "comment"
+    t.integer "originating_strategy_action_id", null: false
+    t.integer "originating_strategy_state_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "stale", default: false
+    t.index ["actor_id"], name: "index_sipity_processing_comments_on_actor_id"
+    t.index ["created_at"], name: "index_sipity_processing_comments_on_created_at"
+    t.index ["entity_id"], name: "index_sipity_processing_comments_on_entity_id"
+    t.index ["originating_strategy_action_id"], name: "sipity_processing_comments_action_index"
+    t.index ["originating_strategy_state_id"], name: "sipity_processing_comments_state_index"
   end
-
-  add_index "sipity_processing_comments", ["actor_id"], name: "index_sipity_processing_comments_on_actor_id", using: :btree
-  add_index "sipity_processing_comments", ["created_at"], name: "index_sipity_processing_comments_on_created_at", using: :btree
-  add_index "sipity_processing_comments", ["entity_id"], name: "index_sipity_processing_comments_on_entity_id", using: :btree
-  add_index "sipity_processing_comments", ["originating_strategy_action_id"], name: "sipity_processing_comments_action_index", using: :btree
-  add_index "sipity_processing_comments", ["originating_strategy_state_id"], name: "sipity_processing_comments_state_index", using: :btree
 
   create_table "sipity_processing_entities", force: :cascade do |t|
-    t.string   "proxy_for_id",      limit: 32,  null: false
-    t.string   "proxy_for_type",    limit: 255, null: false
-    t.integer  "strategy_id",       limit: 4,   null: false
-    t.integer  "strategy_state_id", limit: 4,   null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string "proxy_for_id", limit: 32, null: false
+    t.string "proxy_for_type", null: false
+    t.integer "strategy_id", null: false
+    t.integer "strategy_state_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_entities_proxy_for", unique: true
+    t.index ["strategy_id"], name: "index_sipity_processing_entities_on_strategy_id"
+    t.index ["strategy_state_id"], name: "index_sipity_processing_entities_on_strategy_state_id"
   end
-
-  add_index "sipity_processing_entities", ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_entities_proxy_for", unique: true, using: :btree
-  add_index "sipity_processing_entities", ["strategy_id"], name: "index_sipity_processing_entities_on_strategy_id", using: :btree
-  add_index "sipity_processing_entities", ["strategy_state_id"], name: "index_sipity_processing_entities_on_strategy_state_id", using: :btree
 
   create_table "sipity_processing_entity_action_registers", force: :cascade do |t|
-    t.integer  "strategy_action_id",    limit: 4,   null: false
-    t.string   "entity_id",             limit: 32,  null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.integer  "requested_by_actor_id", limit: 4,   null: false
-    t.integer  "on_behalf_of_actor_id", limit: 4,   null: false
-    t.string   "subject_id",            limit: 255, null: false
-    t.string   "subject_type",          limit: 255, null: false
+    t.integer "strategy_action_id", null: false
+    t.string "entity_id", limit: 32, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "requested_by_actor_id", null: false
+    t.integer "on_behalf_of_actor_id", null: false
+    t.string "subject_id", null: false
+    t.string "subject_type", null: false
+    t.index ["strategy_action_id", "entity_id", "on_behalf_of_actor_id"], name: "sipity_processing_entity_action_registers_on_behalf"
+    t.index ["strategy_action_id", "entity_id", "requested_by_actor_id"], name: "sipity_processing_entity_action_registers_requested"
+    t.index ["strategy_action_id", "entity_id"], name: "sipity_processing_entity_action_registers_aggregate"
+    t.index ["subject_id", "subject_type"], name: "sipity_processing_entity_action_registers_subject"
   end
-
-  add_index "sipity_processing_entity_action_registers", ["strategy_action_id", "entity_id", "on_behalf_of_actor_id"], name: "sipity_processing_entity_action_registers_on_behalf", using: :btree
-  add_index "sipity_processing_entity_action_registers", ["strategy_action_id", "entity_id", "requested_by_actor_id"], name: "sipity_processing_entity_action_registers_requested", using: :btree
-  add_index "sipity_processing_entity_action_registers", ["strategy_action_id", "entity_id"], name: "sipity_processing_entity_action_registers_aggregate", using: :btree
-  add_index "sipity_processing_entity_action_registers", ["subject_id", "subject_type"], name: "sipity_processing_entity_action_registers_subject", using: :btree
 
   create_table "sipity_processing_entity_specific_responsibilities", force: :cascade do |t|
-    t.integer  "strategy_role_id", limit: 4,  null: false
-    t.string   "entity_id",        limit: 32, null: false
-    t.integer  "actor_id",         limit: 4,  null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.integer "strategy_role_id", null: false
+    t.string "entity_id", limit: 32, null: false
+    t.integer "actor_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "sipity_processing_entity_specific_responsibilities_actor"
+    t.index ["entity_id"], name: "sipity_processing_entity_specific_responsibilities_entity"
+    t.index ["strategy_role_id", "entity_id", "actor_id"], name: "sipity_processing_entity_specific_responsibilities_aggregate", unique: true
+    t.index ["strategy_role_id"], name: "sipity_processing_entity_specific_responsibilities_role"
   end
-
-  add_index "sipity_processing_entity_specific_responsibilities", ["actor_id"], name: "sipity_processing_entity_specific_responsibilities_actor", using: :btree
-  add_index "sipity_processing_entity_specific_responsibilities", ["entity_id"], name: "sipity_processing_entity_specific_responsibilities_entity", using: :btree
-  add_index "sipity_processing_entity_specific_responsibilities", ["strategy_role_id", "entity_id", "actor_id"], name: "sipity_processing_entity_specific_responsibilities_aggregate", unique: true, using: :btree
-  add_index "sipity_processing_entity_specific_responsibilities", ["strategy_role_id"], name: "sipity_processing_entity_specific_responsibilities_role", using: :btree
 
   create_table "sipity_processing_strategies", force: :cascade do |t|
-    t.string   "name",        limit: 255,   null: false
-    t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sipity_processing_strategies_on_name", unique: true
   end
-
-  add_index "sipity_processing_strategies", ["name"], name: "index_sipity_processing_strategies_on_name", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_action_analogues", force: :cascade do |t|
-    t.integer  "strategy_action_id",              limit: 4, null: false
-    t.integer  "analogous_to_strategy_action_id", limit: 4, null: false
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+    t.integer "strategy_action_id", null: false
+    t.integer "analogous_to_strategy_action_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["analogous_to_strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_analogous_stgy"
+    t.index ["strategy_action_id", "analogous_to_strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_aggregate", unique: true
+    t.index ["strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_strategy"
   end
-
-  add_index "sipity_processing_strategy_action_analogues", ["analogous_to_strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_analogous_stgy", using: :btree
-  add_index "sipity_processing_strategy_action_analogues", ["strategy_action_id", "analogous_to_strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_aggregate", unique: true, using: :btree
-  add_index "sipity_processing_strategy_action_analogues", ["strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_strategy", using: :btree
 
   create_table "sipity_processing_strategy_action_prerequisites", force: :cascade do |t|
-    t.integer  "guarded_strategy_action_id",      limit: 4
-    t.integer  "prerequisite_strategy_action_id", limit: 4
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
+    t.integer "guarded_strategy_action_id"
+    t.integer "prerequisite_strategy_action_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["guarded_strategy_action_id", "prerequisite_strategy_action_id"], name: "sipity_processing_strategy_action_prerequisites_aggregate", unique: true
   end
-
-  add_index "sipity_processing_strategy_action_prerequisites", ["guarded_strategy_action_id", "prerequisite_strategy_action_id"], name: "sipity_processing_strategy_action_prerequisites_aggregate", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_actions", force: :cascade do |t|
-    t.integer  "strategy_id",                       limit: 4,                  null: false
-    t.integer  "resulting_strategy_state_id",       limit: 4
-    t.string   "name",                              limit: 255,                null: false
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
-    t.string   "action_type",                       limit: 255,                null: false
-    t.integer  "presentation_sequence",             limit: 4
-    t.boolean  "allow_repeat_within_current_state",             default: true, null: false
+    t.integer "strategy_id", null: false
+    t.integer "resulting_strategy_state_id"
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "action_type", null: false
+    t.integer "presentation_sequence"
+    t.boolean "allow_repeat_within_current_state", default: true, null: false
+    t.index ["action_type"], name: "index_sipity_processing_strategy_actions_on_action_type"
+    t.index ["resulting_strategy_state_id"], name: "sipity_processing_strategy_actions_resulting_strategy_state"
+    t.index ["strategy_id", "name"], name: "sipity_processing_strategy_actions_aggregate", unique: true
+    t.index ["strategy_id", "presentation_sequence"], name: "sipity_processing_strategy_actions_sequence"
   end
-
-  add_index "sipity_processing_strategy_actions", ["action_type"], name: "index_sipity_processing_strategy_actions_on_action_type", using: :btree
-  add_index "sipity_processing_strategy_actions", ["resulting_strategy_state_id"], name: "sipity_processing_strategy_actions_resulting_strategy_state", using: :btree
-  add_index "sipity_processing_strategy_actions", ["strategy_id", "name"], name: "sipity_processing_strategy_actions_aggregate", unique: true, using: :btree
-  add_index "sipity_processing_strategy_actions", ["strategy_id", "presentation_sequence"], name: "sipity_processing_strategy_actions_sequence", using: :btree
 
   create_table "sipity_processing_strategy_responsibilities", force: :cascade do |t|
-    t.integer  "actor_id",         limit: 4, null: false
-    t.integer  "strategy_role_id", limit: 4, null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.integer "actor_id", null: false
+    t.integer "strategy_role_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id", "strategy_role_id"], name: "sipity_processing_strategy_responsibilities_aggregate", unique: true
   end
-
-  add_index "sipity_processing_strategy_responsibilities", ["actor_id", "strategy_role_id"], name: "sipity_processing_strategy_responsibilities_aggregate", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_roles", force: :cascade do |t|
-    t.integer  "strategy_id", limit: 4, null: false
-    t.integer  "role_id",     limit: 4, null: false
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.integer "strategy_id", null: false
+    t.integer "role_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["strategy_id", "role_id"], name: "sipity_processing_strategy_roles_aggregate", unique: true
   end
-
-  add_index "sipity_processing_strategy_roles", ["strategy_id", "role_id"], name: "sipity_processing_strategy_roles_aggregate", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_state_action_permissions", force: :cascade do |t|
-    t.integer  "strategy_role_id",         limit: 4, null: false
-    t.integer  "strategy_state_action_id", limit: 4, null: false
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.integer "strategy_role_id", null: false
+    t.integer "strategy_state_action_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["strategy_role_id", "strategy_state_action_id"], name: "sipity_processing_strategy_state_action_permissions_aggregate", unique: true
   end
-
-  add_index "sipity_processing_strategy_state_action_permissions", ["strategy_role_id", "strategy_state_action_id"], name: "sipity_processing_strategy_state_action_permissions_aggregate", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_state_actions", force: :cascade do |t|
-    t.integer  "originating_strategy_state_id", limit: 4, null: false
-    t.integer  "strategy_action_id",            limit: 4, null: false
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
+    t.integer "originating_strategy_state_id", null: false
+    t.integer "strategy_action_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["originating_strategy_state_id", "strategy_action_id"], name: "sipity_processing_strategy_state_actions_aggregate", unique: true
   end
-
-  add_index "sipity_processing_strategy_state_actions", ["originating_strategy_state_id", "strategy_action_id"], name: "sipity_processing_strategy_state_actions_aggregate", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_states", force: :cascade do |t|
-    t.integer  "strategy_id", limit: 4,   null: false
-    t.string   "name",        limit: 255, null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer "strategy_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sipity_processing_strategy_states_on_name"
+    t.index ["strategy_id", "name"], name: "sipity_processing_type_state_aggregate", unique: true
   end
-
-  add_index "sipity_processing_strategy_states", ["name"], name: "index_sipity_processing_strategy_states_on_name", using: :btree
-  add_index "sipity_processing_strategy_states", ["strategy_id", "name"], name: "sipity_processing_type_state_aggregate", unique: true, using: :btree
 
   create_table "sipity_processing_strategy_usages", force: :cascade do |t|
-    t.integer  "strategy_id", limit: 4,   null: false
-    t.integer  "usage_id",    limit: 4,   null: false
-    t.string   "usage_type",  limit: 255, null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer "strategy_id", null: false
+    t.integer "usage_id", null: false
+    t.string "usage_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["strategy_id"], name: "idx_sipity_processing_strategy_usages_strategy_fk"
+    t.index ["usage_id", "usage_type"], name: "idx_sipity_processing_strategy_usages_usage_fk", unique: true
   end
-
-  add_index "sipity_processing_strategy_usages", ["strategy_id"], name: "idx_sipity_processing_strategy_usages_strategy_fk", using: :btree
-  add_index "sipity_processing_strategy_usages", ["usage_id", "usage_type"], name: "idx_sipity_processing_strategy_usages_usage_fk", unique: true, using: :btree
 
   create_table "sipity_roles", force: :cascade do |t|
-    t.string   "name",        limit: 255,   null: false
-    t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
-
-  add_index "sipity_roles", ["name"], name: "index_sipity_roles_on_name", unique: true, using: :btree
 
   create_table "sipity_submission_window_work_types", force: :cascade do |t|
-    t.integer  "submission_window_id", limit: 4, null: false
-    t.integer  "work_type_id",         limit: 4, null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.integer "submission_window_id", null: false
+    t.integer "work_type_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["submission_window_id", "work_type_id"], name: "sipity_submission_window_work_types_surrogate", unique: true
+    t.index ["submission_window_id"], name: "idx_sipity_submission_window_work_types_submission_window_id"
+    t.index ["work_type_id"], name: "idx_sipity_submission_window_work_types_work_type_id"
   end
-
-  add_index "sipity_submission_window_work_types", ["submission_window_id", "work_type_id"], name: "sipity_submission_window_work_types_surrogate", unique: true, using: :btree
-  add_index "sipity_submission_window_work_types", ["submission_window_id"], name: "idx_sipity_submission_window_work_types_submission_window_id", using: :btree
-  add_index "sipity_submission_window_work_types", ["work_type_id"], name: "idx_sipity_submission_window_work_types_work_type_id", using: :btree
 
   create_table "sipity_submission_windows", force: :cascade do |t|
-    t.integer  "work_area_id",                       limit: 4,   null: false
-    t.string   "slug",                               limit: 255, null: false
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
+    t.integer "work_area_id", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "open_for_starting_submissions_at"
     t.datetime "closed_for_starting_submissions_at"
+    t.index ["closed_for_starting_submissions_at"], name: "idx_submission_windows_closed_surrogate"
+    t.index ["open_for_starting_submissions_at"], name: "idx_submission_window_opening_at"
+    t.index ["slug"], name: "index_sipity_submission_windows_on_slug"
+    t.index ["work_area_id", "open_for_starting_submissions_at"], name: "idx_submission_windows_open_surrogate"
+    t.index ["work_area_id", "slug"], name: "index_sipity_submission_windows_on_work_area_id_and_slug", unique: true
+    t.index ["work_area_id"], name: "index_sipity_submission_windows_on_work_area_id"
   end
-
-  add_index "sipity_submission_windows", ["closed_for_starting_submissions_at"], name: "idx_submission_windows_closed_surrogate", using: :btree
-  add_index "sipity_submission_windows", ["open_for_starting_submissions_at"], name: "idx_submission_window_opening_at", using: :btree
-  add_index "sipity_submission_windows", ["slug"], name: "index_sipity_submission_windows_on_slug", using: :btree
-  add_index "sipity_submission_windows", ["work_area_id", "open_for_starting_submissions_at"], name: "idx_submission_windows_open_surrogate", using: :btree
-  add_index "sipity_submission_windows", ["work_area_id", "slug"], name: "index_sipity_submission_windows_on_work_area_id_and_slug", unique: true, using: :btree
-  add_index "sipity_submission_windows", ["work_area_id"], name: "index_sipity_submission_windows_on_work_area_id", using: :btree
 
   create_table "sipity_work_areas", force: :cascade do |t|
-    t.string   "slug",                          limit: 255, null: false
-    t.string   "partial_suffix",                limit: 255, null: false
-    t.string   "demodulized_class_prefix_name", limit: 255, null: false
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
-    t.string   "name",                          limit: 255, null: false
+    t.string "slug", null: false
+    t.string "partial_suffix", null: false
+    t.string "demodulized_class_prefix_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.index ["name"], name: "index_sipity_work_areas_on_name", unique: true
+    t.index ["slug"], name: "index_sipity_work_areas_on_slug", unique: true
   end
-
-  add_index "sipity_work_areas", ["name"], name: "index_sipity_work_areas_on_name", unique: true, using: :btree
-  add_index "sipity_work_areas", ["slug"], name: "index_sipity_work_areas_on_slug", unique: true, using: :btree
 
   create_table "sipity_work_redirect_strategies", force: :cascade do |t|
-    t.string   "work_id",    limit: 255, null: false
-    t.string   "url",        limit: 255, null: false
-    t.date     "start_date",             null: false
-    t.date     "end_date"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string "work_id", null: false
+    t.string "url", null: false
+    t.date "start_date", null: false
+    t.date "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["work_id", "start_date"], name: "idx_work_redirect_strategies_surrogate"
   end
-
-  add_index "sipity_work_redirect_strategies", ["work_id", "start_date"], name: "idx_work_redirect_strategies_surrogate", using: :btree
 
   create_table "sipity_work_submissions", force: :cascade do |t|
-    t.integer  "work_area_id",         limit: 4,   null: false
-    t.integer  "submission_window_id", limit: 4,   null: false
-    t.string   "work_id",              limit: 255, null: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.integer "work_area_id", null: false
+    t.integer "submission_window_id", null: false
+    t.string "work_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["submission_window_id", "work_id"], name: "idx_sipity_work_submissions_submission_window"
+    t.index ["work_area_id", "work_id"], name: "idx_sipity_work_submissions_work_area"
+    t.index ["work_id"], name: "idx_sipity_work_submissions_primary_key", unique: true
   end
-
-  add_index "sipity_work_submissions", ["submission_window_id", "work_id"], name: "idx_sipity_work_submissions_submission_window", using: :btree
-  add_index "sipity_work_submissions", ["work_area_id", "work_id"], name: "idx_sipity_work_submissions_work_area", using: :btree
-  add_index "sipity_work_submissions", ["work_id"], name: "idx_sipity_work_submissions_primary_key", unique: true, using: :btree
 
   create_table "sipity_work_types", force: :cascade do |t|
-    t.string   "name",        limit: 255,   null: false
-    t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sipity_work_types_on_name", unique: true
   end
-
-  add_index "sipity_work_types", ["name"], name: "index_sipity_work_types_on_name", unique: true, using: :btree
 
   create_table "sipity_works", id: false, force: :cascade do |t|
-    t.string   "id",         limit: 32,    null: false
-    t.text     "title",      limit: 65535
+    t.string "id", limit: 32, null: false
+    t.text "title"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "work_type",  limit: 255,   null: false
+    t.string "work_type", null: false
+    t.index ["id"], name: "index_sipity_works_on_id", unique: true
+    t.index ["title"], name: "index_sipity_works_on_title"
+    t.index ["work_type"], name: "index_sipity_works_on_work_type"
   end
-
-  add_index "sipity_works", ["id"], name: "index_sipity_works_on_id", unique: true, using: :btree
-  add_index "sipity_works", ["title"], name: "index_sipity_works_on_title", length: {"title"=>64}, using: :btree
-  add_index "sipity_works", ["work_type"], name: "index_sipity_works_on_work_type", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                      limit: 255
+    t.string "email"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",              limit: 4,   default: 0,     null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",         limit: 255
-    t.string   "last_sign_in_ip",            limit: 255
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "name",                       limit: 255
-    t.integer  "role",                       limit: 4
-    t.string   "username",                   limit: 255,                 null: false
-    t.boolean  "agreed_to_terms_of_service",             default: false
+    t.string "name"
+    t.integer "role"
+    t.string "username", null: false
+    t.boolean "agreed_to_terms_of_service", default: false
+    t.index ["agreed_to_terms_of_service"], name: "index_users_on_agreed_to_terms_of_service"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
-
-  add_index "users", ["agreed_to_terms_of_service"], name: "index_users_on_agreed_to_terms_of_service", using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2016_04_20_133504) do
 
-  create_table "sipity_access_rights", force: :cascade do |t|
+  create_table "sipity_access_rights", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "entity_id", limit: 32, null: false
     t.string "entity_type", null: false
     t.string "access_right_code", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["entity_id", "entity_type"], name: "index_sipity_access_rights_on_entity_id_and_entity_type", unique: true
   end
 
-  create_table "sipity_account_placeholders", force: :cascade do |t|
+  create_table "sipity_account_placeholders", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "identifier", null: false
     t.string "name"
     t.string "identifier_type", limit: 32, null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["state"], name: "index_sipity_account_placeholders_on_state"
   end
 
-  create_table "sipity_additional_attributes", force: :cascade do |t|
+  create_table "sipity_additional_attributes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "work_id", limit: 32, null: false
     t.string "key", null: false
     t.text "value"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_id"], name: "index_sipity_additional_attributes_on_work_id"
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.string "authentication_token", null: false
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["name"], name: "index_sipity_agents_on_name", unique: true
   end
 
-  create_table "sipity_attachments", id: false, force: :cascade do |t|
+  create_table "sipity_attachments", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "work_id", limit: 32, null: false
     t.string "pid", null: false
     t.string "predicate_name", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_id"], name: "index_sipity_attachments_on_work_id"
   end
 
-  create_table "sipity_collaborators", force: :cascade do |t|
+  create_table "sipity_collaborators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "work_id", limit: 32, null: false
     t.integer "sequence"
     t.string "name"
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_id", "sequence"], name: "index_sipity_collaborators_on_work_id_and_sequence"
   end
 
-  create_table "sipity_doi_creation_requests", force: :cascade do |t|
+  create_table "sipity_doi_creation_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "work_id", limit: 32, null: false
     t.string "state", default: "request_not_yet_submitted", null: false
     t.string "response_message"
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_id"], name: "index_sipity_doi_creation_requests_on_work_id", unique: true
   end
 
-  create_table "sipity_event_logs", force: :cascade do |t|
+  create_table "sipity_event_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "entity_id", limit: 32, null: false
     t.string "entity_type", limit: 64, null: false
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["user_id"], name: "index_sipity_event_logs_on_user_id"
   end
 
-  create_table "sipity_group_memberships", force: :cascade do |t|
+  create_table "sipity_group_memberships", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "group_id", null: false
     t.string "membership_role", null: false
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["user_id"], name: "index_sipity_group_memberships_on_user_id"
   end
 
-  create_table "sipity_groups", force: :cascade do |t|
+  create_table "sipity_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["name"], name: "index_sipity_groups_on_name", unique: true
   end
 
-  create_table "sipity_models_processing_administrative_scheduled_actions", force: :cascade do |t|
+  create_table "sipity_models_processing_administrative_scheduled_actions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "scheduled_time", null: false
     t.string "reason", null: false
     t.string "entity_id", null: false
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["entity_id", "reason"], name: "idx_sipity_scheduled_actions_entity_id_reason"
   end
 
-  create_table "sipity_notification_email_recipients", force: :cascade do |t|
+  create_table "sipity_notification_email_recipients", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "email_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -162,14 +162,14 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["role_id"], name: "sipity_notification_email_recipients_role"
   end
 
-  create_table "sipity_notification_emails", force: :cascade do |t|
+  create_table "sipity_notification_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "method_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["method_name"], name: "index_sipity_notification_emails_on_method_name"
   end
 
-  create_table "sipity_notification_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notification_notifiable_contexts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "idx_sipity_notification_notifiable_contexts_concern"
   end
 
-  create_table "sipity_processing_actors", force: :cascade do |t|
+  create_table "sipity_processing_actors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "proxy_for_id", limit: 32, null: false
     t.string "proxy_for_type", null: false
     t.string "name_of_proxy"
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_processing_actors_proxy_for", unique: true
   end
 
-  create_table "sipity_processing_comments", force: :cascade do |t|
+  create_table "sipity_processing_comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "entity_id", limit: 32, null: false
     t.integer "actor_id", null: false
     t.text "comment"
@@ -207,7 +207,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["originating_strategy_state_id"], name: "sipity_processing_comments_state_index"
   end
 
-  create_table "sipity_processing_entities", force: :cascade do |t|
+  create_table "sipity_processing_entities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "proxy_for_id", limit: 32, null: false
     t.string "proxy_for_type", null: false
     t.integer "strategy_id", null: false
@@ -219,7 +219,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_state_id"], name: "index_sipity_processing_entities_on_strategy_state_id"
   end
 
-  create_table "sipity_processing_entity_action_registers", force: :cascade do |t|
+  create_table "sipity_processing_entity_action_registers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_action_id", null: false
     t.string "entity_id", limit: 32, null: false
     t.datetime "created_at", null: false
@@ -234,7 +234,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["subject_id", "subject_type"], name: "sipity_processing_entity_action_registers_subject"
   end
 
-  create_table "sipity_processing_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_processing_entity_specific_responsibilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_role_id", null: false
     t.string "entity_id", limit: 32, null: false
     t.integer "actor_id", null: false
@@ -246,7 +246,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_role_id"], name: "sipity_processing_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_processing_strategies", force: :cascade do |t|
+  create_table "sipity_processing_strategies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["name"], name: "index_sipity_processing_strategies_on_name", unique: true
   end
 
-  create_table "sipity_processing_strategy_action_analogues", force: :cascade do |t|
+  create_table "sipity_processing_strategy_action_analogues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_action_id", null: false
     t.integer "analogous_to_strategy_action_id", null: false
     t.datetime "created_at", null: false
@@ -264,7 +264,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_action_id"], name: "ix_sipity_processing_strategy_action_analogues_strategy"
   end
 
-  create_table "sipity_processing_strategy_action_prerequisites", force: :cascade do |t|
+  create_table "sipity_processing_strategy_action_prerequisites", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "guarded_strategy_action_id"
     t.integer "prerequisite_strategy_action_id"
     t.datetime "created_at", null: false
@@ -272,7 +272,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["guarded_strategy_action_id", "prerequisite_strategy_action_id"], name: "sipity_processing_strategy_action_prerequisites_aggregate", unique: true
   end
 
-  create_table "sipity_processing_strategy_actions", force: :cascade do |t|
+  create_table "sipity_processing_strategy_actions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_id", null: false
     t.integer "resulting_strategy_state_id"
     t.string "name", null: false
@@ -287,7 +287,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_id", "presentation_sequence"], name: "sipity_processing_strategy_actions_sequence"
   end
 
-  create_table "sipity_processing_strategy_responsibilities", force: :cascade do |t|
+  create_table "sipity_processing_strategy_responsibilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "actor_id", null: false
     t.integer "strategy_role_id", null: false
     t.datetime "created_at", null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["actor_id", "strategy_role_id"], name: "sipity_processing_strategy_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_processing_strategy_roles", force: :cascade do |t|
+  create_table "sipity_processing_strategy_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_id", "role_id"], name: "sipity_processing_strategy_roles_aggregate", unique: true
   end
 
-  create_table "sipity_processing_strategy_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_processing_strategy_state_action_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_role_id", null: false
     t.integer "strategy_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -311,7 +311,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_role_id", "strategy_state_action_id"], name: "sipity_processing_strategy_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_processing_strategy_state_actions", force: :cascade do |t|
+  create_table "sipity_processing_strategy_state_actions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "originating_strategy_state_id", null: false
     t.integer "strategy_action_id", null: false
     t.datetime "created_at", null: false
@@ -319,7 +319,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["originating_strategy_state_id", "strategy_action_id"], name: "sipity_processing_strategy_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_processing_strategy_states", force: :cascade do |t|
+  create_table "sipity_processing_strategy_states", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["strategy_id", "name"], name: "sipity_processing_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_processing_strategy_usages", force: :cascade do |t|
+  create_table "sipity_processing_strategy_usages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "strategy_id", null: false
     t.integer "usage_id", null: false
     t.string "usage_type", null: false
@@ -338,7 +338,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["usage_id", "usage_type"], name: "idx_sipity_processing_strategy_usages_usage_fk", unique: true
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -346,7 +346,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_submission_window_work_types", force: :cascade do |t|
+  create_table "sipity_submission_window_work_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "submission_window_id", null: false
     t.integer "work_type_id", null: false
     t.datetime "created_at", null: false
@@ -356,7 +356,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_type_id"], name: "idx_sipity_submission_window_work_types_work_type_id"
   end
 
-  create_table "sipity_submission_windows", force: :cascade do |t|
+  create_table "sipity_submission_windows", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "work_area_id", null: false
     t.string "slug", null: false
     t.datetime "created_at", null: false
@@ -371,7 +371,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_area_id"], name: "index_sipity_submission_windows_on_work_area_id"
   end
 
-  create_table "sipity_work_areas", force: :cascade do |t|
+  create_table "sipity_work_areas", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "slug", null: false
     t.string "partial_suffix", null: false
     t.string "demodulized_class_prefix_name", null: false
@@ -382,7 +382,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["slug"], name: "index_sipity_work_areas_on_slug", unique: true
   end
 
-  create_table "sipity_work_redirect_strategies", force: :cascade do |t|
+  create_table "sipity_work_redirect_strategies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "work_id", null: false
     t.string "url", null: false
     t.date "start_date", null: false
@@ -392,7 +392,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_id", "start_date"], name: "idx_work_redirect_strategies_surrogate"
   end
 
-  create_table "sipity_work_submissions", force: :cascade do |t|
+  create_table "sipity_work_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "work_area_id", null: false
     t.integer "submission_window_id", null: false
     t.string "work_id", null: false
@@ -403,7 +403,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["work_id"], name: "idx_sipity_work_submissions_primary_key", unique: true
   end
 
-  create_table "sipity_work_types", force: :cascade do |t|
+  create_table "sipity_work_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -411,18 +411,18 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.index ["name"], name: "index_sipity_work_types_on_name", unique: true
   end
 
-  create_table "sipity_works", id: false, force: :cascade do |t|
+  create_table "sipity_works", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "id", limit: 32, null: false
     t.text "title"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "work_type", null: false
     t.index ["id"], name: "index_sipity_works_on_id", unique: true
-    t.index ["title"], name: "index_sipity_works_on_title"
+    t.index ["title"], name: "index_sipity_works_on_title", length: 64
     t.index ["work_type"], name: "index_sipity_works_on_work_type"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email"
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 2016_04_20_133504) do
     t.string "demodulized_class_prefix_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
+    t.string "name", null: false
     t.index ["name"], name: "index_sipity_work_areas_on_name", unique: true
     t.index ["slug"], name: "index_sipity_work_areas_on_slug", unique: true
   end

--- a/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
+++ b/spec/fixtures/seeds/rendering_correct_actions_based_on_user_entity_state.rb
@@ -1,97 +1,122 @@
-User.create!([
-  {email: "test@example.com", remember_created_at: nil, sign_in_count: 2, current_sign_in_at: "2015-02-24 18:32:52", last_sign_in_at: "2015-02-24 18:32:52", current_sign_in_ip: "127.0.0.1", last_sign_in_ip: "127.0.0.1", name: "Test User", role: nil, username: "test@example.com"}
+users = User.create!([
+  {email: "test@example.com", remember_created_at: nil, sign_in_count: 2, current_sign_in_at: "2015-02-24 18:32:52", last_sign_in_at: "2015-02-24 18:32:52", current_sign_in_ip: "127.0.0.1", last_sign_in_ip: "127.0.0.1", name: "Test User", role: nil, username: "test@example.com"},
+  {email: "second-test@example.com", remember_created_at: nil, sign_in_count: 2, current_sign_in_at: "2015-02-24 18:32:52", last_sign_in_at: "2015-02-24 18:32:52", current_sign_in_ip: "127.0.0.1", last_sign_in_ip: "127.0.0.1", name: "Second Test User", role: nil, username: "second-test@example.com"}
 ])
-Sipity::Models::Processing::Actor.create!([
-  {proxy_for_id: 1, proxy_for_type: "User", name_of_proxy: nil}
+
+work_types = Sipity::Models::WorkType.create!([
+  {name: "doctoral_dissertation", description: nil}
 ])
-Sipity::Models::Processing::Entity.create!([
-  {proxy_for_id: 1, proxy_for_type: "Sipity::Models::Work", strategy_id: 1, strategy_state_id: "2"}
+
+actors = Sipity::Models::Processing::Actor.create!([
+  {proxy_for: users[0], name_of_proxy: nil},
+  {proxy_for: users[1], name_of_proxy: nil}
 ])
-Sipity::Models::Processing::EntityActionRegister.create!([
-  {strategy_action_id: 2, entity_id: 1, subject_id: 1, subject_type: "Sipity::Models::Processing::Entity", requested_by_actor_id: 1, on_behalf_of_actor_id: 1},
-  {strategy_action_id: 4, entity_id: 1, subject_id: 1, subject_type: "Sipity::Models::Processing::Entity", requested_by_actor_id: 1, on_behalf_of_actor_id: 1},
-  {strategy_action_id: 5, entity_id: 1, subject_id: 1, subject_type: "Sipity::Models::Processing::Entity", requested_by_actor_id: 1, on_behalf_of_actor_id: 1},
-  {strategy_action_id: 6, entity_id: 1, subject_id: 1, subject_type: "Sipity::Models::Processing::Entity", requested_by_actor_id: 1, on_behalf_of_actor_id: 2}
+
+works = Sipity::Models::Work.create!([
+  id: Rails.application.config.default_pid_minter.call, work_type: work_types[0].name
 ])
-Sipity::Models::Processing::EntitySpecificResponsibility.create!([
-  {strategy_role_id: 1, entity_id: 1, actor_id: 1}
-])
-Sipity::Models::Processing::Strategy.create!([
+
+strategies = Sipity::Models::Processing::Strategy.create!([
   {name: "doctoral_dissertation processing", description: nil}
 ])
-Sipity::Models::Processing::StrategyUsage.create!([
-  {strategy_id: 1, usage_id: 1, usage_type: 'Sipity::Models::WorkType'}
-])
-Sipity::Models::Processing::StrategyAction.create!([
-  {strategy_id: 1, name: "show", action_type: "resourceful_action"},
-  {strategy_id: 1, name: "describe", action_type: "enrichment_action"},
-  {strategy_id: 1, name: "assign_a_doi", action_type: "enrichment_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 2, name: "submit_for_review", action_type: "state_advancing_action"},
-  {strategy_id: 1, allow_repeat_within_current_state: false, name: "already_taken_on_behalf" },
-  {strategy_id: 1, allow_repeat_within_current_state: false, name: "already_taken_but_by_someone_else" },
-  {strategy_id: 1, allow_repeat_within_current_state: false, name: "analog_to_submit_for_review" }
-])
-Sipity::Models::Processing::StrategyActionAnalogue.create!([
-  {strategy_action_id: 7, analogous_to_strategy_action_id: 4}
-])
-Sipity::Models::Processing::StrategyActionPrerequisite.create!([
-  {guarded_strategy_action_id: 4, prerequisite_strategy_action_id: 2}
-])
-Sipity::Models::Processing::StrategyRole.create!([
-  {strategy_id: 1, role_id: 1},
-  {strategy_id: 1, role_id: 2},
-  {strategy_id: 1, role_id: 3}
-])
-Sipity::Models::Processing::StrategyState.create!([
-  {strategy_id: 1, name: "new"},
-  {strategy_id: 1, name: "under_advisor_review"}
-])
-Sipity::Models::Processing::StrategyStateAction.create!([
-  {originating_strategy_state_id: 1, strategy_action_id: 1},
-  {originating_strategy_state_id: 2, strategy_action_id: 1},
-  {originating_strategy_state_id: 1, strategy_action_id: 2},
-  {originating_strategy_state_id: 1, strategy_action_id: 3},
-  {originating_strategy_state_id: 2, strategy_action_id: 3},
-  {originating_strategy_state_id: 1, strategy_action_id: 4},
-  {originating_strategy_state_id: 1, strategy_action_id: 5},
-  {originating_strategy_state_id: 2, strategy_action_id: 5},
-  {originating_strategy_state_id: 1, strategy_action_id: 6},
-  {originating_strategy_state_id: 2, strategy_action_id: 6},
-  {originating_strategy_state_id: 1, strategy_action_id: 7},
-  {originating_strategy_state_id: 2, strategy_action_id: 7}
-])
-Sipity::Models::Processing::StrategyStateActionPermission.create!([
-  {strategy_role_id: 1, strategy_state_action_id: 6},
-  {strategy_role_id: 1, strategy_state_action_id: 1},
-  {strategy_role_id: 1, strategy_state_action_id: 3},
-  {strategy_role_id: 1, strategy_state_action_id: 4},
-  {strategy_role_id: 1, strategy_state_action_id: 2},
-  {strategy_role_id: 2, strategy_state_action_id: 1},
-  {strategy_role_id: 2, strategy_state_action_id: 3},
-  {strategy_role_id: 2, strategy_state_action_id: 4},
-  {strategy_role_id: 2, strategy_state_action_id: 2},
-  {strategy_role_id: 2, strategy_state_action_id: 5},
-  {strategy_role_id: 3, strategy_state_action_id: 1},
-  {strategy_role_id: 3, strategy_state_action_id: 2},
-  {strategy_role_id: 2, strategy_state_action_id: 6},
-  {strategy_role_id: 2, strategy_state_action_id: 7},
-  {strategy_role_id: 2, strategy_state_action_id: 8},
-  {strategy_role_id: 2, strategy_state_action_id: 9},
-  {strategy_role_id: 2, strategy_state_action_id: 10},
-  {strategy_role_id: 2, strategy_state_action_id: 11},
-  {strategy_role_id: 2, strategy_state_action_id: 12},
-  {strategy_role_id: 1, strategy_state_action_id: 7},
-  {strategy_role_id: 1, strategy_state_action_id: 8},
-  {strategy_role_id: 1, strategy_state_action_id: 9},
-  {strategy_role_id: 1, strategy_state_action_id: 10},
-  {strategy_role_id: 1, strategy_state_action_id: 11},
-  {strategy_role_id: 1, strategy_state_action_id: 12}
-])
-Sipity::Models::Role.create!([
+
+roles = Sipity::Models::Role.create!([
   {name: "creating_user", description: nil},
   {name: "etd_reviewing", description: nil},
   {name: "advising", description: nil}
 ])
-Sipity::Models::WorkType.create!([
-  {name: "doctoral_dissertation", description: nil}
+
+strategy_states = Sipity::Models::Processing::StrategyState.create!([
+  {strategy: strategies[0], name: "new"},
+  {strategy: strategies[0], name: "under_advisor_review"}
+])
+
+strategy_actions = Sipity::Models::Processing::StrategyAction.create!([
+  {strategy: strategies[0], name: "show", action_type: "resourceful_action"},
+  {strategy: strategies[0], name: "describe", action_type: "enrichment_action"},
+  {strategy: strategies[0], name: "assign_a_doi", action_type: "enrichment_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[1], name: "submit_for_review", action_type: "state_advancing_action"},
+  {strategy: strategies[0], allow_repeat_within_current_state: false, name: "already_taken_on_behalf" },
+  {strategy: strategies[0], allow_repeat_within_current_state: false, name: "already_taken_but_by_someone_else" },
+  {strategy: strategies[0], allow_repeat_within_current_state: false, name: "analog_to_submit_for_review" }
+])
+
+strategy_roles = Sipity::Models::Processing::StrategyRole.create!([
+  {strategy: strategies[0], role: roles[0]},
+  {strategy: strategies[0], role: roles[1]},
+  {strategy: strategies[0], role: roles[2]}
+])
+
+entities = Sipity::Models::Processing::Entity.create!([
+  {proxy_for: works[0], strategy: strategies[0], strategy_state: strategy_states[1]}
+])
+
+entity_action_registers = Sipity::Models::Processing::EntityActionRegister.create!([
+  {strategy_action: strategy_actions[1], entity: entities[0], subject: entities[0], requested_by_actor: actors[0], on_behalf_of_actor: actors[0]},
+  {strategy_action: strategy_actions[3], entity: entities[0], subject: entities[0], requested_by_actor: actors[0], on_behalf_of_actor: actors[0]},
+  {strategy_action: strategy_actions[4], entity: entities[0], subject: entities[0], requested_by_actor: actors[0], on_behalf_of_actor: actors[0]},
+  {strategy_action: strategy_actions[5], entity: entities[0], subject: entities[0], requested_by_actor: actors[0], on_behalf_of_actor: actors[1]}
+])
+
+entity_specific_responsibilities = Sipity::Models::Processing::EntitySpecificResponsibility.create!([
+  {strategy_role: strategy_roles[0], entity: entities[0], actor: actors[0]}
+])
+
+strategy_usages = Sipity::Models::Processing::StrategyUsage.create!([
+  {strategy: strategies[0], usage: work_types[0]}
+])
+
+strategy_action_analogues = Sipity::Models::Processing::StrategyActionAnalogue.create!([
+  {strategy_action: strategy_actions[6], analogous_to_strategy_action: strategy_actions[3]}
+])
+
+requiring_strategy_action_prerequisites = Sipity::Models::Processing::StrategyActionPrerequisite.create!([
+  {guarded_strategy_action: strategy_actions[3], prerequisite_strategy_action: strategy_actions[1]}
+])
+
+strategy_state_actions = Sipity::Models::Processing::StrategyStateAction.create!([
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[1]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[2]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[2]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[3]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[4]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[4]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[5]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[5]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[6]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[6]}
+])
+
+strategy_state_action_permissions = Sipity::Models::Processing::StrategyStateActionPermission.create!([
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[5]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[0]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[2]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[3]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[1]},
+
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[0]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[2]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[3]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[1]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[4]},
+
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[0]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[1]},
+
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[5]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[6]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[7]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[8]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[9]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[10]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[11]},
+
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[6]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[7]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[8]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[9]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[10]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[11]}
 ])

--- a/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
+++ b/spec/fixtures/seeds/scope_strategy_actions_with_incomplete_prerequisites.rb
@@ -3,159 +3,168 @@
 #
 # This data was generated via rake db:seed:dump
 # It is used for a specific test.
-User.create!([
+users = User.create!([
   {email: nil, remember_created_at: nil, sign_in_count: 1, current_sign_in_at: "2015-02-23 15:05:46", last_sign_in_at: "2015-02-23 15:05:46", current_sign_in_ip: "::1", last_sign_in_ip: "::1", name: nil, role: nil, username: "jfriesen"}
 ])
-Sipity::Models::Processing::Actor.create!([
-  {proxy_for_id: 1, proxy_for_type: "User", name_of_proxy: nil}
+actors = Sipity::Models::Processing::Actor.create!([
+  {proxy_for: users[0], name_of_proxy: nil}
 ])
-Sipity::Models::Processing::Entity.create!([
-  {proxy_for_id: 1, proxy_for_type: "Sipity::Models::Work", strategy_id: 1, strategy_state_id: "1"}
+
+work_types = Sipity::Models::WorkType.create!([
+  {name: "doctoral_dissertation", description: nil}
 ])
-Sipity::Models::Processing::EntityActionRegister.create!([
-  {strategy_action_id: 4, entity_id: 1, requested_by_actor_id: 1, on_behalf_of_actor_id: 1, subject_id: 1, subject_type: 'Sipity::Models::Processing::Entity'}
-])
-Sipity::Models::Processing::EntitySpecificResponsibility.create!([
-  {strategy_role_id: 1, entity_id: 1, actor_id: 1}
-])
-Sipity::Models::Processing::Strategy.create!([
+
+strategies = Sipity::Models::Processing::Strategy.create!([
   {name: "etd processing", description: nil}
 ])
-Sipity::Models::Processing::StrategyUsage.create!([
-  {strategy_id: 1, usage_id: 1, usage_type: 'Sipity::Models::WorkType'}
-])
-Sipity::Models::Processing::StrategyAction.create!([
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "show", action_type: "resourceful_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "edit", action_type: "resourceful_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "destroy", action_type: "resourceful_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "describe", action_type: "enrichment_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "attach", action_type: "enrichment_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "collaborators", action_type: "enrichment_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "assign_a_doi", action_type: "enrichment_action"},
-  {strategy_id: 1, resulting_strategy_state_id: nil, name: "assign_a_citation", action_type: "enrichment_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 2, name: "submit_for_review", action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 4, name: "advisor_signs_off", action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 3, name: "advisor_requests_changes", action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 2, name: "request_revision", action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 5, name: "grad_school_signoff", action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 6, name: "ingest", action_type: "state_advancing_action"},
-  {strategy_id: 1, resulting_strategy_state_id: 7, name: "ingest_completed", action_type: "state_advancing_action"}
-])
-Sipity::Models::Processing::StrategyActionPrerequisite.create!([
-  {guarded_strategy_action_id: 9, prerequisite_strategy_action_id: 4},
-  {guarded_strategy_action_id: 9, prerequisite_strategy_action_id: 5},
-  {guarded_strategy_action_id: 9, prerequisite_strategy_action_id: 6}
-])
-Sipity::Models::Processing::StrategyRole.create!([
-  {strategy_id: 1, role_id: 1},
-  {strategy_id: 1, role_id: 2},
-  {strategy_id: 1, role_id: 3}
-])
-Sipity::Models::Processing::StrategyState.create!([
-  {strategy_id: 1, name: "new"},
-  {strategy_id: 1, name: "under_advisor_review"},
-  {strategy_id: 1, name: "advisor_changes_requested"},
-  {strategy_id: 1, name: "under_grad_school_review"},
-  {strategy_id: 1, name: "ready_for_ingest"},
-  {strategy_id: 1, name: "ingesting"},
-  {strategy_id: 1, name: "done"}
-])
-Sipity::Models::Processing::StrategyStateAction.create!([
-  {originating_strategy_state_id: 1, strategy_action_id: 1},
-  {originating_strategy_state_id: 2, strategy_action_id: 1},
-  {originating_strategy_state_id: 3, strategy_action_id: 1},
-  {originating_strategy_state_id: 4, strategy_action_id: 1},
-  {originating_strategy_state_id: 5, strategy_action_id: 1},
-  {originating_strategy_state_id: 6, strategy_action_id: 1},
-  {originating_strategy_state_id: 7, strategy_action_id: 1},
-  {originating_strategy_state_id: 1, strategy_action_id: 2},
-  {originating_strategy_state_id: 3, strategy_action_id: 2},
-  {originating_strategy_state_id: 4, strategy_action_id: 2},
-  {originating_strategy_state_id: 1, strategy_action_id: 3},
-  {originating_strategy_state_id: 2, strategy_action_id: 3},
-  {originating_strategy_state_id: 3, strategy_action_id: 3},
-  {originating_strategy_state_id: 4, strategy_action_id: 3},
-  {originating_strategy_state_id: 1, strategy_action_id: 4},
-  {originating_strategy_state_id: 1, strategy_action_id: 5},
-  {originating_strategy_state_id: 1, strategy_action_id: 6},
-  {originating_strategy_state_id: 1, strategy_action_id: 7},
-  {originating_strategy_state_id: 2, strategy_action_id: 7},
-  {originating_strategy_state_id: 3, strategy_action_id: 7},
-  {originating_strategy_state_id: 4, strategy_action_id: 7},
-  {originating_strategy_state_id: 1, strategy_action_id: 8},
-  {originating_strategy_state_id: 2, strategy_action_id: 8},
-  {originating_strategy_state_id: 3, strategy_action_id: 8},
-  {originating_strategy_state_id: 4, strategy_action_id: 8},
-  {originating_strategy_state_id: 1, strategy_action_id: 9},
-  {originating_strategy_state_id: 2, strategy_action_id: 10},
-  {originating_strategy_state_id: 2, strategy_action_id: 11},
-  {originating_strategy_state_id: 4, strategy_action_id: 12}
-])
-Sipity::Models::Processing::StrategyStateActionPermission.create!([
-  {strategy_role_id: 1, strategy_state_action_id: 26},
-  {strategy_role_id: 1, strategy_state_action_id: 1},
-  {strategy_role_id: 1, strategy_state_action_id: 8},
-  {strategy_role_id: 1, strategy_state_action_id: 15},
-  {strategy_role_id: 1, strategy_state_action_id: 16},
-  {strategy_role_id: 1, strategy_state_action_id: 17},
-  {strategy_role_id: 1, strategy_state_action_id: 11},
-  {strategy_role_id: 1, strategy_state_action_id: 18},
-  {strategy_role_id: 1, strategy_state_action_id: 22},
-  {strategy_role_id: 1, strategy_state_action_id: 2},
-  {strategy_role_id: 1, strategy_state_action_id: 20},
-  {strategy_role_id: 1, strategy_state_action_id: 24},
-  {strategy_role_id: 1, strategy_state_action_id: 3},
-  {strategy_role_id: 1, strategy_state_action_id: 9},
-  {strategy_role_id: 1, strategy_state_action_id: 13},
-  {strategy_role_id: 1, strategy_state_action_id: 4},
-  {strategy_role_id: 1, strategy_state_action_id: 5},
-  {strategy_role_id: 1, strategy_state_action_id: 6},
-  {strategy_role_id: 1, strategy_state_action_id: 7},
-  {strategy_role_id: 2, strategy_state_action_id: 1},
-  {strategy_role_id: 2, strategy_state_action_id: 8},
-  {strategy_role_id: 2, strategy_state_action_id: 15},
-  {strategy_role_id: 2, strategy_state_action_id: 16},
-  {strategy_role_id: 2, strategy_state_action_id: 17},
-  {strategy_role_id: 2, strategy_state_action_id: 11},
-  {strategy_role_id: 2, strategy_state_action_id: 18},
-  {strategy_role_id: 2, strategy_state_action_id: 22},
-  {strategy_role_id: 2, strategy_state_action_id: 2},
-  {strategy_role_id: 2, strategy_state_action_id: 19},
-  {strategy_role_id: 2, strategy_state_action_id: 23},
-  {strategy_role_id: 2, strategy_state_action_id: 12},
-  {strategy_role_id: 2, strategy_state_action_id: 27},
-  {strategy_role_id: 2, strategy_state_action_id: 28},
-  {strategy_role_id: 2, strategy_state_action_id: 20},
-  {strategy_role_id: 2, strategy_state_action_id: 3},
-  {strategy_role_id: 2, strategy_state_action_id: 9},
-  {strategy_role_id: 2, strategy_state_action_id: 13},
-  {strategy_role_id: 2, strategy_state_action_id: 21},
-  {strategy_role_id: 2, strategy_state_action_id: 25},
-  {strategy_role_id: 2, strategy_state_action_id: 29},
-  {strategy_role_id: 2, strategy_state_action_id: 4},
-  {strategy_role_id: 2, strategy_state_action_id: 10},
-  {strategy_role_id: 2, strategy_state_action_id: 14},
-  {strategy_role_id: 2, strategy_state_action_id: 5},
-  {strategy_role_id: 2, strategy_state_action_id: 6},
-  {strategy_role_id: 2, strategy_state_action_id: 7},
-  {strategy_role_id: 3, strategy_state_action_id: 1},
-  {strategy_role_id: 3, strategy_state_action_id: 2},
-  {strategy_role_id: 3, strategy_state_action_id: 27},
-  {strategy_role_id: 3, strategy_state_action_id: 28},
-  {strategy_role_id: 3, strategy_state_action_id: 3},
-  {strategy_role_id: 3, strategy_state_action_id: 4},
-  {strategy_role_id: 3, strategy_state_action_id: 5},
-  {strategy_role_id: 3, strategy_state_action_id: 6},
-  {strategy_role_id: 3, strategy_state_action_id: 7}
-])
-Sipity::Models::Role.create!([
+
+roles = Sipity::Models::Role.create!([
   {name: "creating_user", description: nil},
   {name: "etd_reviewing", description: nil},
   {name: "advising", description: nil}
 ])
-Sipity::Models::Work.create!([
-  {id: '1', title: "Hello", work_type: "doctoral_dissertation"}
+
+works = Sipity::Models::Work.create!([
+  id: Rails.application.config.default_pid_minter.call, work_type: work_types[0].name
 ])
-Sipity::Models::WorkType.create!([
-  {name: "doctoral_dissertation", description: nil}
+
+strategy_states = Sipity::Models::Processing::StrategyState.create!([
+  {strategy: strategies[0], name: "new"},
+  {strategy: strategies[0], name: "under_advisor_review"},
+  {strategy: strategies[0], name: "advisor_changes_requested"},
+  {strategy: strategies[0], name: "under_grad_school_review"},
+  {strategy: strategies[0], name: "ready_for_ingest"},
+  {strategy: strategies[0], name: "ingesting"},
+  {strategy: strategies[0], name: "done"}
+])
+
+strategy_usages = Sipity::Models::Processing::StrategyUsage.create!([
+  {strategy: strategies[0], usage: work_types[0]}
+])
+strategy_actions = Sipity::Models::Processing::StrategyAction.create!([
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "show", action_type: "resourceful_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "edit", action_type: "resourceful_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "destroy", action_type: "resourceful_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "describe", action_type: "enrichment_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "attach", action_type: "enrichment_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "collaborators", action_type: "enrichment_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "assign_a_doi", action_type: "enrichment_action"},
+  {strategy: strategies[0], resulting_strategy_state: nil, name: "assign_a_citation", action_type: "enrichment_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[1], name: "submit_for_review", action_type: "state_advancing_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[3], name: "advisor_signs_off", action_type: "state_advancing_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[2], name: "advisor_requests_changes", action_type: "state_advancing_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[1], name: "request_revision", action_type: "state_advancing_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[4], name: "grad_school_signoff", action_type: "state_advancing_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[5], name: "ingest", action_type: "state_advancing_action"},
+  {strategy: strategies[0], resulting_strategy_state: strategy_states[6], name: "ingest_completed", action_type: "state_advancing_action"}
+])
+strategy_state_actions = Sipity::Models::Processing::StrategyStateAction.create!([
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[2], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[3], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[4], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[5], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[6], strategy_action: strategy_actions[0]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[1]},
+  {originating_strategy_state: strategy_states[2], strategy_action: strategy_actions[1]},
+  {originating_strategy_state: strategy_states[3], strategy_action: strategy_actions[1]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[2]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[2]},
+  {originating_strategy_state: strategy_states[2], strategy_action: strategy_actions[2]},
+  {originating_strategy_state: strategy_states[3], strategy_action: strategy_actions[2]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[3]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[4]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[5]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[6]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[6]},
+  {originating_strategy_state: strategy_states[2], strategy_action: strategy_actions[6]},
+  {originating_strategy_state: strategy_states[3], strategy_action: strategy_actions[6]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[7]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[7]},
+  {originating_strategy_state: strategy_states[2], strategy_action: strategy_actions[7]},
+  {originating_strategy_state: strategy_states[3], strategy_action: strategy_actions[7]},
+  {originating_strategy_state: strategy_states[0], strategy_action: strategy_actions[8]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[9]},
+  {originating_strategy_state: strategy_states[1], strategy_action: strategy_actions[10]},
+  {originating_strategy_state: strategy_states[3], strategy_action: strategy_actions[11]}
+])
+strategy_action_prerequisites = Sipity::Models::Processing::StrategyActionPrerequisite.create!([
+  {guarded_strategy_action: strategy_actions[8], prerequisite_strategy_action: strategy_actions[3]},
+  {guarded_strategy_action: strategy_actions[8], prerequisite_strategy_action: strategy_actions[4]},
+  {guarded_strategy_action: strategy_actions[8], prerequisite_strategy_action: strategy_actions[5]}
+])
+strategy_roles = Sipity::Models::Processing::StrategyRole.create!([
+  {strategy: strategies[0], role: roles[0]},
+  {strategy: strategies[0], role: roles[1]},
+  {strategy: strategies[0], role: roles[2]}
+])
+
+entities = Sipity::Models::Processing::Entity.create!([
+  {proxy_for: works[0], strategy: strategies[0], strategy_state: strategy_states[0]}
+])
+
+entity_action_registers = Sipity::Models::Processing::EntityActionRegister.create!([
+  {strategy_action: strategy_actions[3], entity: entities[0], requested_by_actor: actors[0], on_behalf_of_actor: actors[0], subject: entities[0]}
+])
+entity_specific_responsibilities = Sipity::Models::Processing::EntitySpecificResponsibility.create!([
+  {strategy_role: strategy_roles[0], entity: entities[0], actor: actors[0]}
+])
+
+strategy_state_action_permissions = Sipity::Models::Processing::StrategyStateActionPermission.create!([
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[25]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[0]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[7]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[14]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[15]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[16]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[10]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[17]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[21]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[1]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[19]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[23]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[2]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[8]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[12]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[3]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[4]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[5]},
+  {strategy_role: strategy_roles[0], strategy_state_action: strategy_state_actions[6]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[0]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[7]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[14]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[15]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[16]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[10]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[17]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[21]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[1]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[18]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[22]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[11]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[26]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[27]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[19]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[2]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[8]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[12]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[20]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[24]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[28]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[3]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[9]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[13]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[4]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[5]},
+  {strategy_role: strategy_roles[1], strategy_state_action: strategy_state_actions[6]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[0]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[1]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[26]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[27]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[2]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[3]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[4]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[5]},
+  {strategy_role: strategy_roles[2], strategy_state_action: strategy_state_actions[6]}
 ])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,10 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
+  # NOTE: During testing, the app-under-test that the browser driver connects to
+  #  uses a different database connection to the database connection used by
+  #  the spec. The app's database connection would not be able to access
+  #  uncommitted transaction data setup over the spec's database connection.
   config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests

--- a/spec/repositories/sipity/queries/comment_queries_spec.rb
+++ b/spec/repositories/sipity/queries/comment_queries_spec.rb
@@ -41,11 +41,11 @@ module Sipity
         end
 
         let!(:comments) do
-          # Creating comments for various points along the way; Not we don't care about originating strategy state
+          # Creating comments for various points along the way; Note we don't care about originating strategy state
           # Just what was the action taken as part of this comment.
           (1..4).collect do |index|
             Models::Processing::Comment.create!(
-              originating_strategy_state_id: index, originating_strategy_action_id: (index % actions.size + 1),
+              originating_strategy_state_id: index, originating_strategy_action_id: actions[(index % actions.size)].id,
               entity_id: entity.id, actor_id: 99, comment: "Comment #{index}",
               stale: (index % 3).zero?
             )

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -515,12 +515,12 @@ module Sipity
           Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: user)
           Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: group)
           Services::ActionTakenOnEntity.register(entity: entity, action: action, requested_by: acting_via_email_collaborator)
-          expect(subject.pluck(:name)).to eq(
+          expect(subject.pluck(:name).sort).to eq(
             [
               user_acting_collaborator.name,
               acting_via_email_collaborator.name,
               group_collaborator.name
-            ]
+            ].sort
           )
         end
       end


### PR DESCRIPTION
## Updating for SSL for Rails 5.2

533f836d973b34a74cf067c46bbab903d852cdba

This update modifies the bin/rails command to inject the SSL directive,
as described at https://madeintandem.com/blog/rails-local-development-https-using-self-signed-ssl-certificate/

## Updating schema to address Rails 5.2 realities

61fd2da120de60efe5e5195048fe52d298133b78

Rails does not adhere to Semantic versioning. Instead they have a
policy in which the minor version can introduce breaking changes. This
usually means prior patch versions will include deprecation notices.

However, in the case of the db/schema.rb file this is not something
that is necessarily vetted. By default the db/schema.rb is only updated
after a migration that has not yet been run is run. When I drop the
local database and run the rake tasks, many things fall apart. This
update address at least the test environment.

## Updating fixtures to reference records

0c7a2f1e7f4dd014bd1f298aa4461a2fee0c2605

As previously, the fixtures and specs assumed that before each spec
ran, the database table's auto-incrementing columns each reset to start
from 1. That assumption holds true with sqlite3. However that does not
hold true for mysql or postgresql. I aspire to switch the test
environment from `sqlite` to `mysql` and to align the test database
with the production and development databases. As I used AREL and
ActiveRecord, the upstream abstractions helped ensure "common enough"
behavior. However as Rails continues to introduce more specific
migration idioms, that "common enough" no longer remains adequate.

This change fixes both fixtures and specs that relied on set record
identifiers (a short-cut that I took during the heart of development
of Sipity but one that impedes longer term maintenance and runs against
what I consider to be best practices).

## Switching from sqlite to mysql for test

7abdbe1cd8407d134e4350caaf1ea503a0887a01

Early in Sipity's development, I focused on speed of tests. I wanted a
quick feedback loop. At the time, using `sqlite3` provided the fastest
testing experience. In leveraging AREL and ActiveRecord, I could create
SQL commands that worked for `sqlite` and `mysql` and `postgres`.

As development moved to production, I adopted `mysql` as the database
for Sipity's production environment; We did not have a Postgresql
database option readily available at the time. To ensure that
production and development had similar configurations for UI-based
exploration, I adopted `mysql` for development.

This reality worked, and can continue to work. However, as Rails
continues to introduce more database-driver specific migration/schema
adjustments, I started to grow uncomfortable. This came to a head when,
after the Rails 5.2 upgrade, Shari reported a Sipity bug to me.

I did some trouble shooting, and the 5f6fc2fab4d26a5ad0a5adbdb5fae8b3ff48a36c
commit addresses what was necessary to fix; At least in the test suite.
With the test suite passing, I verified the behavior in the UI. And
there I encountered a series of migration issues.

A common method for working on Sipity is to blow up your database and
start over with your development environment. Doing that, Rails threw
some unexpected migration errors. And I took that time to fix those
issues, testing under SSL, updating specs/fixtures to remove hard-coded
ids (a terrible practice but one born out of urgency), and now ensuring
the test environment uses the same database driver as the production
and development ecosystem.

## Adding mysql as a service for Travis

c55fa7e1b4e5a4ee2c4fdba98e152743edb75ae0

Based on some GoogleFu, I'm going to try the following:

https://github.com/travis-ci/travis-ci/issues/6842#issuecomment-502259411

Also, in switching from `sqlite3` to `mysql` on Travis, I needed to
ensure that the database existed upstream.

## Fixing error on "required" field but no options

00e69344530a9fd20e5a754ca9b29f0bb54e5409

Due to a change in the underlying javascript, the jQuery functions that
handled toggling the HTML 5 "required" attribute no longer functioned.

This update corrects that behavior.
