### PR TITLE
Addressing ssl issues

### DIFF
--- a/app/services/sipity/services/netid_query_service.rb
+++ b/app/services/sipity/services/netid_query_service.rb
@@ -24,7 +24,7 @@ module Sipity
         new(netid).valid_netid?
       end
 
-      def initialize(netid, url_reader: self.class.method(:read))
+      def initialize(netid, url_reader: self.class.method(:read_without_ssl_verification))
         self.netid = netid
         self.url_reader = url_reader
       end

--- a/spec/services/sipity/services/netid_query_service_spec.rb
+++ b/spec/services/sipity/services/netid_query_service_spec.rb
@@ -37,8 +37,8 @@ module Sipity
       end
 
       context 'default reader' do
-        it 'reads via OpenSSL' do
-          expect(described_class.new(netid).url_reader).to eq(described_class.method(:read))
+        it 'reads via OpenSSL but does not verify ssl' do
+          expect(described_class.new(netid).url_reader).to eq(described_class.method(:read_without_ssl_verification))
         end
         it 'has the same method signature as the injected url_reader' do
           expect(described_class.new(netid).url_reader.parameters).to eq(url_reader.parameters)

--- a/spec/services/sipity/services/netid_query_service_spec.rb
+++ b/spec/services/sipity/services/netid_query_service_spec.rb
@@ -4,11 +4,48 @@ require 'sipity/services/netid_query_service'
 module Sipity
   module Services
     RSpec.describe NetidQueryService do
+      # Rubocop doesn't like this, but I want the injected URL reader
+      # to have the same method signature
+
+      # rubocop:disable Lint/UnusedBlockArgument
+      let(:url_reader) { ->(url:) { response } }
+      # rubocop:enable Lint/UnusedBlockArgument
+      let(:response) { nil }
       let(:netid) { 'somenetid' }
       let(:full_name) { 'Full Name' }
-      subject { described_class.new(netid) }
+      let(:url) { double }
 
-      context 'self.preferred_name' do
+      let(:service) { described_class.new(netid, url_reader: url_reader) }
+
+      context '.read' do
+        let(:url) { double }
+        let(:response) { StringIO.new(body) }
+        let(:body) { 'hello' }
+        it 'opens the URL and reads the content' do
+          expect(described_class).to receive(:open).with(url).and_return(response)
+          expect(described_class.read(url: url)).to eq(body)
+        end
+      end
+      context '.read_without_ssl_verification' do
+        let(:url) { double }
+        let(:response) { StringIO.new(body) }
+        let(:body) { 'hello' }
+        it 'opens the URL and reads the content' do
+          expect(described_class).to receive(:open).with(url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE).and_return(response)
+          expect(described_class.read_without_ssl_verification(url: url)).to eq(body)
+        end
+      end
+
+      context 'default reader' do
+        it 'reads via OpenSSL' do
+          expect(described_class.new(netid).url_reader).to eq(described_class.method(:read))
+        end
+        it 'has the same method signature as the injected url_reader' do
+          expect(described_class.new(netid).url_reader.parameters).to eq(url_reader.parameters)
+        end
+      end
+
+      context '.preferred_name' do
         it 'will get preferred_name for the given netid' do
           expect(described_class).to receive_message_chain(:new, :preferred_name).
             and_return(full_name)
@@ -16,64 +53,84 @@ module Sipity
         end
       end
 
-      context 'self.valid_netid?' do
-        it 'will validate netif for the given netid' do
-          expect(described_class).to receive_message_chain(:new, :valid_netid?).
-            and_return(netid)
-          expect(described_class.valid_netid?(netid)).to eq(netid)
+      context '.valid_netid?' do
+        context 'with valid netid' do
+          subject { described_class.valid_netid?(netid) }
+          before { expect(described_class).to receive_message_chain(:new, :valid_netid?).and_return(true) }
+          it { is_expected.to be_truthy }
         end
       end
 
-      it 'will assume an empty netid is invalid and not call the remote service' do
-        subject = described_class.new(" ")
-        expect(subject).to_not receive(:open)
-        expect(subject.valid_netid?).to eq(false)
-      end
-
-      it 'gracefully handles a netid with a space in it' do
-        # https://errbit.library.nd.edu/apps/55280e706a6f68a6d2090000/problems/5571ba3b6a6f685aa1141200
-        subject = described_class.new(" #{netid}")
-        expect(subject).to receive(:open).and_return(StringIO.new(valid_response_with_netid))
-        expect(subject.valid_netid?).to eq('a_netid')
-      end
-
-      context 'preferred_name' do
-        it 'will return false when the request returns a 404 status' do
-          expect(subject).to receive(:open).and_raise(OpenURI::HTTPError.new('', ''))
-          expect(subject.preferred_name).to eq(netid)
-        end
-
-        it 'will return false when the requested NetID is not found for a person' do
-          expect(subject).to receive(:open).and_return(StringIO.new(valid_response_but_not_for_a_user))
-          expect(subject.preferred_name).to eq(netid)
-        end
-        it 'will return the NetID when the document contains the NetID' do
-          expect(subject).to receive(:open).and_return(StringIO.new(valid_response_with_netid))
-          expect(subject.preferred_name).to eq('Bob the Builder')
-        end
-        it 'will raise an exception if the returned document is malformed' do
-          expect(subject).to receive(:open).and_return(StringIO.new(invalid_document))
-          expect { subject.preferred_name }.to raise_error(NoMethodError)
+      context 'with an empty netid' do
+        let(:netid) { " " }
+        it 'will assume that is invalid and not call the remote service' do
+          expect(url_reader).to_not receive(:call)
+          expect(service.valid_netid?).to eq(false)
         end
       end
 
