### PR TITLE
Adding default omit terminal actions

### DIFF
--- a/app/forms/sipity/forms/work_areas/core/show_form.rb
+++ b/app/forms/sipity/forms/work_areas/core/show_form.rb
@@ -9,7 +9,7 @@ module Sipity
         # Responsible for "showing" an ETD Work Area.
         class ShowForm
           ProcessingForm.configure(
-            form_class: self, base_class: Models::WorkArea, attribute_names: [:processing_state, :order, :page, :q, :submission_window]
+            form_class: self, base_class: Models::WorkArea, attribute_names: [:processing_states, :order, :page, :q, :submission_window]
           )
 
           def initialize(work_area:, requested_by:, attributes: {}, **keywords)
@@ -17,7 +17,7 @@ module Sipity
             self.requested_by = requested_by
             self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
             self.search_criteria_config = keywords.fetch(:search_criteria_config) { default_search_criteria_config }
-            self.processing_state = attributes[:processing_state]
+            self.processing_states = attributes[:processing_states]
             self.submission_window = attributes[:submission_window]
             self.q = attributes[:q]
             self.order = attributes.fetch(:order) { default_order }
@@ -26,8 +26,8 @@ module Sipity
 
           # @note There is a correlation to the Parameters::SearchCriteriaForWorksParameter
           #   object
-          def input_name_for_select_processing_state
-            "#{model_name.param_key}[processing_state]"
+          def input_name_for_select_processing_states
+            "#{model_name.param_key}[processing_states][]"
           end
 
           def processing_states_for_select

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -2,7 +2,7 @@ module Sipity
   module Parameters
     # A coordination parameter to help build the search criteria for works.
     class SearchCriteriaForWorksParameter
-      ATTRIBUTE_NAMES = [:page, :order, :proxy_for_type, :processing_state, :submission_window, :user, :work_area, :per, :additional_attributes, :q].freeze
+      ATTRIBUTE_NAMES = [:page, :order, :proxy_for_type, :processing_state, :submission_window, :user, :per, :additional_attributes, :q].freeze
       DEFAULT_ATTRIBUTE_NAMES = ATTRIBUTE_NAMES.map { |a| "default_#{a}".to_sym }.freeze
 
       class_attribute(*DEFAULT_ATTRIBUTE_NAMES, instance_writer: false)
@@ -12,7 +12,6 @@ module Sipity
       self.default_user = nil
       self.default_proxy_for_type = Models::Work
       self.default_processing_state = nil
-      self.default_work_area = nil
       self.default_submission_window = nil
       self.default_q = nil
       self.default_order = 'title'.freeze
@@ -51,13 +50,16 @@ module Sipity
         ORDER_BY_OPTIONS
       end
 
-      def initialize(**keywords)
+      def initialize(work_area: default_work_area, **keywords)
+        self.work_area = work_area
         ATTRIBUTE_NAMES.each do |attribute_name|
           send("#{attribute_name}=", keywords.fetch(attribute_name) { send("default_#{attribute_name}") })
         end
       end
 
       attr_reader(*ATTRIBUTE_NAMES)
+      attr_reader :work_area
+      alias work_area? work_area
 
       ATTRIBUTE_NAMES.each do |method_name|
         define_method "#{method_name}?" do

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -2,7 +2,7 @@ module Sipity
   module Parameters
     # A coordination parameter to help build the search criteria for works.
     class SearchCriteriaForWorksParameter
-      ATTRIBUTE_NAMES = [:page, :order, :proxy_for_type, :processing_state, :submission_window, :user, :per, :additional_attributes, :q].freeze
+      ATTRIBUTE_NAMES = [:page, :order, :proxy_for_type, :processing_states, :submission_window, :user, :per, :additional_attributes, :q].freeze
       DEFAULT_ATTRIBUTE_NAMES = ATTRIBUTE_NAMES.map { |a| "default_#{a}".to_sym }.freeze
 
       class_attribute(*DEFAULT_ATTRIBUTE_NAMES, instance_writer: false)
@@ -11,9 +11,9 @@ module Sipity
       self.default_per = 15
       self.default_user = nil
       self.default_proxy_for_type = Models::Work
