### PR TITLE
Adding Author Name and Submission Date to Dashboard

### DIFF
--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -92,8 +92,8 @@ module Sipity
           select_fields << "#{table_name}.value AS #{key}"
         end
 
+        # Note this must return the modified scope.
         scope.select(select_fields.join(", "))
-        scope
       end
 
       attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -35,7 +35,6 @@ module Sipity
       }
       ORDER_BY_OPTIONS = [
         'title', 'title DESC',
-        'author_name', 'author_name DESC',
         'etd_submission_date', 'etd_submission_date DESC',
         'created_at', 'created_at DESC',
         'updated_at', 'updated_at DESC'

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -38,7 +38,7 @@ module Sipity
         "program_name" => { key: 'program_name', join_as_table_name: 'program_names' }
       }
 
-      self.default_additional_attributes = ADDITIONAL_ATTRIBUTE_MAP.keys.freeze
+      self.default_additional_attributes = []
 
       ORDER_BY_OPTIONS = [
         'title', 'title DESC',

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -16,7 +16,6 @@ module Sipity
       self.default_submission_window = nil
       self.default_q = nil
       self.default_order = 'title'.freeze
-      self.default_additional_attributes = ["author_name", "etd_submission_date"].freeze
 
       # Note the parity between this and the additional attributes.
       # I'm including the following map to remove a possible SQL

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -16,7 +16,7 @@ module Sipity
       self.default_submission_window = nil
       self.default_q = nil
       self.default_order = 'title'.freeze
-      self.default_additional_attributes = ["author_name", "submission_date"].freeze
+      self.default_additional_attributes = ["author_name", "etd_submission_date"].freeze
 
       # Note the parity between this and the additional attributes.
       # I'm including the following map to remove a possible SQL
@@ -26,14 +26,21 @@ module Sipity
       # 1. `key`: - the `sipity_additional_attributes.key` field's value
       # 2. `join_as_table_name`: - for the purposes of the join, the
       #    table name we'll join as.
+      # 3. `cardinality`: - do we have one entry or many
       #
       # We need the `join_as_table_name` so that we can join multiple
       # times to the same `sipity_additional_attributes` table.
       ADDITIONAL_ATTRIBUTE_MAP = {
-        "author_name" => { key: 'author_name', join_as_table_name: 'author_names' },
-        "submission_date" => { key: 'submission_date', join_as_table_name: 'submission_dates' },
+        "author_name" => { key: 'author_name', join_as_table_name: 'author_names', cardinality: 1 },
+        "etd_submission_date" => { key: 'etd_submission_date', join_as_table_name: 'etd_submission_dates', cardinality: 1 },
       }
-      ORDER_BY_OPTIONS = ['title', 'title DESC', 'created_at', 'created_at DESC', 'updated_at', 'updated_at DESC'].freeze
+      ORDER_BY_OPTIONS = [
+        'title', 'title DESC',
+        'author_name', 'author_name DESC',
+        'etd_submission_date', 'etd_submission_date DESC',
+        'created_at', 'created_at DESC',
+        'updated_at', 'updated_at DESC'
+      ].freeze
 
       def self.order_options_for_select
         ORDER_BY_OPTIONS

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -2,7 +2,7 @@ module Sipity
   module Parameters
     # A coordination parameter to help build the search criteria for works.
     class SearchCriteriaForWorksParameter
-      ATTRIBUTE_NAMES = [:page, :order, :proxy_for_type, :processing_state, :submission_window, :user, :work_area, :per, :q].freeze
+      ATTRIBUTE_NAMES = [:page, :order, :proxy_for_type, :processing_state, :submission_window, :user, :work_area, :per, :additional_attributes, :q].freeze
       DEFAULT_ATTRIBUTE_NAMES = ATTRIBUTE_NAMES.map { |a| "default_#{a}".to_sym }.freeze
 
       class_attribute(*DEFAULT_ATTRIBUTE_NAMES, instance_writer: false)
@@ -16,6 +16,7 @@ module Sipity
       self.default_submission_window = nil
       self.default_q = nil
       self.default_order = 'title'.freeze
+      self.default_additional_attributes = ["author_name", "submission_date"].freeze
       ORDER_BY_OPTIONS = ['title', 'title DESC', 'created_at', 'created_at DESC', 'updated_at', 'updated_at DESC'].freeze
 
       def self.order_options_for_select
@@ -36,9 +37,56 @@ module Sipity
         end
       end
 
+      ##
+      #
+      # @param scope [ActiveRecord::Relation<proxy_for_types>] the query scope that we're actively building.
+      # @return ActiveRecord::Relation<proxy_for_types>
+      def apply_and_return(scope:)
+        scope = scope.order(order) if order?
+        scope = scope.page(page) if page?
+        # For Kaminari to work with `.per` page, there is a method call temporal
+        # dependency. First you must call `.page` then you may call `.per`.
+        scope = scope.per(per) if per? && page?
+        apply_and_return_additional_attributes_to(scope: scope)
+      end
+
       private
 
+      # And due to the nature of ActiveRecord, fields added to the
+      # SQL's SELECT statement are part of the data structure of the
+      # object.  In this way we can create a view of a work object
+      # that includes additional attributes.
+      #
+      # @note At this time, the implementation assumes that there will
+      # be only one row per additional attribute.  If that were to
+      # change, we'd need to craft a better approach.  Not sure what
+      # that better approach would be, but I'm sure it would depend on
+      # the product owner requirements for those fields.
+      def apply_and_return_additional_attributes_to(scope:)
+        attr_table_name = Models::AdditionalAttribute.quoted_table_name
+        work_table_name = scope.quoted_table_name
+        select_fields = ["#{work_table_name}.*"]
+
+        additional_attributes.each do |attribute|
+          table_name = attribute.to_s.pluralize
+          scope = scope.joins(
+            %(LEFT OUTER JOIN #{attr_table_name} AS #{table_name} ON #{table_name}.work_id = #{work_table_name}.id AND #{table_name}.key = "#{attribute}")
+          )
+          select_fields << "#{table_name}.value AS #{attribute}"
+        end
+
+        scope.select(select_fields.join(", "))
+        scope
+      end
+
       attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per
+
+      # Doing our due diligence to santize parameters
+      def additional_attributes=(input)
+        @additional_attributes = Array(input).map do |attribute_name|
+          Models::AdditionalAttribute.sanitize_sql_for_conditions(attribute_name.to_s)
+        end
+      end
 
       def page=(input)
         @page = input.to_i

--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -32,7 +32,7 @@ module Sipity
                 work_area: work_area,
                 q: work_area.q,
                 submission_window: work_area.submission_window,
-                additional_attributes: ["author_name", "submission_date"]
+                additional_attributes: ["author_name", "etd_submission_date"]
               )
             end
           end

--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -7,23 +7,32 @@ module Sipity
       module Core
         # Responsible for presenting a work area
         class ShowPresenter < Controllers::Visitors::Core::WorkAreaPresenter
-          public def filter_form(dom_class: 'form-inline', method: 'get', &block)
+          def filter_form(dom_class: 'form-inline', method: 'get', &block)
             form_tag(request.path, method: method, class: dom_class, &block)
           end
 
-          public def works
+          def works
             @works ||= repository.find_works_via_search(criteria: search_criteria)
           end
 
-          public def paginate_works
+          def paginate_works
             paginate(works)
           end
 
-          private def search_criteria
+          private
+
+          def search_criteria
             @search_criteria ||= begin
               Parameters::SearchCriteriaForWorksParameter.new(
-                user: current_user, processing_state: work_area.processing_state, page: work_area.page, order: work_area.order,
-                repository: repository, work_area: work_area, q: work_area.q, submission_window: work_area.submission_window
+                user: current_user,
+                processing_state: work_area.processing_state,
+                page: work_area.page,
+                order: work_area.order,
+                repository: repository,
+                work_area: work_area,
+                q: work_area.q,
+                submission_window: work_area.submission_window,
+                additional_attributes: ["author_name", "submission_date"]
               )
             end
           end

--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -31,8 +31,7 @@ module Sipity
                 repository: repository,
                 work_area: work_area,
                 q: work_area.q,
-                submission_window: work_area.submission_window,
-                additional_attributes: ["author_name", "etd_submission_date"]
+                submission_window: work_area.submission_window
               )
             end
           end

