### PR TITLE
Revert "HACK - Switch NetID reader to not verify SSL"

### DIFF
--- a/app/services/sipity/services/netid_query_service.rb
+++ b/app/services/sipity/services/netid_query_service.rb
@@ -24,7 +24,7 @@ module Sipity
         new(netid).valid_netid?
       end
 
-      def initialize(netid, url_reader: self.class.method(:read_without_ssl_verification))
+      def initialize(netid, url_reader: self.class.method(:read))
         self.netid = netid
         self.url_reader = url_reader
       end

--- a/spec/services/sipity/services/netid_query_service_spec.rb
+++ b/spec/services/sipity/services/netid_query_service_spec.rb
@@ -37,8 +37,8 @@ module Sipity
       end
 
       context 'default reader' do
-        it 'reads via OpenSSL but does not verify ssl' do
-          expect(described_class.new(netid).url_reader).to eq(described_class.method(:read_without_ssl_verification))
+        it 'reads via OpenSSL' do
+          expect(described_class.new(netid).url_reader).to eq(described_class.method(:read))
         end
         it 'has the same method signature as the injected url_reader' do
           expect(described_class.new(netid).url_reader.parameters).to eq(url_reader.parameters)


### PR DESCRIPTION
This reverts commit e3b76c568fa82220c6d97c6d6eecb918ce2c7499.

On Sipity PREP I have tested and verified the commit just prior to the
the e3b76c5 commit (e.g. what this commit reverts).

Once merged and deployed, Sipity will again verify SSL connections.

In using the revert, I'm hoping to keep this information around as a
reference point.