-      self.default_processing_state = nil
       self.default_submission_window = nil
       self.default_q = nil
+      self.default_processing_states = []
       self.default_order = 'title'.freeze
 
       # Note the parity between this and the additional attributes.
@@ -59,7 +59,10 @@ module Sipity
 
       attr_reader(*ATTRIBUTE_NAMES)
       attr_reader :work_area
-      alias work_area? work_area
+
+      def work_area?
+        !work_area.nil?
+      end
 
       ATTRIBUTE_NAMES.each do |method_name|
         define_method "#{method_name}?" do
@@ -88,12 +91,13 @@ module Sipity
         apply_and_return_additional_attributes_to(scope: scope)
       end
 
-      def processing_states
-        Array.wrap(processing_state).select(&:present?)
-      end
-
       def processing_states?
         !processing_states.empty?
+      end
+
+      def default_processing_states
+        # If we don't have a work area don't even try to build a list of defaults
+        return [] unless work_area?
       end
 
       private
@@ -140,7 +144,15 @@ module Sipity
         scope.select(select_fields.join(", "))
       end
 
-      attr_writer :user, :processing_state, :proxy_for_type, :work_area, :submission_window, :per
+      attr_writer :user, :proxy_for_type, :work_area, :submission_window, :per
+
+      def default_work_area
+        nil
+      end
+
+      def processing_states=(input)
+        @processing_states = Array.wrap(input).select(&:present?)
+      end
 
       # Doing our due diligence to santize parameters
       def additional_attributes=(input)

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -86,6 +86,14 @@ module Sipity
         apply_and_return_additional_attributes_to(scope: scope)
       end
 
+      def processing_states
+        Array.wrap(processing_state).select(&:present?)
+      end
+
+      def processing_states?
+        !processing_states.empty?
+      end
+
       private
 
       # And due to the nature of ActiveRecord, fields added to the

--- a/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
+++ b/app/parameters/sipity/parameters/search_criteria_for_works_parameter.rb
@@ -92,7 +92,7 @@ module Sipity
       end
 
       def processing_states?
-        !processing_states.empty?
+        processing_states.any?(&:present?)
       end
 
       def default_processing_states
@@ -151,7 +151,7 @@ module Sipity
       end
 
       def processing_states=(input)
-        @processing_states = Array.wrap(input).select(&:present?)
+        @processing_states = Array.wrap(input)
       end
 
       # Doing our due diligence to santize parameters

--- a/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/core/show_presenter.rb
@@ -31,7 +31,7 @@ module Sipity
             @search_criteria ||= begin
               Parameters::SearchCriteriaForWorksParameter.new(
                 user: current_user,
-                processing_state: work_area.processing_state,
+                processing_states: work_area.processing_states,
                 page: work_area.page,
                 order: work_area.order,
                 repository: repository,

--- a/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
@@ -12,7 +12,7 @@ module Sipity
           select_tag(
             work_area.input_name_for_select_processing_state,
             options_from_collection_for_select(
-              work_area.processing_states_for_select, :to_s, :humanize, work_area.processing_state
+              work_area.processing_states_for_select, :to_s, :humanize, work_area.processing_states
             ), multiple: true, prompt: 'All states', class: 'form-control'
           ).html_safe
         end

--- a/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
@@ -8,9 +8,9 @@ module Sipity
       class FilterFormPresenter < Curly::Presenter
         presents :work_area
 
-        def select_tag_for_processing_state
+        def select_tag_for_processing_states
           select_tag(
-            work_area.input_name_for_select_processing_state,
+            work_area.input_name_for_select_processing_states,
             options_from_collection_for_select(
               work_area.processing_states_for_select, :to_s, :humanize, work_area.processing_states
             ), multiple: true, prompt: 'All states', class: 'form-control'

--- a/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
@@ -13,7 +13,7 @@ module Sipity
             work_area.input_name_for_select_processing_state,
             options_from_collection_for_select(
               work_area.processing_states_for_select, :to_s, :humanize, work_area.processing_state
-            ), prompt: 'All states', class: 'form-control'
+            ), multiple: true, prompt: 'All states', class: 'form-control'
           ).html_safe
         end
 

