### PR TITLE
Reworking IngestCompleted to handle error state

### DIFF
--- a/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
@@ -28,17 +28,41 @@ module Sipity
           context 'with "error" for job_state' do
             let(:attributes) { { job_state: described_class::JOB_STATE_ERROR } }
             before do
-              allow(subject).to receive(:valid?).and_return(false)
+              allow(subject).to receive(:valid?).and_return(true)
             end
             it 'will notify Sentry' do
               expect(Raven).to receive(:capture_exception).and_call_original
               subject.submit
             end
-            it 'will not submit' do
+            it 'will not create a redirect' do
               expect(subject).to_not receive(:create_a_redirect)
               subject.submit
             end
-            its(:submit) { is_expected.to eq(false) }
+            it 'will not submit the underlying processing form' do
+              expect(subject.send(:processing_action_form)).to_not receive(:submit)
+              subject.submit
+            end
+            its(:submit) { is_expected.to eq(true) }
+          end
+
+          context 'with "processing" for job_state' do
+            let(:attributes) { { job_state: described_class::JOB_STATE_PROCESSING } }
+            before do
+              allow(subject).to receive(:valid?).and_return(true)
+            end
+            it 'will NOT notify Sentry' do
+              expect(Raven).not_to receive(:capture_exception)
+              subject.submit
+            end
+            it 'will not create a redirect' do
+              expect(subject).to_not receive(:create_a_redirect)
+              subject.submit
+            end
+            it 'will not submit the underlying processing form' do
+              expect(subject.send(:processing_action_form)).to_not receive(:submit)
+              subject.submit
+            end
+            its(:submit) { is_expected.to eq(true) }
           end
 
           context 'with invalid data' do


### PR DESCRIPTION
Prior to this commit, there was an assumption that the IngestCompleted
form was only used to advance the state.  However, in discussion with
Don, the purpose of the WEBHOOK for the batch ingester was meant to be a
communication tool (e.g., post status to WEBHOOK when we start
processing, when there's an error, and when there's success).

Under the above batch ingester assumption, the client should not send a
422 because ERROR was invalid.  Instead, it should send a 200
status (e.g. yup, I got your message).

Future work might include reworking the form to handle routing to
different states based on the status of the WEBHOOK.  For now, this gets
things unstuck.