### PR TITLE
Defaulting UI to start with only terminal states

### DIFF
--- a/app/forms/sipity/forms/work_areas/core/show_form.rb
+++ b/app/forms/sipity/forms/work_areas/core/show_form.rb
@@ -17,7 +17,7 @@ module Sipity
             self.requested_by = requested_by
             self.processing_action_form = processing_action_form_builder.new(form: self, **keywords)
             self.search_criteria_config = keywords.fetch(:search_criteria_config) { default_search_criteria_config }
-            self.processing_states = attributes[:processing_states]
+            self.processing_states = attributes.fetch(:processing_states) { default_processing_states }
             self.submission_window = attributes[:submission_window]
             self.q = attributes[:q]
             self.order = attributes.fetch(:order) { default_order }
@@ -61,6 +61,10 @@ module Sipity
           delegate :name, :slug, to: :work_area
 
           private
+
+          def default_processing_states
+            repository.processing_state_names_for_select_within_work_area(work_area: work_area, include_terminal: false)
+          end
 
           delegate :default_order, :default_page, :order_options_for_select, to: :search_criteria_config
           attr_accessor :search_criteria_config


### PR DESCRIPTION
Prior to this commit, the UI did not start with any processing states
selected.  Which, by default, meant include all of them in the filter.

<img width="540" alt="Screen Shot 2021-08-19 at 11 43 08 AM" src="https://user-images.githubusercontent.com/2130/130099424-c3d049d0-f5fc-410d-b871-8456247a43eb.png">
(Notice the PREP URL with no items selected)

After this commit, the UI now defaults to the non-terminal states being
selected.

<img width="531" alt="Screen Shot 2021-08-19 at 11 43 33 AM" src="https://user-images.githubusercontent.com/2130/130099506-02489f5a-39f0-48ea-bb7b-e22a5140bafe.png">

(notice the DEV URL with items selected by default)