--- a/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
+++ b/app/presenters/sipity/controllers/work_areas/filter_form_presenter.rb
@@ -13,7 +13,7 @@ module Sipity
             work_area.input_name_for_select_processing_states,
             options_from_collection_for_select(
               work_area.processing_states_for_select, :to_s, :humanize, work_area.processing_states
-            ), multiple: true, prompt: 'All states', class: 'form-control'
+            ), multiple: true, class: 'form-control'
           ).html_safe
         end
 

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -520,11 +520,11 @@ module Sipity
           returning = entities[:proxy_for_type].eq(proxy_for_type).and(
             responsibility[:actor_id].in(user_actor_contraints)
           )
-          if criteria.processing_state?
+          if criteria.processing_states?
             returning = returning.and(
               entities[:strategy_state_id].in(
                 strategy_states.project(strategy_states[:id]).where(
-                  strategy_states[:name].eq(criteria.processing_state)
+                  strategy_states[:name].in(criteria.processing_states)
                 )
               )
             )

--- a/app/repositories/sipity/queries/processing_queries.rb
+++ b/app/repositories/sipity/queries/processing_queries.rb
@@ -35,9 +35,12 @@ module Sipity
       #
       # @param work_area [Object] that can be converted into a Sipity::Models::WorkArea
       # @param usage_type [Object] the polymorphic type for database storage
+      # @param include_terminal [Boolean] when true, include
+      #        processing states that are terminal (e.g., there are no
+      #        actions that transition out of the state).
       #
       # @return [Array<String>] name of actions available
-      def processing_state_names_for_select_within_work_area(work_area:, usage_type: Sipity::Models::WorkType)
+      def processing_state_names_for_select_within_work_area(work_area:, usage_type: Sipity::Models::WorkType, include_terminal: true)
         work_area = PowerConverter.convert(work_area, to: :work_area)
         usage_type = PowerConverter.convert(usage_type, to: :polymorphic_type)
 
@@ -46,19 +49,29 @@ module Sipity
         submission_window_work_types = Models::SubmissionWindowWorkType.arel_table
         submission_windows = Models::SubmissionWindow.arel_table
 
-        select_manager = strategy_states.project(strategy_states[:name]).order(strategy_states[:name]).distinct.join(strategy_usages).on(
-          strategy_usages[:strategy_id].eq(strategy_states[:strategy_id]).and(
-            strategy_usages[:usage_type].eq(usage_type)
-          )
-        ).join(submission_window_work_types).on(
-          submission_window_work_types[:work_type_id].eq(strategy_usages[:usage_id])
-        ).join(submission_windows).on(
-          submission_windows[:id].eq(submission_window_work_types[:submission_window_id]).and(
-            submission_windows[:work_area_id].eq(work_area.id)
-          )
-        )
+        scope = Models::Processing::StrategyState.distinct.
+          where(
+            strategy_states[:strategy_id].in(
+              strategy_usages.project(strategy_usages[:strategy_id]).
+                where(strategy_usages[:usage_type].eq(usage_type)).
+                join(submission_window_work_types).on(
+                  submission_window_work_types[:work_type_id].eq(strategy_usages[:usage_id])
+                ).join(submission_windows).on(
+                  submission_windows[:id].eq(submission_window_work_types[:submission_window_id]).and(submission_windows[:work_area_id].eq(work_area.id)))))
 
-        Models::Processing::StrategyState.from(strategy_states.create_table_alias(select_manager, strategy_states.table_name)).pluck(:name)
+        unless include_terminal
+          strategy_state_actions = Models::Processing::StrategyStateAction.arel_table
+          strategy_actions = Models::Processing::StrategyAction.arel_table
+          scope = scope.where(
+            strategy_states[:id].in(
+              strategy_state_actions.project(strategy_state_actions[:originating_strategy_state_id]).
+                join(strategy_actions).on(
+                  strategy_actions[:id].eq(strategy_state_actions[:strategy_action_id]).
+                    and(strategy_actions[:resulting_strategy_state_id].not_eq(nil))
+                )))
+
+        end
+        scope.pluck(:name).sort
       end
 
       # @api public

