### PR TITLE
Adding full NOIDs integration

### DIFF
--- a/app/services/sipity/services/noid_minter.rb
+++ b/app/services/sipity/services/noid_minter.rb
@@ -1,19 +1,55 @@
 module Sipity
   module Services
-    # This module uses noid client to mint a pid
-    module NoidMinter
-      module_function
-
-      def call
-        connection.mint.first
+    # Responsible for minting a single noid
+    #
+    # @see https://githbub.com/ndlib/noids
+    class NoidMinter
+      # While you can pass the configuration, the first time is what matters, as
+      # it sets the minter and caches the minter.
+      #
+      # @note There is a critical assumption in this implimentation that the
+      #       named pool already exists in the noid server. This is because we
+      #       use the same pool for CurateND, CurateND's batch system, and
+      #       Sipity.
+      #
+      # @return [String] a unique noid (from the configured pool)
+      # @see #initialize for parameteres
+      def self.call(**kwargs)
+        @minter ||= new(**kwargs)
+        @minter.call
       end
 
-      def connection(env: Figaro.env)
-        return @connection if @connection.present?
-        server = env.noid_server!
-        port = env.noid_port!.to_i
-        pool = env.noid_pool!
-        @connection = ::NoidsClient::Connection.new("#{server}:#{port}").get_pool(pool)
+      # @param kwargs [Hash] a hash or list of keyword args
+      # @option kwargs [String] :server - the named server (http://localhost)
+      #            that host the noid
+      # @option kwargs [#to_i] :port - the port to connect for the named server
+      # @option kwargs [String] :pool_name - the name of the pool from which to
+      #            mint a pid
+      # @option kwargs [NoidsClient::Connection] :connection_class - added for
+      #            dependency injection to ease testing.
+      def initialize(**kwargs)
+        @server = kwargs.fetch(:server, Figaro.env.noid_server!)
+        @port = kwargs.fetch(:port, Figaro.env.noid_port!)
+        @pool_name = kwargs.fetch(:pool_name, Figaro.env.noid_pool!)
+        @connection_class = kwargs.fetch(:connection_class) { default_connection_class }
+        establish_connection!
+      end
+      attr_reader :server, :port, :pool_name, :pool, :connection, :connection_class
+
+      def call
+        @pool ||= connection.get_pool(pool_name)
+        @pool.mint.first
+      end
+
+      private
+
+      def default_connection_class
+        require 'noids_client'
+        ::NoidsClient::Connection
+      end
+
+      def establish_connection!
+        @connection = connection_class.new("#{server}:#{port}")
       end
     end
   end

--- a/spec/services/sipity/services/noid_minter_spec.rb
+++ b/spec/services/sipity/services/noid_minter_spec.rb
@@ -1,28 +1,47 @@
 require 'rails_helper'
 require 'sipity/services/noid_minter'
+require 'noids_client/integration_test' if ENV["WITH_NOIDS_SERVER"]
+
 module Sipity
   module Services
     describe NoidMinter do
-      include ::Sipity::Services::NoidMinter
       let(:pid) { "pid" }
-      let(:connection) { double(mint: [pid]) }
-
-      context '#call' do
+      let(:pool) { double("Minter", mint: [pid]) }
+      let(:connection) { double("Connection", get_pool: pool) }
+      context '.call' do
         it 'will mint a pid' do
-          expect(described_class).to receive(:connection).
-            and_return(connection)
+          expect(NoidsClient::Connection).to(
+            receive(:new).with("#{Figaro.env.noid_server}:#{Figaro.env.noid_port}").and_return(connection)
+          )
+          expect(connection).to(
+            receive(:get_pool).with(Figaro.env.noid_pool).and_return(pool)
+          )
           expect(described_class.call).to eq(pid)
         end
       end
 
-      context '#connections' do
-        let(:first_connection) { described_class.connection }
-        it 'verify connections are cached' do
-          expect(::NoidsClient::Connection).to receive_message_chain(:new, :get_pool).
-            and_return(connection)
-          next_connection = described_class.connection
-          expect(first_connection.object_id).to eq(next_connection.object_id)
+      if ENV["WITH_NOIDS_SERVER"]
+        context 'with "live" NOIDs server' do
+          # A bit of hard-coded magic. These are the default hosts and ports
+          let(:noid_server) { "http://localhost" }
+          let(:noid_port) { "13001" }
+          let(:noid_pool_name) { "test" }
+          it 'will mint a pid' do
+            ::NoidsClient::IntegrationTest::NoidServerRunner.new.run do
+              # Sipity assumes that the noid_pool already exists. It is the one
+              # CurateND has been using.
+              noid_minter = described_class.new(server: noid_server, port: noid_port, pool_name: noid_pool_name)
+              noid_minter.connection.new_pool("test", ".sddd")
+              expect(noid_minter.call).to eq("000")
+              expect(noid_minter.call).to eq("001")
+            end
+          end
         end
+      else
+        $stdout.puts %(\n\n\n)
+        $stdout.puts %(Skipping "live" test of noids minter.)
+        $stdout.puts %(To run with a live menter, run the test suite with ENV["WITH_NOIDS_SERVER"] of true)
+        $stdout.puts %(\n\n\n)
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, Sipity did not have a means of testing against a
running [our NOIDs server](https://github.com/ndlib/noids). This
commit refactors the specs and minter implementation to make it
possible to run an integration test against a "live" NOIDs server.

The refactor preserves the lambda method signature in the [application
config][1] for the configured default_pid_minter.

Dependent on ndlib/noids_client#5

[1]:./config/application.rb