### PR TITLE
Reducing number of hack `'` characters for crontab

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,10 +19,10 @@ if @environment == 'production' || @environment == 'prep'
   # "I am the cicada, coo coo ca choo"
 
   every 1.day, at: '3:17 am', roles: [:app] do
-    runner "Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: 'etd', initial_processing_state_name: 'ready_for_ingest', processing_action_name: 'submit_for_ingest')"
+    runner %(Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: "etd", initial_processing_state_name: "ready_for_ingest", processing_action_name: "submit_for_ingest"))
   end
 
   every 1.day, at: '1:11 am', roles: [:app] do
-    runner "Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: 'etd', initial_processing_state_name: 'ready_for_doi_minting', processing_action_name: 'submit_for_doi_minting')"
+    runner %(Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: "etd", initial_processing_state_name: "ready_for_doi_minting", processing_action_name: "submit_for_doi_minting"))
   end
 end


### PR DESCRIPTION
To make it a bit less messy, I went with another string method for
clarification.

The prior implementation:

```
runner "Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: 'etd',
initial_processing_state_name: 'ready_for_doi_minting',
processing_action_name: 'submit_for_doi_minting')"
```

is functionally equivalent to the new implementation:

```
runner %(Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: "etd",
initial_processing_state_name: "ready_for_doi_minting",
processing_action_name: "submit_for_doi_minting"))
```

The resulting crontab for the prior implemntation is:

```
11 1 * * * /bin/bash -l -c 'cd ~/git/ndlib/sipity &&
/usr/local/bin/bundle exec bin/rails runner -e production
'\''Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug:
'\''\'\'''\''etd'\''\'\'''\'', initial_processing_state_name:
'\''\'\'''\''ready_for_doi_minting'\''\'\'''\'', processing_action_name:
'\''\'\'''\''submit_for_doi_minting'\''\'\'''\'')'\'' >>
/home/app/sipity/shared/log/cron_log.log 2>&1'
```

The resulting crontab for the new implementation is:

```
11 1 * * * /bin/bash -l -c 'cd ~/git/ndlib/sipity &&
/usr/local/bin/bundle exec bin/rails runner -e production
'\''Sipity::Jobs::Core::BulkIngestJob.call(work_area_slug: "etd",
initial_processing_state_name: "ready_for_doi_minting",
processing_action_name: "submit_for_doi_minting")'\'' >>
/home/app/sipity/shared/log/cron_log.log 2>&1'
```

This is a significant reduction in the number of escaped hack (`'`)
characters.  Alas, it does not solve the [error from Sentry][1], but it
does make it easier to visually parse the resulting crontab.

The reported sentry error is evident new implementation's resolved
crontab:

Note the opening `'` at `-c 'cd`.  There’s an incorrect closing `'` at
`-e production '\''` (the first `'` closes the quote then we escape and
re-open).

[1]:https://sentry.io/organizations/university-of-notre-dame-ts/issues/2441963274/?project=1324638