-      context 'valid_netid?' do
-        it 'will return false when the request returns a 404 status' do
-          expect(subject).to receive(:open).and_raise(OpenURI::HTTPError.new('', ''))
-          expect(subject.valid_netid?).to eq(false)
+      context 'with netid that has a space' do
+        let(:response) { valid_response_with_netid }
+        let(:netid) { " somenetid" }
+        it 'gracefully handles a netid with a space in it' do
+          # https://errbit.library.nd.edu/apps/55280e706a6f68a6d2090000/problems/5571ba3b6a6f685aa1141200
+          expect(service.valid_netid?).to eq('a_netid')
+        end
+      end
+
+      context '#preferred_name' do
+        subject { service.preferred_name }
+        context 'when the url_reader raises an HTTPError' do
+          it 'will use the netid for the preferred name' do
+            expect(url_reader).to receive(:call).and_raise(OpenURI::HTTPError.new('', ''))
+            expect(subject).to eq(netid)
+          end
         end
 
-        it 'will return false when the requested NetID is not found for a person' do
-          expect(subject).to receive(:open).and_return(StringIO.new(valid_response_but_not_for_a_user))
-          expect(subject.valid_netid?).to eq(false)
+        context 'when the requested NetID is not found for a person' do
+          let(:response) { valid_response_but_not_for_a_user }
+          it 'will use the netid for the preferred name' do
+            expect(subject).to eq(netid)
+          end
         end
-        it 'will return the NetID when the document contains the NetID' do
-          expect(subject).to receive(:open).and_return(StringIO.new(valid_response_with_netid))
-          expect(subject.valid_netid?).to eq('a_netid')
+
+        context 'when the NetID is found in the remote service' do
+          let(:response) { valid_response_with_netid }
+          it 'will use the preferred name' do
+            expect(subject).to eq('Bob the Builder')
+          end
         end
-        it 'will raise an exception if the returned document is malformed' do
-          expect(subject).to receive(:open).and_return(StringIO.new(invalid_document))
-          expect { subject.valid_netid? }.to raise_error(NoMethodError)
+
+        context 'when the document is malformed' do
+          let(:response) { invalid_document }
+          it 'will raise an exception if the returned document is malformed' do
+            expect { subject }.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      context '#valid_netid?' do
+        subject { service.valid_netid? }
+        context 'when the url_reader raises an HTTPError' do
+          before { expect(url_reader).to receive(:call).and_raise(OpenURI::HTTPError.new('', '')) }
+          it { is_expected.to be_falsey }
+        end
+
+        context 'when the requested NetID is not found for a person' do
+          let(:response) { valid_response_but_not_for_a_user }
+          it { is_expected.to be_falsey }
+        end
+
+        context 'when the NetID is found in the remote service' do
+          let(:response) { valid_response_with_netid }
+          it { is_expected.to be_truthy }
+        end
+
+        context 'when the document is malformed' do
+          let(:response) { invalid_document }
+          it 'will raise an exception if the returned document is malformed' do
+            expect { subject.valid_netid? }.to raise_error(NoMethodError)
+          end
         end
       end
 


### PR DESCRIPTION
## Adding ability to swap method used for NetID read

83d6b359abc756ae72b8c610994c3d74e5244651

We encountered the following error:

```shell
OpenSSL::SSL::SSLError
SSL_connect returned=1 errno=0 state=error: certificate verify failed
```

Triaging the problem, we discovered an intermittent issue that we are
working to resolve. In the mean time, I worked through this commit.

First, I adjusted the system to provide two different reader methods. I
did not want to lose sight of the "when things are working" state. I
also wanted to draw attention to the "when things aren't working" state
and how we solved that.

This commit makes the upcoming change easier. By design, I'm exposing
the workaround as an option, but with this commit continuing to use the
desired method.

## HACK - Switch NetID reader to not verify SSL

e3b76c568fa82220c6d97c6d6eecb918ce2c7499

Yes, this is not ideal. However, we have a production outage regarding
the certificate. So this change circumvents the problem.

Once the production change has been remediated, we can revert this
commit.