--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -7,6 +7,12 @@ module Sipity
       module Core
         # Responsible for presenting a work area
         class ShowPresenter < Controllers::Visitors::Core::WorkAreaPresenter
+          # We're injecting these attributes onto the result set for
+          # the works.  And by default that would be no attributes.
+          #
+          # @see Sipity::Parameters::SearchCriteriaForWorksParameter
+          class_attribute :additional_attributes, default: [], instance_writer: false
+
           def filter_form(dom_class: 'form-inline', method: 'get', &block)
             form_tag(request.path, method: method, class: dom_class, &block)
           end
@@ -31,7 +37,8 @@ module Sipity
                 repository: repository,
                 work_area: work_area,
                 q: work_area.q,
-                submission_window: work_area.submission_window
+                submission_window: work_area.submission_window,
+                additional_attributes: additional_attributes
               )
             end
           end

--- a/app/presenters/sipity/controllers/work_areas/etd/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/etd/show_presenter.rb
@@ -4,6 +4,8 @@ module Sipity
       module Etd
         # Present due to template lookup method
         class ShowPresenter < WorkAreas::Core::ShowPresenter
+          self.additional_attributes = ["author_name", "etd_submission_date", "program_name"]
+
           def view_submitted_etds_url
             Figaro.env.curate_nd_url_for_etds!
           end

