### PR TITLE
Improving returned value for force state change

### DIFF
--- a/app/services/sipity/services/administrative/force_into_processing_state.rb
+++ b/app/services/sipity/services/administrative/force_into_processing_state.rb
@@ -30,6 +30,7 @@ module Sipity
         def call
           entity.update_columns(strategy_state_id: state.id)
           repository.destroy_existing_registered_state_changing_actions_for(entity: entity, strategy_state: state) if clear_actions?
+          return true
         end
 
         private


### PR DESCRIPTION
Prior to this commit, the returned value was an empty array (e.g.,
`[]`).  That return value might lead one to think that no objects were
processed.

In returning `true`, I hope to have a more friendly (less head-scratchy)
returned value.