--- a/app/views/sipity/controllers/work_areas/etd/show.html.curly
+++ b/app/views/sipity/controllers/work_areas/etd/show.html.curly
@@ -31,7 +31,7 @@
             {{@filter_form}}
               <fieldset class="form-group">
                 <td>{{q_tag}}</td>
-                <td>{{select_tag_for_processing_state}}</td>
+                <td>{{select_tag_for_processing_states}}</td>
                 <td>{{select_tag_for_sort_order}}</td>
               </fieldset>
               <td>{{submit_button}}</td>

--- a/app/views/sipity/controllers/work_areas/ulra/show.html.curly
+++ b/app/views/sipity/controllers/work_areas/ulra/show.html.curly
@@ -20,7 +20,7 @@
       {{@filter_form}}
         <fieldset class="form-group">
           {{q_tag}}
-          {{select_tag_for_processing_state}}
+          {{select_tag_for_processing_states}}
           {{select_tag_for_submission_window}}
           {{select_tag_for_sort_order}}
         </fieldset>

--- a/spec/forms/sipity/forms/work_areas/core/show_form_spec.rb
+++ b/spec/forms/sipity/forms/work_areas/core/show_form_spec.rb
@@ -19,7 +19,7 @@ module Sipity
           it { is_expected.to delegate_method(:slug).to(:work_area) }
 
           its(:order_options_for_select) { is_expected.to be_a(Array) }
-          its(:input_name_for_select_processing_state) { is_expected.to eq('work_area[processing_state]') }
+          its(:input_name_for_select_processing_states) { is_expected.to eq('work_area[processing_states][]') }
           its(:input_name_for_select_sort_order) { is_expected.to eq('work_area[order]') }
           its(:input_name_for_selecting_submission_window) { is_expected.to eq('work_area[submission_window]') }
           its(:input_name_for_q) { is_expected.to eq('work_area[q]') }

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -14,7 +14,7 @@ module Sipity
       context 'instance' do
         subject { described_class.new }
         it { is_expected.to respond_to(:user) }
-        it { is_expected.to respond_to(:processing_state) }
+        it { is_expected.to respond_to(:processing_states) }
         it { is_expected.to respond_to(:order) }
         it { is_expected.to respond_to(:proxy_for_type) }
         it { is_expected.to respond_to(:work_area) }
@@ -31,8 +31,8 @@ module Sipity
       its(:user?) { is_expected.to eq(false) }
       its(:default_proxy_for_type) { is_expected.to eq(Models::Work) }
       its(:proxy_for_type?) { is_expected.to eq(true) }
-      its(:default_processing_state) { is_expected.to eq(nil) }
-      its(:processing_state?) { is_expected.to eq(false) }
+      its(:default_processing_states) { is_expected.to eq [] }
+      its(:processing_states?) { is_expected.to eq(false) }
       its(:work_area?) { is_expected.to eq(false) }
       its(:default_submission_window) { is_expected.to eq(nil) }
       its(:submission_window?) { is_expected.to eq(false) }
@@ -52,7 +52,7 @@ module Sipity
 
       describe '#processing_states' do
         it 'can be set' do
-          subject = described_class.new(processing_state: 'Hello')
+          subject = described_class.new(processing_states: 'Hello')
           expect(subject.processing_states).to eq(["Hello"])
           expect(subject.processing_states?).to eq(true)
         end

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -33,7 +33,6 @@ module Sipity
       its(:proxy_for_type?) { is_expected.to eq(true) }
       its(:default_processing_state) { is_expected.to eq(nil) }
       its(:processing_state?) { is_expected.to eq(false) }
-      its(:default_work_area) { is_expected.to eq(nil) }
       its(:work_area?) { is_expected.to eq(false) }
       its(:default_submission_window) { is_expected.to eq(nil) }
       its(:submission_window?) { is_expected.to eq(false) }

--- a/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
+++ b/spec/parameters/sipity/parameters/search_criteria_for_works_parameter_spec.rb
@@ -41,12 +41,21 @@ module Sipity
       its(:order?) { is_expected.to eq(true) }
       its(:default_q) { is_expected.to eq(nil) }
       its(:q?) { is_expected.to eq(false) }
