### PR TITLE
UI Improvements

### DIFF
--- a/app/presenters/sipity/controllers/visitors/etd/work_area_presenter.rb
+++ b/app/presenters/sipity/controllers/visitors/etd/work_area_presenter.rb
@@ -9,6 +9,10 @@ module Sipity
           def view_submitted_etds_url
             Figaro.env.curate_nd_url_for_etds!
           end
+
+          def login_path
+            new_user_session_path(previous_url: request.path)
+          end
         end
       end
     end

--- a/app/presenters/sipity/controllers/work_areas/etd/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/etd/show_presenter.rb
@@ -7,6 +7,10 @@ module Sipity
           def view_submitted_etds_url
             Figaro.env.curate_nd_url_for_etds!
           end
+
+          def reset_path
+            '/areas/etd'
+          end
         end
       end
     end

--- a/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
@@ -13,7 +13,7 @@ module Sipity
             work_area.input_name_for_select_processing_state,
             options_from_collection_for_select(
               work_area.processing_states_for_select, :to_s, :humanize, work_area.processing_state
-            ), include_blank: true, class: 'form-control'
+            ), prompt: 'All states', class: 'form-control'
           ).html_safe
         end
 
@@ -31,17 +31,19 @@ module Sipity
             work_area.input_name_for_select_sort_order,
             options_from_collection_for_select(
               work_area.order_options_for_select, :to_s, :humanize, work_area.order
-            ), include_blank: true, class: 'form-control'
+            ), class: 'form-control'
           ).html_safe
         end
 
         def q_tag
           text_field_tag(
-            work_area.input_name_for_q, work_area.q, placeholder: 'Search for…'
+            work_area.input_name_for_q,
+            work_area.q,
+            placeholder: 'Search for…', class: 'form-control'
           )
         end
 
-        def submit_button(dom_class: 'btn btn-default', name: 'Go')
+        def submit_button(dom_class: 'btn btn-primary', name: 'Go')
           submit_tag(name, class: dom_class)
         end
 

--- a/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
@@ -41,7 +41,7 @@ module Sipity
           )
         end
 
-        def submit_button(dom_class: 'btn btn-default', name: 'Filter')
+        def submit_button(dom_class: 'btn btn-default', name: 'Go')
           submit_tag(name, class: dom_class)
         end
 

--- a/app/views/sipity/controllers/visitors/etd/work_area.html.curly
+++ b/app/views/sipity/controllers/visitors/etd/work_area.html.curly
@@ -11,6 +11,7 @@
     <div class="col-xs-12">
       <a href="{{ start_a_submission_path }}" class="btn btn-primary">{{ translate.start_a_submission }}</a>
       <a href="{{ view_submitted_etds_url }}" class="btn btn-primary">{{ translate.view_submitted_etds }}</a>
+      <a href="{{ login_path }}" class="btn btn-primary">{{ translate.login }}</a>
     </div>
   </div>
 </section>

--- a/app/views/sipity/controllers/work_areas/etd/show.html.curly
+++ b/app/views/sipity/controllers/work_areas/etd/show.html.curly
@@ -16,13 +16,28 @@
   </div>
   <div class="row dashboard-actions">
     <div class="col-xs-12">
-      {{@filter_form}}
-        <fieldset class="form-group">
-          {{select_tag_for_processing_state}}
-          {{select_tag_for_sort_order}}
-        </fieldset>
-        {{submit_button}}
-      {{/filter_form}}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Search Title, Creator, or Program</th>
+            <th>Select Processing State</th>
+            <th>Sort By</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            {{@filter_form}}
+              <fieldset class="form-group">
+                <td>{{q_tag}}</td>
+                <td>{{select_tag_for_processing_state}}</td>
+                <td>{{select_tag_for_sort_order}}</td>
+              </fieldset>
+              <td>{{submit_button}}</td>
+            {{/filter_form}}
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 

--- a/app/views/sipity/controllers/work_areas/etd/show.html.curly
+++ b/app/views/sipity/controllers/work_areas/etd/show.html.curly
@@ -12,6 +12,7 @@
     <div class="col-xs-12">
       <a href="{{start_a_submission_path}}" class="btn btn-primary">{{ translate.start_a_submission }}</a>
       <a href="{{view_submitted_etds_url}}" class="btn btn-primary">{{ translate.view_submitted_etds }}</a>
+      <a href="{{reset_path}}" class="btn btn-primary pull-right">{{ translate.reset }}</a>
     </div>
   </div>
   <div class="row dashboard-actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,6 +237,8 @@ en:
           label: "View ETDs in CurateND"
         start_a_submission:
           label: "Start an ETD Submission"
+        reset:
+          label: "Reset"
         login:
           label: "Login for ETD Work List"
         landing_page_greeting_introduction_html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,9 +234,11 @@ en:
           label: "Start a CurateND Submission"
       work_area/etd:
         view_submitted_etds:
-          label: "View Submitted ETDs"
+          label: "View ETDs in CurateND"
         start_a_submission:
           label: "Start an ETD Submission"
+        login:
+          label: "Login for ETD Work List"
         landing_page_greeting_introduction_html:
           label: |
             <p>This is a collection of electronic master's theses and doctoral dissertations (ETDs) available from the University of Notre Dame.

--- a/spec/presenters/sipity/controllers/visitors/etd/work_area_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/visitors/etd/work_area_presenter_spec.rb
@@ -22,6 +22,7 @@ module Sipity
           end
 
           its(:view_submitted_etds_url) { is_expected.to match(%r{\Ahttps://curate.nd.edu}) }
+          its(:login_path) { is_expected.to start_with('/sign_in') }
         end
       end
     end

--- a/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
@@ -22,6 +22,7 @@ module Sipity
           end
           it { is_expected.to be_a(Sipity::Controllers::WorkAreas::Core::ShowPresenter) }
           its(:view_submitted_etds_url) { is_expected.to match(%r{\Ahttps://curate.nd.edu}) }
+          its(:reset_path) { is_expected.to match('/areas/etd') }
         end
       end
     end

--- a/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
 
   it 'will expose select_tag_for_processing_state' do
     expect(subject.select_tag_for_processing_state).to have_tag('select[name="hello[world]"]') do
-      with_tag("option[value='']", text: '')
+      with_tag("option[value='']", text: 'All states')
       with_tag("option[value='new'][selected='selected']", text: 'New')
       with_tag("option[value='say']", text: 'Say')
     end
@@ -46,13 +46,12 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
 
   it 'will expose select_tag_for_sort_order' do
     expect(subject.select_tag_for_sort_order).to have_tag('select[name="name[sort_order]"]') do
-      with_tag("option[value='']", text: '')
       with_tag("option[value='title'][selected='selected']", text: 'Title')
       with_tag("option[value='created_at']", text: 'Created at')
     end
   end
 
   it 'will have a submit button' do
-    expect(subject.submit_button).to have_tag('input.btn.btn-default[type="submit"]')
+    expect(subject.submit_button).to have_tag('input.btn.btn-primary[type="submit"]')
   end
 end


### PR DESCRIPTION
This addresses a number of pain-point issues identified in the following tickets:

CURATE-287 - adds search in sipity
CURATE-105 - adds another button for those not logged in so advisor's option is more clear.
CURATE-104 - adds some translations and titles for advisor approval buttons & verification views
CURATE-288 - sorting by initial submission begin date was already present, but somewhat hidden. This adds titles to the sort/select/search boxes.

note: branch is deployed on prep for review purposes.