### PR TITLE
Updating sassc to v2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -611,7 +611,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)


### PR DESCRIPTION
This addresses a problem we encountered in our deploy. This was fixed in
the PR for https://github.com/sass/sassc-ruby/pull/156