### PR TITLE
Adding `/status/:work_id` end point

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,16 @@ The primary feature of Sipity is state-based permissions. It can be helpful to f
 
 Example: `Sipity::Services::Administrative::ForceIntoProcessingState.call(entity: Sipity::Models::Work.find(id), state: 'ready_for_ingest')`
 
+### Get the processing status of a Sipity::Models::Work
+
+`GET /status/:work_id`
+
+Response document:
+
+```json
+{ "id": <:work_id>, "status": <the_status> }
+```
+
 ### Batch Ingest Documentation
 
 #### Sipity Code-Path for Batch Ingest

--- a/app/controllers/sipity/controllers/visitors_controller.rb
+++ b/app/controllers/sipity/controllers/visitors_controller.rb
@@ -17,6 +17,13 @@ module Sipity
         )
       end
 
+      def status
+        headers['Content-Type'] = 'application/json'
+        work = Sipity::Models::Work.includes(:processing_entity).find(work_id)
+        json = { id: work.id, status: work.processing_state }
+        render json: json
+      end
+
       delegate(
         :prepend_processing_action_view_path_with,
         :run_and_respond_with_processing_action,
@@ -34,6 +41,10 @@ module Sipity
 
       def work_area_slug
         params.require(:work_area_slug)
+      end
+
+      def work_id
+        params.require(:work_id)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     get 'areas/:work_area_slug', to: 'sipity/controllers/visitors#work_area'
   end
 
+  get 'status/:work_id', to: 'sipity/controllers/visitors#status'
+
   ##############################################################################
   # Begin Account related things
   ##############################################################################

--- a/spec/controllers/sipity/controllers/visitors_controller_spec.rb
+++ b/spec/controllers/sipity/controllers/visitors_controller_spec.rb
@@ -24,6 +24,18 @@ module Sipity
           end.to raise_error(ActionController::UnknownFormat) # Because auto-rendering
         end
       end
+
+      context 'GET #status' do
+        let(:work) { double(Sipity::Models::Work, id: '1234', processing_state: "wonky") }
+        context 'without authentication' do
+          it "returns a basic JSON document" do
+            # Yes this is a violation of the Law of Demeter, but I opted to not
+            # write a database record and build the whole world.
+            expect(Sipity::Models::Work).to receive_message_chain(:includes, find: work.id).and_return(work)
+            get('status', params: { work_id: work.id }, format: :json)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This end-point enables a quick assessment of an object in Sipity. It
produces minimal information:

* id: the id of the object
* status: the name of the object's current processing state

As this is entirely non-identifying information, its not behind an API
end point.

Closes #1240