### PR TITLE
Export attachments as json

### DIFF
--- a/app/exporters/sipity/exporters/base_exporter/api_file_utils.rb
+++ b/app/exporters/sipity/exporters/base_exporter/api_file_utils.rb
@@ -14,12 +14,6 @@ module Sipity
         def self.mv(_from, destination)
           RestClient.post destination, "", 'X-Api-Token' => Figaro.env.curate_batch_api_key!
         end
-
-        def self.put_file(path, file)
-          # The entire file is loaded into memory prior to sending it.
-          content = File.new(file, 'rb').read
-          RestClient.put path, content, 'X-Api-Token' => Figaro.env.curate_batch_api_key!
-        end
       end
     end
   end

--- a/app/exporters/sipity/exporters/batch_ingest_exporter/attachment_writer.rb
+++ b/app/exporters/sipity/exporters/batch_ingest_exporter/attachment_writer.rb
@@ -16,28 +16,12 @@ module Sipity
         end
 
         def call
-          exporter.with_path_to_data_directory do |path|
-            write_attachments_to(path: path)
-          end
+          path = File.join(exporter.data_directory, "attachments-#{exporter.work_id}.json")
+          content = attachments.to_json
+          exporter.file_writer.call(content: content, path: path)
         end
 
         private
-
-        def write_attachments_to(path:)
-          attachments.each do |attachment|
-            write_attachment_content_to(path: path, attachment: attachment)
-          end
-        end
-
-        def write_attachment_content_to(attachment:, path:)
-          filename = File.join(path, attachment.to_rof_file_basename)
-          case exporter.ingest_method
-          when :files
-            attachment.file.to_file(filename)
-          when :api
-            exporter.file_utility.put_file(filename, attachment.file.path)
-          end
-        end
 
         attr_accessor :work, :exporter, :attachments
         attr_accessor :work_to_attachments_converter

--- a/spec/exporters/sipity/exporters/base_exporter/api_file_utils_spec.rb
+++ b/spec/exporters/sipity/exporters/base_exporter/api_file_utils_spec.rb
@@ -32,13 +32,6 @@ module Sipity
               subject.mv(path, destination)
             end
           end
-          describe '#put_file' do
-            let(:file) { File.new(__FILE__) }
-            it 'executes a put request to RestClient' do
-              expect(RestClient).to receive(:put)
-              subject.put_file(path, file)
-            end
-          end
         end
       end
     end

--- a/spec/exporters/sipity/exporters/batch_ingest_exporter/attachment_writer_spec.rb
+++ b/spec/exporters/sipity/exporters/batch_ingest_exporter/attachment_writer_spec.rb
@@ -4,60 +4,76 @@ module Sipity
   module Exporters
     class BatchIngestExporter
       RSpec.describe AttachmentWriter do
-        let(:work_to_attachments_converter) { double('work_to_attachments_converter', call: [attachment]) }
-        let(:attachment) { Models::Attachment.new(pid: 'abc:123', file: __FILE__) }
+        let(:subject) do
+          described_class.new(
+            work: work,
+            exporter: exporter,
+            work_to_attachments_converter: work_to_attachments_converter
+          )
+        end
+        let(:exporter) do
+          double('exporter',
+                  work: work,
+                  work_id: work.id,
+                  data_directory: data_directory,
+                  ingest_method: ingest_method,
+                  file_utility: file_utility,
+                  file_writer: file_writer
+                )
+        end
         let(:work) { Models::Work.new(id: '123') }
-        let(:temporary_directory) { '/tmp/hello/world' }
+        let(:attachments) { [attachment1, attachment2] }
+        let(:attachment1) { Models::Attachment.new(
+                  work_id: work.id, 
+                  pid: 'abcabc', 
+                  predicate_name: 'attachment',
+                  file_uid: "2021/08/17/5t2fiqw7ej_file_abc.jpg",
+                  file_name: "file_abc.jpg")
+         }
+         let(:attachment2) { Models::Attachment.new(
+                  work_id: work.id, 
+                  pid: 'abcdef', 
+                  predicate_name: 'attachment',
+                  file_uid: "2021/08/17/5t2fiqw7ej_file_def.jpg",
+                  file_name: "file_def.jpg")
+         }
+        let(:work_to_attachments_converter) { 
+          double('work_to_attachments_converter', call: attachments) 
+        }
+        let(:filename) { 
+          File.join(data_directory, "attachments-#{exporter.work_id}.json") 
+        }
+        let(:content) { attachments.to_json }
 
-        context 'for :files' do
-          let(:exporter) do
-            double('exporter',
-                   with_path_to_data_directory: true,
-                   ingest_method: :files,
-                   file_utility: FileUtils)
-          end
+        describe':files' do
+          let(:ingest_method) { :files }
+          let(:file_utility) { FileUtils }
+          let(:file_writer) { FileWriter }
+          let (:data_directory) { '/tmp/sipity-1661' }
 
           it 'exposes .call as a convenience method' do
             expect_any_instance_of(described_class).to receive(:call)
-            described_class.call(work: work, exporter: exporter)
+            subject.call
           end
 
-          subject { described_class.new(work: work, exporter: exporter, work_to_attachments_converter: work_to_attachments_converter) }
           its(:default_work_to_attachments_converter) { is_expected.to respond_to(:call) }
 
           context '#call' do
-            before do
-              allow(exporter).to receive(:with_path_to_data_directory).and_yield(temporary_directory)
-            end
-            it "copies each of the attachments to the exporter's provided data directory" do
+            it "writes a json file with attachment data" do
+              expect(FileWriter).to receive(:call).with(content: content, path: filename)
               subject.call
-              attachment_pathname = Pathname.new(File.join(temporary_directory, "#{attachment.pid}-#{attachment.file_name}"))
-              expect(attachment_pathname.exist?).to eq(true)
             end
           end
         end
 
-        context 'for :api' do
-          let(:exporter) do
-            double('exporter',
-                   with_path_to_data_directory: true,
-                   ingest_method: :api,
-                   file_utility: Sipity::Exporters::BaseExporter::ApiFileUtils)
-          end
-          let(:filename) { File.join(temporary_directory, "#{attachment.pid}-#{attachment.file_name}") }
-          let(:path) { attachment.file.path }
-          let(:subject) do
-            described_class.new(work: work,
-                                exporter: exporter,
-                                work_to_attachments_converter: work_to_attachments_converter)
-          end
+        describe ':api' do
+          let(:ingest_method) { :api }
+          let(:file_utility) { Sipity::Exporters::BaseExporter::ApiFileUtils}
+          let(:file_writer) { ApiFileWriter }
+          let (:data_directory) { '/tmp/sipity-1661/files' }
 
-          before do
-            allow(exporter).to receive(:with_path_to_data_directory).and_yield(temporary_directory)
-          end
-
-          it "calls the api for each of the attachments" do
-            expect(ApiFileUtils).to receive(:put_file).with(filename, path)
+          it "calls writes attachments as a json file" do
+            expect(ApiFileWriter).to receive(:call).with(content: content, path: filename)
             subject.call
           end
         end


### PR DESCRIPTION
Rather than sending full attachment files via HTTP request during
export, create a json file of the attachment location information, and
add that file to the request.