### PR TITLE
Ensuring that we can skip mysql password

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ bundle exec bin/rails s
 ```
 Then go to http://localhost:3000
 
+Before you run `bundle exec bin/rails s` you may consider adding `export SKIP_MYSQL_PASSWORD_FOR_LOCAL_DEVELOPMENT="true"` (or adding this to your `.bashrc` or `.profile`).  That export will tell the Rails configuration to skip using a password for the `config/database.yml` user in the local environment.
+
 ### Running with Authentication (in Development)
 
 You will need the Okta environment variables file.

--- a/config/database.yml
+++ b/config/database.yml
@@ -31,7 +31,9 @@ local_user: &local_user
   <<: *mysql_settings
   <<: *mysql_connection
   username: root
+<% if ! ENV['SKIP_MYSQL_PASSWORD_FOR_LOCAL_DEVELOPMENT'] %>
   password: root
+<% end %>
 
 development: &development
   <<: *local_user


### PR DESCRIPTION
With this change, you no longer need a mysql password.

In your shell, you can add the following:

```
export SKIP_MYSQL_PASSWORD_FOR_LOCAL_DEVELOPMENT="true"
```

I added the above line to my `config/aliases.zsh`, which should
propogate through my tests.