### PR TITLE
Adjusting requests outside pagination range

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -73,6 +73,10 @@ module Sipity
       end
     end
 
+    # A paginated request was outside of the pagination window
+    class RequestOutsidePaginationRange < RuntimeError
+    end
+
     # The object did not implement the expected interface.
     class InterfaceExpectationError < RuntimeError
       def initialize(object:, expectations:)

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -23,11 +23,23 @@ module Sipity
       end
 
       # @param criteria [Sipity::Parameters::SearchCriteriaForWorksParameter]
+      # @param repository [#scope_proxied_objects_for_the_user_and_proxy_for_type, #apply_work_area_filter_to], defaults to the current
+      #        repository object, likely a Sipity::Queries::QueryRepository object.
       #
       # @return [ActiveModel::Relation<Sipity::Models::Work>]
+      # @raise [ActiveRecord::RecordNotFound] when page requested is outside the total number of pages of pagination
       def find_works_via_search(criteria:, repository: self)
         scope = repository.scope_proxied_objects_for_the_user_and_proxy_for_type(criteria: criteria)
-        apply_work_area_filter_to(scope: scope, criteria: criteria)
+        scope = apply_work_area_filter_to(scope: scope, criteria: criteria)
+
+        # For an empty scope (e.g. no records), treat the first page as present.
+        return scope if criteria.page == 1
+
+        # For any other page request, verify that its within the total pages range
+        return scope if criteria.page > 0 && criteria.page <= scope.total_pages
+
+        # You have requested records outside of the paginator range
+        raise Exceptions::RequestOutsidePaginationRange
       end
 
       def apply_work_area_filter_to(scope:, criteria:)

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,6 @@ module Sipity
     # config.i18n.default_locale = :de
 
     config.action_dispatch.rescue_responses['Sipity::Exceptions::AuthorizationFailureError'] = :unauthorized
+    config.action_dispatch.rescue_responses['Sipity::Exceptions::RequestOutsidePaginationRange'] = :not_found
   end
 end


### PR DESCRIPTION
Prior to this commit, when requesting a paginated list of works, the
requester would always get a 200 HTTP response when the requested page
was within the total pages for the pagination OR when the requested
page was outside the pagination range. The response document would
have an empty array of works and pagination links (self, first, last,
prev, next) as per the JSON+API specification.

In the case of one API integration, the requester appeared to follow
the following logic:

```
let page = 1
request page
while response status is 200
  for each element in work array
    run some process
  end for
  increment page by 1
  request page
end while
```

The process did not appear to check that the response had any elements
in the array and stop once it encountered an empty array.

With this commit, the pagination logic has changed a bit:

* When you request page 1, you will get a 200 response.
* When you request a page within the pagination window (e.g. between 1
  and total number of pages) you will get a 200 response.
* When you request a page outside the pagination window, you will get
  a 404 response