### PR TITLE
Adding "hurray" email to Doctoral Dissertation

### DIFF
--- a/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
+++ b/app/data_generators/sipity/data_generators/work_types/etd_work_types.config.json
@@ -893,6 +893,10 @@
       "from_states": [{
         "name": ["ingesting"],
         "roles": ["batch_ingesting"]
+      }],
+      "emails": [{
+        "name": "hurray_your_work_is_in_curatend",
+        "to": ["creating_user"]
       }]
     }, {
       "name": "submit_for_ingest",


### PR DESCRIPTION
Prior to this commit, the Master's Thesis had the "hurray your work"
email, but not the doctoral dissertation.

That is an oversight and this change adds that feature.