--- a/app/presenters/sipity/controllers/work_areas/work_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/work_presenter.rb
@@ -47,7 +47,7 @@ module Sipity
         end
 
         def program_names_to_sentence
-          Array.wrap(repository.work_attribute_values_for(work: work, key: 'program_name')).to_sentence
+          additional_attribute_for(key: "program_name", cardinality: :many).to_sentence
         end
 
         def date_created

--- a/app/presenters/sipity/controllers/work_areas/work_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/work_presenter.rb
@@ -15,6 +15,17 @@ module Sipity
           work.work_type.to_s.humanize
         end
 
+        def author_name
+          if work.respond_to?(:author_name)
+            # This condition is when the underlying ActiveRecord query
+            # adds the pseudo-attribute author name
+            work.author_name
+          else
+            # And the fallback if something upstream has not done that.
+            additional_attribute_for(key: "author_name", cardinality: 1)
+          end
+        end
+
         def creator_names_to_sentence
           creators.to_sentence
         end
@@ -43,6 +54,17 @@ module Sipity
           work.created_at.strftime('%a, %d %b %Y')
         end
 
+        def submission_date
+          if work.respond_to?(:submission_date)
+            # This condition is when the underlying ActiveRecord query
+            # adds the pseudo-attribute submission date
+            return work.submission_date
+          else
+            # And the fallback if something upstream has not done that.
+            additional_attribute_for(key: "submission_date", cardinality: 1)
+          end
+        end
+
         def processing_state
           work.processing_state.to_s.humanize
         end
@@ -62,6 +84,10 @@ module Sipity
         def advisors
           # The repository comes from the underlying context; Which is likely a controller.
           @advisors ||= Array.wrap(repository.scope_users_for_entity_and_roles(entity: work, roles: Models::Role::ADVISING))
+        end
+
+        def additional_attribute_for(key:, cardinality:)
+          repository.work_attribute_values_for(work: work, key: key, cardinality: cardinality)
         end
       end
     end

--- a/app/presenters/sipity/controllers/work_areas/work_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/work_presenter.rb
@@ -47,7 +47,13 @@ module Sipity
         end
 
         def program_names_to_sentence
-          additional_attribute_for(key: "program_name", cardinality: :many).to_sentence
+          if work.respond_to?(:program_name)
+            # This condition is when the underlying ActiveRecord query
+            # adds the pseudo-attribute program_name.
+            work.program_name
+          else
+            Array.wrap(additional_attribute_for(key: "program_name", cardinality: :many)).to_sentence
+          end
         end
 
         def date_created
