### PR TITLE
Coercing page parameter to integer

### DIFF
--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -38,7 +38,11 @@ module Sipity
 
       private
 
-      attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per, :page
+      attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per
+
+      def page=(input)
+        @page = input.to_i
+      end
 
       def order=(input)
         @order = ORDER_BY_OPTIONS.include?(input) ? input : default_order

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -50,6 +50,14 @@ module Sipity
         end
       end
 
+      describe '#page' do
+        it 'coerces to an integer' do
+          subject = described_class.new(page: '1')
+          expect(subject.page?).to eq(true)
+          expect(subject.page).to eq(1)
+        end
+      end
+
       it 'will fallback on default order if an invalid order is given' do
         subject = described_class.new(order: 'chicken-sandwich')
         expect(subject.order).to eq(subject.send(:default_order))


### PR DESCRIPTION
Prior to this commit, it appears that we had a String for page. In the
comparison introduced in SHA 5ff5ca05fffb809b47ca3d12f5f88a528308dd7b,
we introduced the bug.

This commit ensures that we are working with integers