### PR TITLE
Increasing dashboard paging size

### DIFF
--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -8,7 +8,7 @@ module Sipity
       class_attribute(*DEFAULT_ATTRIBUTE_NAMES, instance_writer: false)
 
       self.default_page = 1
-      self.default_per = 8
+      self.default_per = 15
       self.default_user = nil
       self.default_proxy_for_type = Models::Work
       self.default_processing_state = nil

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -25,7 +25,7 @@ module Sipity
 
       its(:default_page) { is_expected.to eq(1) }
       its(:page?) { is_expected.to eq(true) }
-      its(:default_per) { is_expected.to eq(8) }
+      its(:default_per) { is_expected.to eq(15) }
       its(:per?) { is_expected.to eq(true) }
       its(:default_user) { is_expected.to eq(nil) }
       its(:user?) { is_expected.to eq(false) }


### PR DESCRIPTION
Given the speed-ups for the dashboard (see ["Adding Author Name and
Submission Date to Dashboard" pull request][1]), we can increase the
size of pagination without impacting performance.

[1]:https://github.com/ndlib/sipity/pull/1287