@@ -58,7 +64,7 @@ module Sipity
           if work.respond_to?(:etd_submission_date)
             # This condition is when the underlying ActiveRecord query
             # adds the pseudo-attribute submission date
-            return work.etd_submission_date
+            work.etd_submission_date
           else
             # And the fallback if something upstream has not done that.
             additional_attribute_for(key: "etd_submission_date", cardinality: 1)

--- a/app/presenters/sipity/controllers/work_areas/work_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/work_presenter.rb
@@ -54,14 +54,14 @@ module Sipity
           work.created_at.strftime('%a, %d %b %Y')
         end
 
-        def submission_date
-          if work.respond_to?(:submission_date)
+        def etd_submission_date
+          if work.respond_to?(:etd_submission_date)
             # This condition is when the underlying ActiveRecord query
             # adds the pseudo-attribute submission date
-            return work.submission_date
+            return work.etd_submission_date
           else
             # And the fallback if something upstream has not done that.
-            additional_attribute_for(key: "submission_date", cardinality: 1)
+            additional_attribute_for(key: "etd_submission_date", cardinality: 1)
           end
         end
 

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -463,12 +463,7 @@ module Sipity
           )
         )
 
-        scope = scope.order(criteria.order) if criteria.order?
-        scope = scope.page(criteria.page) if criteria.page?
-        # For Kaminari to work with `.per` page, there is a method call temporal
-        # dependency. First you must call `.page` then you may call `.per`.
-        scope = scope.per(criteria.per) if criteria.per? && criteria.page?
-        scope
+        scope = criteria.apply_and_return(scope: scope)
       end
 
       PermissionScope = Struct.new(:entity, :strategy)

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -73,10 +73,12 @@ module Sipity
       def apply_joins_for_additional_attributes(scope:, criteria:)
         attr_table_name = Models::AdditionalAttribute.quoted_table_name
         work_table_name = scope.quoted_table_name