+      its(:processing_states) { is_expected.to be_a(Array) }
 
       describe '#q' do
         it 'can be set' do
           subject = described_class.new(q: 'Hello')
           expect(subject.q?).to eq(true)
           expect(subject.q).to eq('Hello')
+        end
+      end
+
+      describe '#processing_states' do
+        it 'can be set' do
+          subject = described_class.new(processing_state: 'Hello')
+          expect(subject.processing_states).to eq(["Hello"])
+          expect(subject.processing_states?).to eq(true)
         end
       end
 

--- a/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/core/show_presenter_spec.rb
@@ -9,7 +9,7 @@ module Sipity
           let(:context) { PresenterHelper::ContextWithForm.new(current_user: current_user, request: double(path: '/path'), paginate: true) }
           let(:current_user) { double('Current User') }
           let(:work_area) do
-            double(slug: 'the-slug', submission_window: '2016', title: 'The Slug', processing_state: 'new', order: 'title', page: 1, q: nil)
+            double(slug: 'the-slug', submission_window: '2016', title: 'The Slug', processing_states: ['new'], order: 'title', page: 1, q: nil)
           end
           let(:repository) { QueryRepositoryInterface.new }
           let(:processing_action) { double(name: 'start_a_submission') }

--- a/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
 
   it 'will expose select_tag_for_processing_states' do
     expect(subject.select_tag_for_processing_states).to have_tag('select[name="hello[world][]"]') do
-      with_tag("option[value='']", text: 'All states')
       with_tag("option[value='new'][selected='selected']", text: 'New')
       with_tag("option[value='say']", text: 'Say')
     end

