### PR TITLE
Restoring ETD_INTEGRATORS to ingested state

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -43,7 +43,7 @@
         "name": ["new", "grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
         "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing", "creating_user"]
       }, {
-        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting"],
+        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
         "roles": ["etd_third_party_integrating"]
       }, {
         "name": ["new", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review"],
@@ -499,7 +499,7 @@
         "name": ["new", "grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
         "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing", "creating_user"]
       }, {
-        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting"],
+        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging", "ready_for_ingest", "ingesting", "ingested"],
         "roles": ["etd_third_party_integrating"]
       }, {
         "name": ["new", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review"],


### PR DESCRIPTION
This undoes a portion of the "Removing ETD_INTEGRATORS from ingested
state" commit (see 3457f118ab2867c5a0ce25a35725cb3b4fc5bcef)

Based on conversations with OIT, their processes were dependent on a
full list of ETDs. With the prior change, they no longer had a full
list of ETDs, but instead had a list of ETDs that were still subject to
changes in Sipity.

This change is a temporary revert of the above commit. Based on
negotiated timelines, we have informed OIT that will remove
ETD_INTEGRATORS access to ingested state objects on March 4th 2020.