### PR TITLE
Adjusting spec method to body match descriptor

### DIFF
--- a/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
@@ -31,11 +31,11 @@ module Sipity
               allow(subject).to receive(:valid?).and_return(false)
             end
             it 'will notify Sentry' do
-              expect(subject).to_not receive(:create_a_redirect)
+              expect(Raven).to receive(:capture_exception).and_call_original
               subject.submit
             end
             it 'will not submit' do
-              expect(Raven).to receive(:capture_exception).and_call_original
+              expect(subject).to_not receive(:create_a_redirect)
               subject.submit
             end
             its(:submit) { is_expected.to eq(false) }


### PR DESCRIPTION
Prior to this commit, the associated descriptors were incorrectly
paired with the executed body of the message.