--- a/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
   let(:context) { PresenterHelper::ContextWithForm.new }
   let(:work_area) do
     double(
-      input_name_for_select_processing_state: 'hello[world]',
+      input_name_for_select_processing_states: 'hello[world][]',
       processing_states: ['new'],
       processing_states_for_select: ['new', 'say'],
       input_name_for_select_sort_order: 'name[sort_order]',
@@ -22,14 +22,14 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
   subject { described_class.new(context, work_area: work_area) }
 
   its(:submit_button) { is_expected.to be_html_safe }
-  its(:select_tag_for_processing_state) { is_expected.to be_html_safe }
+  its(:select_tag_for_processing_states) { is_expected.to be_html_safe }
 
   it 'will expose q_tag' do
     expect(subject.q_tag).to have_tag('input[type="text"][value="Searching for"][name="name[q]"]')
   end
 
-  it 'will expose select_tag_for_processing_state' do
-    expect(subject.select_tag_for_processing_state).to have_tag('select[name="hello[world][]"]') do
+  it 'will expose select_tag_for_processing_states' do
+    expect(subject.select_tag_for_processing_states).to have_tag('select[name="hello[world][]"]') do
       with_tag("option[value='']", text: 'All states')
       with_tag("option[value='new'][selected='selected']", text: 'New')
       with_tag("option[value='say']", text: 'Say')

--- a/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
   let(:work_area) do
     double(
       input_name_for_select_processing_state: 'hello[world]',
-      processing_state: 'new',
+      processing_states: ['new'],
       processing_states_for_select: ['new', 'say'],
       input_name_for_select_sort_order: 'name[sort_order]',
       order_options_for_select: ['title', 'created_at'],

--- a/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
+++ b/spec/presenters/sipity/controllers/work_areas/filter_form_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Sipity::Controllers::WorkAreas::FilterFormPresenter do
   end
 
   it 'will expose select_tag_for_processing_state' do
-    expect(subject.select_tag_for_processing_state).to have_tag('select[name="hello[world]"]') do
+    expect(subject.select_tag_for_processing_state).to have_tag('select[name="hello[world][]"]') do
       with_tag("option[value='']", text: 'All states')
       with_tag("option[value='new'][selected='selected']", text: 'New')
       with_tag("option[value='say']", text: 'Say')

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -74,6 +74,19 @@ module Sipity
         it 'will return actions associated with the work area' do
           expect(subject).to match_array(results_array)
         end
+
+        context "when we do not include terminal actions" do
+          it 'will not include the ingested state' do
+            all_states = test_repository.processing_state_names_for_select_within_work_area(work_area: work_area)
+            all_non_terminal_states = test_repository.processing_state_names_for_select_within_work_area(work_area: work_area, include_terminal: false)
+
+            # The non-terminal states are only the following:
+            expect(all_states - all_non_terminal_states).to eq(["deactivated", "ingested"])
+
+            # The non-terminal states are a subset of all of the states
+            expect(all_non_terminal_states - all_states).to eq([])
+          end
+        end
       end
 
       context '#scope_actors_associated_with_entity_and_role' do

--- a/spec/repositories/sipity/queries/processing_queries_spec.rb
+++ b/spec/repositories/sipity/queries/processing_queries_spec.rb
@@ -240,7 +240,7 @@ module Sipity
 
           expect(
             test_repository.scope_proxied_objects_for_the_user_and_proxy_for_type(
-              criteria: parameter_builder.call(user: user, processing_state: 'hello')
+              criteria: parameter_builder.call(user: user, processing_states: ['hello'])
             )
           ).to eq([])
 

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -214,7 +214,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb
-    def processing_state_names_for_select_within_work_area(work_area:, usage_type: Sipity::Models::WorkType)
+    def processing_state_names_for_select_within_work_area(work_area:, usage_type: Sipity::Models::WorkType, include_terminal: true)
     end
 
     # @see ./app/repositories/sipity/commands/todo_list_commands.rb

--- a/spec/support/sipity/query_repository_interface.rb
+++ b/spec/support/sipity/query_repository_interface.rb
@@ -134,7 +134,7 @@ module Sipity
     end
 
     # @see ./app/repositories/sipity/queries/processing_queries.rb
-    def processing_state_names_for_select_within_work_area(work_area:, usage_type: Sipity::Models::WorkType)
+    def processing_state_names_for_select_within_work_area(work_area:, usage_type: Sipity::Models::WorkType, include_terminal: true)
     end
 
     # @see ./app/repositories/sipity/queries/attachment_queries.rb


### PR DESCRIPTION
## Interstitial commit to query multiple states

2400ed74057e29d7067dc88e1f783618965e6882

With this commit, you can now select and filter on multiple states on
the dashboard.

## Switching work area interface

4e8ce0b7caea1a51ca6c70b3b002748873d375fe

This aligns with the emerging changes for the
`SearchCriteriaForWorksParameter` interface (e.g., moving from single
value to multiple value).

## Updating work_area to be an "first set" attribute

3a0b76421a30487679466e15b4d7f1c16a6b45f4

Prior to this commit, the order of assignment was somewhat arbitrary.
And as I want to amend the default_processing_states to start with
non-terminal states, I need to ensure that work_area is set before the
others (so that I can query the work area's non-terminal states).

## Renaming search/filter parameter to plural

a16ec11bdf9429de594fde662f2115bcdf0c1262

Prior to this change, the parameter name presumed a singular value.
With this change, the parameter name implies plurality.

As part of the refactor, I've removed the singular name (which could
remain if we alias plural to singular, but instead I chose to remove it
for clarity).

## Parameterizing list for states to allow non-terminal

981ad969d4d7dd68ee661b3ef8796e659fc849b1

This commit is a refactoring of a query, to allow for more immediate and
simplified AREL query chaining.

The goal of this change is to introduce a means for generating a list of
non-terminal states for the given work area.  Non-terminal states are
those states that have actions that can transition them out of the given
state.  A terminal state is an a state in which there are no actions
that will transition the object out of it's current state.

## Removing "all states" from select list

f3d97eda4b0023461da4c1a17224b72d33f671c6

In local testing, the Rails logic around the input prompt and
multi-select can create some inconsistent behavior.

For example, if I selected only "All States", then ran the search, the
returned page would not indicate that "All States" was selected.  In
other words, the select box would have nothing selected.  I found that
this created an odd visual state.

Thinking about this it makes sense; what does it mean to have a
multi-select and then someone selects "All States" and "New"?  Which do
we honor in the filter?

My response is to remove the "All States" prompt/placeholder thus
showing specifically which states you've selected.  I suppose if you
select NONE of them, the inner logic will render all of the states.

Addresses - https://jira.library.nd.edu/browse/CURATE-289