-        scope = scope.joins("LEFT OUTER JOIN #{attr_table_name} AS author_names ON author_names.work_id = #{work_table_name}.id").
-          where(author_names: { key: "author_name" })
-        scope = scope.joins("LEFT OUTER JOIN #{attr_table_name} AS submission_dates ON submission_dates.work_id = #{work_table_name}.id").
-          where(submission_dates: { key: "submission_date" })
+        scope = scope.joins(
+          %(LEFT OUTER JOIN #{attr_table_name} AS author_names ON author_names.work_id = #{work_table_name}.id AND author_names.key = "author_name")
+        )
+        scope = scope.joins(
+          %(LEFT OUTER JOIN #{attr_table_name} AS submission_dates ON submission_dates.work_id = #{work_table_name}.id AND submission_dates.key = "submission_date")
+        )
         scope.select(%(#{work_table_name}.*, submission_dates.value AS submission_date, author_names.value AS author_name))
       end
       private :apply_joins_for_additional_attributes

--- a/app/repositories/sipity/queries/work_queries.rb
+++ b/app/repositories/sipity/queries/work_queries.rb
@@ -31,7 +31,6 @@ module Sipity
       def find_works_via_search(criteria:, repository: self)
         scope = repository.scope_proxied_objects_for_the_user_and_proxy_for_type(criteria: criteria)
         scope = apply_work_area_filter_to(scope: scope, criteria: criteria)
-        scope = apply_joins_for_additional_attributes(scope: scope, criteria: criteria)
 
         # For an empty scope (e.g. no records), treat the first page as present.
         return scope if criteria.page == 1
@@ -54,34 +53,6 @@ module Sipity
         )
       end
       private :apply_work_area_filter_to
-
-      ##
-      # Added as an inflection point in the code.  The current
-      # implementation (as of <2021-08-11 Wed>) assumes that we want two additional fields:
-      #
-      # 1. The work's `submission_date`
-      # 2. The work's `author_name`
-      #
-      # The left outer joins help expose that in a single query
-      # (instead of requiring N+1 sub-queries where N is the
-      # pagination size.)
-      #
-      # If for some reason the result set wants additional attributes,
-      # we could change how this behaves (perhaps leveraging the above
-      # `scope_proxied_objects_for_the_user_and_proxy_for_type`
-      # method).
-      def apply_joins_for_additional_attributes(scope:, criteria:)
-        attr_table_name = Models::AdditionalAttribute.quoted_table_name
-        work_table_name = scope.quoted_table_name
-        scope = scope.joins(
-          %(LEFT OUTER JOIN #{attr_table_name} AS author_names ON author_names.work_id = #{work_table_name}.id AND author_names.key = "author_name")
-        )
-        scope = scope.joins(
-          %(LEFT OUTER JOIN #{attr_table_name} AS submission_dates ON submission_dates.work_id = #{work_table_name}.id AND submission_dates.key = "submission_date")
-        )
-        scope.select(%(#{work_table_name}.*, submission_dates.value AS submission_date, author_names.value AS author_name))
-      end
-      private :apply_joins_for_additional_attributes
 
       def work_access_right_code(work:)
         work.access_right.access_right_code

--- a/app/views/sipity/controllers/work_areas/etd/show.html.curly
+++ b/app/views/sipity/controllers/work_areas/etd/show.html.curly
@@ -54,10 +54,11 @@
         <thead>
           <tr>
             <th>Title</th>
-            <th>Creator(s)</th>
+            <th>Author Name</th>
             <th>Program Name(s)</th>
             <th>Type</th>
             <th>Processing State</th>
+            <th>Submission Date</th>
             <th>Date Created</th>
           </tr>
         </thead>
@@ -65,10 +66,10 @@
           {{*works}}
             <tr>
               <td><a href="{{path}}">{{title}}</td>
-              <td>{{creator_names_to_sentence}}</td>
+              <td>{{author_name}}</td>
               <td>{{program_names_to_sentence}}</td>
               <td>{{work_type}}</td>
-              <td>{{processing_state}}</td>
+              <td>{{submission_date}}</td>
               <td>{{date_created}}</td>
             </tr>
           {{/works}}

--- a/app/views/sipity/controllers/work_areas/etd/show.html.curly
+++ b/app/views/sipity/controllers/work_areas/etd/show.html.curly
@@ -58,7 +58,7 @@
             <th>Program Name(s)</th>
             <th>Type</th>
             <th>Processing State</th>
-            <th>Submission Date</th>
+            <th>ETD Submission Date</th>
             <th>Date Created</th>
           </tr>
         </thead>
@@ -69,7 +69,8 @@
               <td>{{author_name}}</td>
               <td>{{program_names_to_sentence}}</td>
               <td>{{work_type}}</td>
-              <td>{{submission_date}}</td>
+              <td>{{processing_state}}</td>
+              <td>{{etd_submission_date}}</td>
               <td>{{date_created}}</td>
             </tr>
           {{/works}}

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,0 +1,5 @@
+---
+# We're hand building a SQL line, for which we've taken precautions to
+# avoid SQL injection.
+:skip_files:
+- app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -70,8 +70,10 @@ module Sipity
             work.additional_attributes.create!(key: "program_name", value: "Program Name #{index}")
             work.additional_attributes.create!(key: "author_name", value: "Author Name #{index}")
           end
-          parameter_object = described_class.new
+          parameter_object = described_class.new(additional_attributes: ["program_name", "author_name"])
           scope = parameter_object.apply_and_return(scope: work.class)
+
+          # Note the array of one element
           expect(scope.all.map(&:program_name)).to eq(["Program Name 1, Program Name 2, Program Name 3"])
 
           # I wish the count would work, but ActiveRecord can't quite

--- a/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
@@ -19,6 +19,8 @@ module Sipity
             allow_any_instance_of(described_class).to receive(:convert_to_processing_action).and_return(processing_action)
           end
 
+          its(:additional_attributes) { is_expected.to eq([]) }
+
           context '#filter_form' do
             it 'will render a form' do
               expect(context).to receive(:form_tag).and_yield

--- a/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/etd/show_presenter_spec.rb
@@ -23,6 +23,8 @@ module Sipity
           it { is_expected.to be_a(Sipity::Controllers::WorkAreas::Core::ShowPresenter) }
           its(:view_submitted_etds_url) { is_expected.to match(%r{\Ahttps://curate.nd.edu}) }
           its(:reset_path) { is_expected.to match('/areas/etd') }
+
+          its(:additional_attributes) { is_expected.to eq(["author_name", "etd_submission_date", "program_name"]) }
         end
       end
     end

--- a/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
@@ -46,6 +46,56 @@ module Sipity
           expect(subject.path).to eq('/the/path')
         end
 
+        describe '#submission_date' do
+          it 'first checks the work'
+          it 'fallsback to the additional attributes'
+        end
+
+        describe '#author_name' do
+          let(:author_name_from_repository) { "author 1" }
+          let(:author_name_from_work) { "author from work" }
+          before do
+            allow(repository).to(
+              receive(:work_attribute_values_for).
+                with(work: work, key: 'author_name', cardinality: 1).and_return(author_name_from_repository)
+            )
+          end
+
+          it 'first checks the work' do
+            allow(work).to receive(:author_name).and_return(author_name_from_work)
+            allow(work).to receive(:respond_to?).with(:author_name).and_return(true)
+            expect(subject.author_name).to eq(author_name_from_work)
+          end
+
+          it 'fallsback to the additional attributes' do
+            allow(work).to receive(:respond_to?).with(:author_name).and_return(false)
+            expect(subject.author_name).to eq(author_name_from_repository)
+          end
+        end
+
+        describe '#submission_date' do
+          let(:submission_date_from_repository) { "2021-01-01" }
+          let(:submission_date_from_work) { "2020-02-02" }
+          before do
+            allow(repository).to(
+              receive(:work_attribute_values_for).
+                with(work: work, key: 'submission_date', cardinality: 1).and_return(submission_date_from_repository)
+            )
+          end
+
+          it 'first checks the work' do
+            allow(work).to receive(:submission_date).and_return(submission_date_from_work)
+            allow(work).to receive(:respond_to?).with(:submission_date).and_return(true)
+            expect(subject.submission_date).to eq(submission_date_from_work)
+          end
+
+          it 'fallsback to the additional attributes' do
+            allow(work).to receive(:respond_to?).with(:submission_date).and_return(false)
+            expect(subject.submission_date).to eq(submission_date_from_repository)
+          end
+        end
+
+
         describe '#advisor_names_as_email_links' do
           subject { described_class.new(context, work: work).advisor_names_as_email_links }
           it { is_expected.to be_html_safe }

--- a/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
@@ -46,11 +46,6 @@ module Sipity
           expect(subject.path).to eq('/the/path')
         end
 
-        describe '#submission_date' do
-          it 'first checks the work'
-          it 'fallsback to the additional attributes'
-        end
-
         describe '#author_name' do
           let(:author_name_from_repository) { "author 1" }
           let(:author_name_from_work) { "author from work" }
@@ -73,25 +68,25 @@ module Sipity
           end
         end
 
-        describe '#submission_date' do
-          let(:submission_date_from_repository) { "2021-01-01" }
-          let(:submission_date_from_work) { "2020-02-02" }
+        describe '#etd_submission_date' do
+          let(:etd_submission_date_from_repository) { "2021-01-01" }
+          let(:etd_submission_date_from_work) { "2020-02-02" }
           before do
             allow(repository).to(
               receive(:work_attribute_values_for).
-                with(work: work, key: 'submission_date', cardinality: 1).and_return(submission_date_from_repository)
+                with(work: work, key: 'etd_submission_date', cardinality: 1).and_return(etd_submission_date_from_repository)
             )
           end
 
           it 'first checks the work' do
-            allow(work).to receive(:submission_date).and_return(submission_date_from_work)
-            allow(work).to receive(:respond_to?).with(:submission_date).and_return(true)
-            expect(subject.submission_date).to eq(submission_date_from_work)
+            allow(work).to receive(:etd_submission_date).and_return(etd_submission_date_from_work)
+            allow(work).to receive(:respond_to?).with(:etd_submission_date).and_return(true)
+            expect(subject.etd_submission_date).to eq(etd_submission_date_from_work)
           end
 
           it 'fallsback to the additional attributes' do
-            allow(work).to receive(:respond_to?).with(:submission_date).and_return(false)
-            expect(subject.submission_date).to eq(submission_date_from_repository)
+            allow(work).to receive(:respond_to?).with(:etd_submission_date).and_return(false)
+            expect(subject.etd_submission_date).to eq(etd_submission_date_from_repository)
           end
         end
 

--- a/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
@@ -95,6 +95,27 @@ module Sipity
           end
         end
 
+        describe '#program_names_to_sentence' do
+          let(:program_name_from_repository) { "Program 1, Program 2" }
+          let(:program_name_from_work) { "Work Program 1, Work Program 2" }
+          before do
+            allow(repository).to(
+              receive(:work_attribute_values_for).
+                with(work: work, key: 'program_name', cardinality: :many).and_return(program_name_from_repository)
+            )
+          end
+
+          it 'first checks the work' do
+            allow(work).to receive(:program_name).and_return(program_name_from_work)
+            allow(work).to receive(:respond_to?).with(:program_name).and_return(true)
+            expect(subject.program_names_to_sentence).to eq(program_name_from_work)
+          end
+
+          it 'fallsback to the additional attributes' do
+            allow(work).to receive(:respond_to?).with(:program_name).and_return(false)
+            expect(subject.program_names_to_sentence).to eq(program_name_from_repository)
+          end
+        end
 
         describe '#advisor_names_as_email_links' do
           subject { described_class.new(context, work: work).advisor_names_as_email_links }

--- a/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/work_presenter_spec.rb
@@ -8,6 +8,7 @@ module Sipity
         let(:advising_user) { User.new(email: 'lastbathroom@aol.com', name: 'Last Bathroom') }
         let(:repository) { QueryRepositoryInterface.new }
         let(:context) { PresenterHelper::ContextWithForm.new(repository: repository) }
+        let(:program_names) { ["name one"] }
         let(:work) do
           double(
             'Work',
@@ -27,6 +28,10 @@ module Sipity
           allow(repository).to(
             receive(:scope_users_for_entity_and_roles).
               with(entity: work, roles: Models::Role::ADVISING).and_return(advising_user)
+          )
+          allow(repository).to(
+            receive(:work_attribute_values_for).
+              with(work: work, key: "program_name", cardinality: :many).and_return(program_names)
           )
         end
 

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -190,6 +190,11 @@ module Sipity
 
           work_four.additional_attributes.create!(key: 'alternate_title', value: "The Lost One of Dire Warning")
 
+          # Adding these to test that multiple additional attributes
+          # don't accidentally add multiple records for the same work.
+          work_four.additional_attributes.create!(key: 'program_name', value: "Program Name One")
+          work_four.additional_attributes.create!(key: 'program_name', value: "Program Name Two")
+
           commands.grant_creating_user_permission_for!(entity: work_one, user: user)
           commands.grant_creating_user_permission_for!(entity: work_two, user: user)
           commands.grant_creating_user_permission_for!(entity: work_four, user: user)


### PR DESCRIPTION
## Interstial change to add two attributes to dashboard

3103308adf88e67f2848d12dbc112074833326d7

I'm not certain that this will work, but I want to capture the logic
that I've done to generate the joins.

The reason that this is not quite right is that I need to add the change
into given `criteria` AND `scope_proxied_objects_for_the_user_and_proxy_for_type` method.

The `criteria` object defines what are the sort columns and query
strings; so I need to expose the field sort for that.  The
`scope_proxied_objects_for_the_user_and_proxy_for_type` creates the
initial AREL scope from which we then build out additional queries.

So, while this "kind of works" and "kind of" addresses the
situation (e.g., the product owner wants to see the author and the
submission date in the dashboard and the dashboard is too slow), it's
not yet done.

## Switching from WHERE to ON in JOIN

08c4209c6a1c67a20eeed5e18d78218396f14bfb

Prior to this, the WHERE required the existence of the joined row.  In
moving it to ON, the query now allows for a NULL author_name or
submission_date

## Moving methods onto search criteria

641b1d5618e59bb5674dc20f62ba742a0e91b854

This is a bit of an odd duck, the criteria parameters are there to help
consolidate the logic necessary to run a search/filter/sort query for
the dashboard.  So there are two inter-related things:

1) The Active Record scope object
2) The criteria parameters

And one updates the other; regardless of how I do this.  I could extract
the logic to happen within the criteria (and am tempted given that I'm
now blending SQL logic into that criteria).

Ultimately, the goal is to allow for the querying of the dashboard to:

1) include a sort on an additional attribute (e.g. submission_date)
2) reduce the number of ActiveRecord queries necessary for building out the
   dashboard

This change iterates in that direction.

What remains?

- [ ] adding the sort criteri
- [ ] updating the templates to render those fields
- [ ] ripping out some of the Curly view object’s antics
- [ ] perhaps removing an `includes` directive on the dashboard's query

## Adding protection against SQL injection

d1704c7363b899ffce65be03a796a0ee5fdbfbdc

Prior to this commit, the SearchCriteriaForWorksParameter class was to
optimistic in the additional_attributes it received.  This was "okay" in
that these attributes were passed from within the application (and not
from user input).

However, I wanted to tighten that up further which is why I added the
changes to fetch the attributes from a map.

And even with all of this, [brakeman][1] identified this as a weak
chance for SQL injection.  So I also added a config/brakeman.yml file to
skip over this file. (alas I can't skip over a singular violation)

[1]:https://rubygems.org/gems/brakeman

## Adding additional attributes for /area/etds

2dbec3660a76390a0bf830f382f2dd342102a47e

While technically not necessary, I wanted to be specific in declaring
what attributes we're including.

I also took the time to refactor the public/private declarations.  It's
a bit more idiomatic.

## Adding author_name and submission_date to etds show

9662ba7399fafe658c47b29ead70d6e4fb00c6df

This builds on the work in the
`Sipity::Parameters::SearchCriteriaForWorksParameter` in which we add
the `author_name` and `submission_date` to the returned ActiveRecord
objects.

This reduces the number of queries that we make.

## Returning the modified scope instead

332e7f234ac15e7f5aa8e01d265fe7fb502108b3

Prior to this change, the code modified the select statement but did not
return that modification.  With this change the select is applied to the
scope and that modified scope is returned.  (Thus the upstream queries
include the virtual attributes).

## Fixing parameter name for dashboard

a8b8c39a3c1f9f9484fac1374e9f0c63c7a834f2

Prior to this, the `submission_date` was not a defined additional
attribute.  So I changed it to `etd_submission_date` (which is defined).

I've tested these changes in the UI to see the sorting mechanisms.

## Refactoring to repurpose a common method

0f66475a1b3a275f2224b1c5ced8a40245103829

Closes https://jira.library.nd.edu/browse/CURATE-288

## Removing author sort

f4291400a32d1f456a7d938a02890c3ec3390649

This really isn't all that helpful, so we'll leave it out.

## Removing author name from the order by options

f39d78a5829f1d41d335af4b5fe4a206a718b0c6

This is not all that useful.  And clutters the interface.

## Improving performance of dashboard response

8ad8ab86d4a738be8eb2c9c2a284c1d870679791

Prior to this commit, for each work on the dashboard, we'd query the
additional parameters for the program names.  With this change, we're
defaulting the dashboard query to add the program_name(s) to the initial
query result set.  This removes one of the conditions of N+1 queries.

One small concession: the SQL concatentation is with a ", " instead of
using Rails's `to_sentence`.  The result is that the array `["A", "B",
"C"]` goes from "A, B, and C" to "A, B, C".

## Having ShowPresenter specify additional_attributes

9c353f8ff67a0e1e420bc39cc6f5a78f4103054d

Prior to this commit, I made the assumption that the ShowPresenter would
defer to the `SearchCriteriaForWorksParameter` for the additional
attributes.

However, as part of the PR, LaRita recommended that each context should
specify it's additional attributes.  Which is spot on.

This change now, in essence, makes the prior changes an additive change
that by default doesn't impact other implementations.  And instead
updates the dashboard rendering behavior to be the only place where the
additional attributes of "author_name", "etd_submission_date", and
"program_name" might be applied.
