### PR TITLE
Enlarge page size for exporter queries

### DIFF
--- a/app/jobs/sipity/jobs/core/bulk_ingest_job.rb
+++ b/app/jobs/sipity/jobs/core/bulk_ingest_job.rb
@@ -91,7 +91,7 @@ module Sipity
 
         def set_search_criteria!
           @search_criteria = search_criteria_builder.call(
-            user: requested_by, processing_state: initial_processing_state_name, work_area: work_area_slug
+            user: requested_by, processing_state: initial_processing_state_name, work_area: work_area_slug, per: 1000
           )
         end
 


### PR DESCRIPTION
Exporters only handle one page of items. Rather than expend a large amount of time to handle pagination in the exporters, it is much easier to just override the default page size for exporter queries.

Resolves CURATE-342