### PR TITLE
Encoding URI's written in WEBHOOKS

### DIFF
--- a/app/exporters/sipity/exporters/batch_ingest_exporter/webhook_writer.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter/webhook_writer.rb
@@ -20,9 +20,11 @@ module Sipity
         private_class_method :target_path
 
         def callback_url(work_id:, authorization_credentials: default_authorization_credentials)
-          File.join(
-            "#{Figaro.env.protocol!}://#{authorization_credentials}@#{Figaro.env.domain_name!}",
-            "/work_submissions/#{work_id}/callback/ingest_completed.json"
+          URI.encode(
+            File.join(
+              "#{Figaro.env.protocol!}://#{authorization_credentials}@#{Figaro.env.domain_name!}",
+              "/work_submissions/#{work_id}/callback/ingest_completed.json"
+            )
           )
         end
 

--- a/spec/exporters/sipity/exporters/batch_ingest_exporter/webhook_writer_spec.rb
+++ b/spec/exporters/sipity/exporters/batch_ingest_exporter/webhook_writer_spec.rb
@@ -5,7 +5,7 @@ module Sipity
   module Exporters
     class BatchIngestExporter
       RSpec.describe WebhookWriter do
-        let(:authorization_credentials) { 'group:password' }
+        let(:authorization_credentials) { 'group with space:password' }
         describe ':files' do
           let(:exporter) { double('BatchIngestExporter', work_id: 1661, ingest_method: :files, data_directory: '/tmp/sipity-1661') }
           before do
@@ -22,7 +22,9 @@ module Sipity
               expect(
                 described_class.callback_url(work_id: '1234', authorization_credentials: authorization_credentials)
               ).to(
-                eq("http://#{authorization_credentials}@localhost:3000/work_submissions/1234/callback/ingest_completed.json")
+                eq(
+                  URI.encode("http://#{authorization_credentials}@localhost:3000/work_submissions/1234/callback/ingest_completed.json")
+                )
               )
             end
           end
@@ -30,7 +32,9 @@ module Sipity
 
         describe ':api' do
           let(:path) { '/tmp/sipity-1661/files/WEBHOOK' }
-          let(:content) { "http://#{authorization_credentials}@localhost:3000/work_submissions/1661/callback/ingest_completed.json" }
+          let(:content) do
+            URI.encode("http://#{authorization_credentials}@localhost:3000/work_submissions/1661/callback/ingest_completed.json")
+          end
           let(:exporter) { double('BatchIngestExporter', work_id: 1661, ingest_method: :api, data_directory: '/tmp/sipity-1661/files') }
           before do
             allow(Models::Group).to receive(:basic_authorization_string_for!).and_return(authorization_credentials)


### PR DESCRIPTION
Alas, spaces in basic auth are not allowed. Curious how this is
showing up years later, but such is the way of technology
implementations slowly catching up with standards and their steady
drift.

This change is a stop gap. To complete the change we will need to:

1) Deploy the change
2) Update all existing published Webhooks to be URI encoded