### PR TITLE
Restoring "Add another Person" button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -60,5 +60,6 @@
     $('.help-icon').tooltip();
   };
 
+  $(document).ready(ready);
   $(document).on('page:load', ready);
 }(jQuery));

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,9 @@
 
 ActiveRecord::Schema.define(version: 2016_04_20_133504) do
 
+  create_table "schema_migrations", primary_key: "version", id: :string, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  end
+
   create_table "sipity_access_rights", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "entity_id", limit: 32, null: false
     t.string "entity_type", null: false


### PR DESCRIPTION
In my haste to push out a fix to the broken "Read More" / "Read Less"
behavior for abstracts, I removed code that fired the "Add another
Person" button.

This change fixes that.

In addition, in running the `rake bootstrap` command to have a fresh
environment, the `db/schema.rb` update came along. It is a rather
innocuous add.