### PR TITLE
Adding NightlyJob exception handling

### DIFF
--- a/app/exceptions/sipity/exceptions.rb
+++ b/app/exceptions/sipity/exceptions.rb
@@ -17,6 +17,22 @@ module Sipity
     class IngestUnableToCompleteError < RuntimeError
     end
 
+    class ScheduledJobError < RuntimeError
+      def initialize(works:)
+        @works = works
+        message = "The following Work IDs had failures in the batch ingest:\n"
+        @works.each do |work|
+          message += "\n\t* #{work.id} (Current Status: #{work.processing_status})"
+        end
+        message += "\n\nThis could mean that the Batch Ingester received the request but in"
+        message += "\nthe response something got mangled (e.g., a broken pipe error). You"
+        message += "\nshould look at other exceptions for these works to see what"
+        message += "\nspecifically happened."
+
+        super(message)
+      end
+    end
+
     # When you can't instantiate a specific work converter, raise this exception.
     class FailedToInitializeWorkConverterError < RuntimeError
       attr_reader :work

--- a/spec/exceptions/sipity/exceptions_spec.rb
+++ b/spec/exceptions/sipity/exceptions_spec.rb
@@ -14,6 +14,12 @@ module Sipity
       its(:message) { is_expected.to be_a(String) }
     end
 
+    RSpec.describe ScheduledJobError do
+      let(:work) { double(id: '123', processing_status: "Broken") }
+      subject { described_class.new(works: [work]) }
+      its(:message) { is_expected.to be_a(String) }
+    end
+
     RSpec.describe EmailAsOptionInvalidError do
       subject { described_class.new(as: :chicken, valid_list: [:hello]) }
       its(:message) { is_expected.to be_a(String) }


### PR DESCRIPTION
Sipity is already raising an individiual exception when it fails to
"ingest" a single work.  What is missing, however, is a greater
context (and sharing of what might be happening).

In adding this new bit of logic, my hope is to include a more verbose
exception that explains: "Yup, there's an error in the bulk job, and as
a result the work's status likely didn't change.  So go look at the
details of that exception."

In other words, the presence of this newly added error says: "Hey, Batch
Ingest had a problem."