### PR TITLE
Removing code climate reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Sipity
 
 [![Build Status](https://travis-ci.org/ndlib/sipity.png?branch=master)](https://travis-ci.org/ndlib/sipity)
-[![Code Climate](https://codeclimate.com/github/ndlib/sipity.png)](https://codeclimate.com/github/ndlib/sipity)
-[![Test Coverage](https://codeclimate.com/github/ndlib/sipity/badges/coverage.svg)](https://codeclimate.com/github/ndlib/sipity)
 [![Documentation Status](http://inch-ci.org/github/ndlib/sipity.svg?branch=master)](http://inch-ci.org/github/ndlib/sipity)
 [![APACHE 2 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 [![Contributing Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,10 +1,9 @@
 if ENV['COV'] || ENV['COVERAGE'] || ENV['TRAVIS']
   if ENV['TRAVIS']
     require 'simplecov'
-    require "codeclimate-test-reporter"
     SimpleCov.start do
       formatter(
-        SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter, CodeClimate::TestReporter::Formatter])
+        SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter])
       )
       load_profile 'rails'
     end


### PR DESCRIPTION
## Removing code climate reporting

059afc6b151b7a3b7bb19cb010f750a059b16423

Prior to this commit, the Github CI checks included a step that pushed
the code coverage report to CodeClimate.  After this commit, that step
is gone.

NOTE: the build will still break if we do not meet the coverage
requirements.
