### PR TITLE
Accept webhooks with an 'error' status

### DIFF
--- a/app/forms/sipity/forms/work_submissions/core/ingest_completed_form.rb
+++ b/app/forms/sipity/forms/work_submissions/core/ingest_completed_form.rb
@@ -24,11 +24,14 @@ module Sipity
           end
 
           include ActiveModel::Validations
-          validates :job_state, inclusion: { in: [JOB_STATE_SUCCESS] }
 
           def submit
+            if job_state == JOB_STATE_SUCCESS
+              processing_action_form.submit { create_a_redirect }
+              return true
+            end
             register_error if job_state == JOB_STATE_ERROR
-            processing_action_form.submit { create_a_redirect }
+            false
           end
 
           private

--- a/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
@@ -22,27 +22,20 @@ module Sipity
           it { is_expected.to respond_to :work }
           it { is_expected.to delegate_method(:submit).to(:processing_action_form) }
 
-          include Shoulda::Matchers::ActiveModel
-          it { is_expected.to validate_inclusion_of(:job_state).in_array([described_class::JOB_STATE_SUCCESS]) }
-
           context 'with "error" for job_state' do
             let(:attributes) { { job_state: described_class::JOB_STATE_ERROR } }
-            before do
-              allow(subject).to receive(:valid?).and_return(false)
-            end
             it 'will notify Sentry' do
-              expect(subject).to_not receive(:create_a_redirect)
+              expect(Raven).to receive(:capture_exception).and_call_original
               subject.submit
             end
             it 'will not submit' do
-              expect(Raven).to receive(:capture_exception).and_call_original
+              expect(subject).to_not receive(:create_a_redirect)
               subject.submit
             end
             its(:submit) { is_expected.to eq(false) }
           end
 
           context 'with invalid data' do
-            before { expect(subject).to receive(:valid?).and_return(false) }
             its(:submit) { is_expected.to eq(false) }
           end
 


### PR DESCRIPTION
The webhook endpoint had a validation rejected every webhook except
"success" ones. Thus webhooks for errors in a batch job were being
rejected (with a 422 error), and the code to send a message to Sentry
was never executed. This commit removes the validation.