### PR TITLE
Removing ETD_INTEGRATORS from ingested state

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -43,7 +43,7 @@
         "name": ["new", "grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
         "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing", "creating_user"]
       }, {
-        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
+        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting"],
         "roles": ["etd_third_party_integrating"]
       }, {
         "name": ["new", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review"],
@@ -499,7 +499,7 @@
         "name": ["new", "grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
         "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing", "creating_user"]
       }, {
-        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
+        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting"],
         "roles": ["etd_third_party_integrating"]
       }, {
         "name": ["new", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review"],

--- a/app/services/sipity/services/revoke_actions_for_given_role.rb
+++ b/app/services/sipity/services/revoke_actions_for_given_role.rb
@@ -1,0 +1,67 @@
+module Sipity
+  module Services
+    # Responsible for revoking action permission
+    class RevokeActionsForGivenRole
+      # @api public
+      #
+      # For the given role and strategy, revoke all of the given actions that exist in the given strategy states
+      #
+      # @param role [#to_role] (see Sipity::Conversions::ConvertToRole)
+      # @param strategy_id [#to_strategy_id] (see Sipity::Conversions::ConvertToProcessingStrategyId)
+      # @param action_names [Array<#convert_to_processing_action_name>, #convert_to_processing_action_name]
+      #                     (see Sipity::Conversions::ConvertToProcessingActionName)
+      # @param strategy_state_names [Array<String>, String] (see Sipity::Conversions::ConvertToProcessingActionName)
+      def self.call(role:, strategy_id:, action_names:, strategy_state_names:)
+        new(role: role, strategy_id: strategy_id, action_names: action_names, strategy_state_names: strategy_state_names).call
+      end
+
+      # @api private
+      def initialize(role:, strategy_id:, action_names:, strategy_state_names:)
+        self.role = role
+        self.strategy_id = strategy_id
+        self.action_names = action_names
+        self.strategy_state_names = strategy_state_names
+        initialize_strategy_roles!
+      end
+      attr_reader :role, :strategy_id, :action_names, :strategy_state_names, :strategy_roles
+
+      # @api private
+      def call
+        strategy_actions = Models::Processing::StrategyAction.where(strategy_id: strategy_id, name: action_names)
+        strategy_states = Models::Processing::StrategyState.where(strategy_id: strategy_id, name: strategy_state_names)
+        strategy_state_actions = Models::Processing::StrategyStateAction.where(
+          originating_strategy_state: strategy_states, strategy_action: strategy_actions
+        )
+        permitted_state_actions = Models::Processing::StrategyStateActionPermission.where(
+          strategy_state_action: strategy_state_actions, strategy_role: strategy_roles
+        )
+        permitted_state_actions.destroy_all
+      end
+
+      private
+
+      def initialize_strategy_roles!
+        @strategy_roles = Models::Processing::StrategyRole.where(strategy_id: strategy_id, role: role)
+      end
+
+      def strategy_state_names=(input)
+        @strategy_state_names = Array.wrap(input)
+      end
+
+      include Conversions::ConvertToProcessingActionName
+      def action_names=(input)
+        @action_names = Array.wrap(input).map { |element| convert_to_processing_action_name(element) }
+      end
+
+      include Conversions::ConvertToRole
+      def role=(object)
+        @role = convert_to_role(object)
+      end
+
+      include Conversions::ConvertToProcessingStrategyId
+      def strategy_id=(object)
+        @strategy_id = convert_to_processing_strategy_id(object)
+      end
+    end
+  end
+end

--- a/spec/services/sipity/services/revoke_actions_for_given_role_spec.rb
+++ b/spec/services/sipity/services/revoke_actions_for_given_role_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+require 'sipity/services/revoke_actions_for_given_role'
+
+module Sipity
+  module Services
+    # Responsible for revoking action permission
+    RSpec.describe RevokeActionsForGivenRole do
+      let(:strategy_id) { 2 }
+      let(:role) { Models::Role.new(id: 3) }
+      let(:other_role) { Models::Role.new(id: 4) }
+      let(:strategy_role) { Models::Processing::StrategyRole.new(strategy_id: strategy_id, role_id: role.id) }
+      let(:strategy_role_other) { Models::Processing::StrategyRole.new(strategy_id: strategy_id, role_id: other_role.id) }
+      let(:action_names) { ["action_one", "action_two"] }
+      let(:strategy_state_names) { double }
+      before do
+        strategy_role.save!
+        strategy_role_other.save!
+
+        action_one = Models::Processing::StrategyAction.create!(strategy_id: strategy_id, name: "action_one")
+        action_two = Models::Processing::StrategyAction.create!(strategy_id: strategy_id, name: "action_two")
+        action_three = Models::Processing::StrategyAction.create!(strategy_id: strategy_id, name: "action_three")
+
+        state_one = Models::Processing::StrategyState.create!(strategy_id: strategy_id, name: "state_one")
+        state_two = Models::Processing::StrategyState.create!(strategy_id: strategy_id, name: "state_two")
+        state_three = Models::Processing::StrategyState.create!(strategy_id: strategy_id, name: "state_three")
+
+        Models::Processing::StrategyStateAction.create!(originating_strategy_state: state_two, strategy_action: action_one).tap do |obj|
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role_other)
+        end
+        Models::Processing::StrategyStateAction.create!(originating_strategy_state: state_one, strategy_action: action_one).tap do |obj|
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role)
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role_other)
+        end
+        Models::Processing::StrategyStateAction.create!(originating_strategy_state: state_one, strategy_action: action_two) do |obj|
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role)
+        end
+        Models::Processing::StrategyStateAction.create!(originating_strategy_state: state_two, strategy_action: action_two).tap do |obj|
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role)
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role_other)
+        end
+        Models::Processing::StrategyStateAction.create!(originating_strategy_state: state_three, strategy_action: action_three) do |obj|
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role)
+        end
+        Models::Processing::StrategyStateAction.create!(originating_strategy_state: state_one, strategy_action: action_three) do |obj|
+          Models::Processing::StrategyStateActionPermission.create!(strategy_state_action: obj, strategy_role: strategy_role_other)
+        end
+      end
+      describe '.call' do
+        it 'will, within the context of the given strategy_id, revoke permission to the actions in the states for the given role' do
+          # Note: while I've given multiple action names and strategy_state_names only action_one & state_one are permitted for
+          # the given role
+          expect do
+            described_class.call(
+              role: role,
+              strategy_id: strategy_id,
+              action_names: ["action_one", "action_three"],
+              strategy_state_names: ["state_one", "state_two"]
+            )
+          end.to change { Models::Processing::StrategyStateActionPermission.count }.by(-1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, the OIT's integration would see ETD works in the
Ingesting and Ingested stated. This meant that all objects that had
been approved by the Grad School were processed each time. This
resulted in at least 170 pages of data to process, and was growing each
year.

Per Grad School instructions, I'm removing access to the
ETD_INTEGRATORS for ingesting and ingested state.

From Shari:

> I don't recall the specifics. I know that it's helpful for us to have
> updates pushed to OnBase if we correct the title or advisor on the
> Sipity record before we approve it (for example). If we could set
> OnBase to stop updating a given record once the Sipity State hits
> "ingesting" that would be the best of all worlds for us.

Upon further discussion, the OnBase process has detected things stuck
in the "ingesting" state. In conversation with Shari, we agreed that
we would preserve permission to OnBase for "ingesting."

In addition, adding service class to assist in revoking permissions for
a given role.

This relates and builds on https://github.com/ndlib/sipity/pull/1227
