### PR TITLE
Removing the "Read More" abstract link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,9 +119,6 @@ group :production, :pre_production, :staging do
   gem 'rack-cache', require: 'rack/cache'
   gem 'rb-readline'
 end
-source 'https://rails-assets.org' do
-  gem 'rails-assets-readmore'
-end
 
 # Removing until I have a non-pro license
 # group :production, :pre_production, :staging, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     actioncable (5.2.3)
       actionpack (= 5.2.3)
@@ -464,9 +463,6 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
-    rails-assets-jquery (3.4.1)
-    rails-assets-readmore (2.2.1)
-      rails-assets-jquery (>= 2.1.4)
     rails-controller-testing (1.0.4)
       actionpack (>= 5.0.1.x)
       actionview (>= 5.0.1.x)
@@ -746,7 +742,6 @@ DEPENDENCIES
   rack-cache
   railroady!
   rails (~> 5.2.0)
-  rails-assets-readmore!
   rails-controller-testing
   rails_layout
   rb-fchange

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require jquery_ujs
 //
 //= require bootstrap-sprockets
-//= require readmore
 //
 //= require vendor/jquery-ui-widget
 //= require vendor/redactor
@@ -59,13 +58,7 @@
     adjustRequiredAttachements();
 		disableSubmitOnClick();
     $('.help-icon').tooltip();
-		$('.abstract').readmore({
-			speed: 75,
-			collapsedHeight: 200,
-			lessLink: '<a href="#">Read less</a>'
-		});
   };
 
-  $(document).ready(ready);
   $(document).on('page:load', ready);
 }(jQuery));


### PR DESCRIPTION
Prior to this commit, and since the v2019.6 release, the "Read More"
link broke; The JS function rendered the "Read More" link however the
text which should have been hidden still displayed on the page,
overlaying the content below the abstract.

I did some debugging and was unable to find a reasonable solution. In
consultation with Shari, she agreed that we could remove the "Read More"
link and instead display the entire abstract.