### PR TITLE
Enabling Grad School editing of submission date

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -153,6 +153,15 @@
         "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing"]
       }]
     }, {
+      "name": "submission_date",
+      "attributes": {
+        "presentation_sequence": 7
+      },
+      "from_states": [{
+        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging"],
+        "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing"]
+      }]
+    }, {
       "name": "search_terms",
       "attributes": {
         "presentation_sequence": 7
@@ -606,6 +615,15 @@
         "roles": ["creating_user"]
       }, {
         "name": ["new", "grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging"],
+        "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing"]
+      }]
+    }, {
+      "name": "submission_date",
+      "attributes": {
+        "presentation_sequence": 7
+      },
+      "from_states": [{
+        "name": ["grad_school_approved_but_waiting_for_routing", "under_advisor_review", "advisor_changes_requested", "under_grad_school_review", "grad_school_changes_requested", "ready_for_cataloging", "back_from_cataloging"],
         "roles": ["etd_reviewing", "etd_student_reviewing", "data_observing"]
       }]
     }, {

--- a/app/forms/sipity/forms/work_submissions/etd/submission_date_form.rb
+++ b/app/forms/sipity/forms/work_submissions/etd/submission_date_form.rb
@@ -1,0 +1,57 @@
+require 'sipity/forms/processing_form'
+require 'active_model/validations'
+
+module Sipity
+  module Forms
+    module WorkSubmissions
+      module Etd
+        # Exposes a means updating the submission date. The submission date is
+        # something assigned by the system, but is something that sometimes
+        # requires editing by the grad school
+        #
+        # @see Sipity::ProcessingHooks::Etd::Works::SubmitForReviewProcessingHook
+        class SubmissionDateForm
+          ProcessingForm.configure(
+            form_class: self, base_class: Models::Work, processing_subject_name: :work, attribute_names: [:submission_date]
+          )
+
+          include Conversions::ExtractInputDateFromInput
+          def initialize(work:, requested_by:, attributes: {}, **keywords)
+            self.work = work
+            self.requested_by = requested_by
+            self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
+            self.submission_date = extract_input_date_from_input(:submission_date, attributes) { submission_date_from_work }
+          end
+
+          include ActiveModel::Validations
+          validates :submission_date, presence: true
+
+          def submit
+            processing_action_form.submit do
+              repository.update_work_attribute_values!(
+                work: work,
+                key: Models::AdditionalAttribute::ETD_SUBMISSION_DATE,
+                values: submission_date
+              )
+            end
+          end
+
+          include Conversions::ConvertToDate
+          def submission_date=(value)
+            @submission_date = convert_to_date(value) { nil }
+          end
+
+          private
+
+          def submission_date_from_work
+            repository.work_attribute_values_for(
+              work: work,
+              key: Models::AdditionalAttribute::ETD_SUBMISSION_DATE,
+              cardinality: 1
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/sipity/controllers/work_submissions/etd/submission_date.html.erb
+++ b/app/views/sipity/controllers/work_submissions/etd/submission_date.html.erb
@@ -1,0 +1,28 @@
+<h1>Submission Date</h1>
+
+<%= simple_form_for(
+  model,
+  url: request.path,
+  method: :post,
+  as: :work,
+  html: { class: 'simple-form panel panel-primary with-footer' }
+) do |f| %>
+  <legend class="panel-heading">
+    <h3 class="panel-title">Update the <b>submission date</b> for this dissertation</h3>
+  </legend>
+
+  <fieldset class="panel-body">
+    <%= f.error_notification %>
+    <%= f.error :base, error_method: :to_sentence %>
+
+    <%= f.input :submission_date, as: :date, input_html: { class: 'form-control' }, wrapper_html: { class: 'form-inline' }, include_blank: true %>
+  </fieldset>
+
+  <div class="panel-footer action-pane">
+    <%= f.submit nil, name: "form/#{model.processing_action_name}/submit" %>
+  </div>
+<% end %>
+
+<div class="action-pane">
+  <%= link_to t("sipity/decorators/entitiy_enrichments.cancel"), work_path(model.work), class: 'btn btn-default' %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,6 +197,8 @@ en:
       label: 'Create a <b>citation</b>'
     defense_date:
       label: "Record the <b>defense date</b> for your %{work_type}"
+    submission_date:
+      label: "Edit the <b>submission date</b> for this %{work_type}"
     search_terms:
       label: "Add <b>search terms</b> for your %{work_type}"
     degree:

--- a/spec/forms/sipity/forms/work_submissions/etd/submission_date_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/etd/submission_date_form_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+require 'support/sipity/command_repository_interface'
+require 'sipity/forms/work_submissions/etd/submission_date_form'
+
+module Sipity
+  module Forms
+    module WorkSubmissions
+      module Etd
+        RSpec.describe SubmissionDateForm do
+          let(:work) { Models::Work.new(id: '1234') }
+          let(:submission_date) { Time.zone.today }
+          let(:repository) { CommandRepositoryInterface.new }
+          let(:attributes) { {} }
+          let(:user) { double }
+          let(:keywords) { { work: work, repository: repository, requested_by: user, attributes: attributes } }
+          subject { described_class.new(keywords) }
+
+          its(:processing_action_name) { is_expected.to eq('submission_date') }
+          its(:policy_enforcer) { is_expected.to eq Policies::WorkPolicy }
+
+          it { is_expected.to respond_to :work }
+          it { is_expected.to respond_to :submission_date }
+
+          include Shoulda::Matchers::ActiveModel
+          it { is_expected.to validate_presence_of(:submission_date) }
+
+          it 'will handle Rails submission_date that was input via Rails HTML multi-field date input' do
+            form = described_class.new(
+              keywords.merge(attributes: { 'submission_date(1i)' => "2014", 'submission_date(2i)' => "10", 'submission_date(3i)' => "1" })
+            )
+            expect(form.submission_date.month).to eq(10)
+          end
+
+          context '#submission_date' do
+            context 'with data from the database' do
+              subject { described_class.new(keywords) }
+              it 'will return the submission_date of the work' do
+                expect(repository).to receive(:work_attribute_values_for).
+                  with(work: work, key: Models::AdditionalAttribute::ETD_SUBMISSION_DATE, cardinality: 1).and_return(submission_date)
+                expect(subject.submission_date).to eq submission_date
+              end
+            end
+            context 'when initial date is given is bogus' do
+              subject { described_class.new(keywords.merge(attributes: { submission_date: '2014-02-31' })) }
+              its(:submission_date) { is_expected.not_to be_present }
+            end
+          end
+
+          context '#submit' do
+            let(:user) { double('User') }
+            context 'with invalid data' do
+              before do
+                expect(subject).to receive(:valid?).and_return(false)
+              end
+              it 'will return false if not valid' do
+                expect(subject.submit)
+              end
+            end
+
+            context 'with valid data' do
+              subject { described_class.new(keywords.merge(attributes: { submission_date: '2014-10-02' })) }
+              before do
+                allow(subject).to receive(:valid?).and_return(true)
+                allow(subject.send(:processing_action_form)).to receive(:submit).and_yield
+              end
+
+              it 'will add additional attributes entries' do
+                expect(repository).to receive(:update_work_attribute_values!).and_call_original
+                subject.submit
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, Sipity stamped the etd_submission_date at the
point when the student submitted their work. Sipity did not then
provide a means of updating etd_submission_date (aside from using
SQL or the Rails console).

With this commit, I added a form in which the grad school can edit the
etd_submission_date.

This feature was prompted in an email thread with Shari.