### PR TITLE
Use Entity Registry to track file replacements

### DIFF
--- a/app/repositories/sipity/commands/todo_list_commands.rb
+++ b/app/repositories/sipity/commands/todo_list_commands.rb
@@ -16,6 +16,12 @@ module Sipity
         )
       end
 
+      def unregister_action_taken_on_entity_by_anyone(entity:, action:, requested_by:, **keywords)
+        Services::ActionTakenOnEntity.unregister_entity_action(
+          entity: entity, action: action, requested_by: requested_by, **{ repository: self }.merge(keywords)
+        )
+      end
+
       # @api public
       #
       # Responsible for capturing a :comment made by a given :commenter on a

--- a/app/repositories/sipity/queries/attachment_queries.rb
+++ b/app/repositories/sipity/queries/attachment_queries.rb
@@ -18,11 +18,13 @@ module Sipity
         scope.order(query_order)
       end
 
+      REPEATABLE_TERMINAL_ACTION = ['ingest_completed']
       def replaced_work_attachments(work:, predicate_name: :all, order: :none)
         # find the most recent ingest date
         proxies = Sipity::Models::Processing::Entity.where(proxy_for_id: work.id)
         proxy_id = proxies.first.id
-        ingested = Sipity::Models::EventLog.where(entity_id: proxy_id, event_name: "ingest_completed/submit")
+        actions_to_test =  Models::Processing::StrategyAction.where(name: REPEATABLE_TERMINAL_ACTION)
+        ingested = Models::Processing::EntityActionRegister.where(entity_id: proxy_id, strategy_action_id: actions_to_test)
 
         if ingested.present?
           # find the prior ingest date

--- a/scripts/one-offs/callback.rb
+++ b/scripts/one-offs/callback.rb
@@ -2,13 +2,8 @@
 work_id = 'xO4iXDK2KdB2duXXpJR7sw=='
 process = 'ingest_completed' # or 'doi_completed'
 Sipity::Models::WorkRedirectStrategy.where(work_id: work_id).destroy_all
-callback_url = Sipity::Exporters::BatchIngestExporter::WebhookWriter.send(:callback_url, work_id: work_id, process: process)
+callback_url = Sipity::Exporters::BaseExporter::WebhookWriter.send(:callback_url, work_id: work_id, process: process)
 callback_url.gsub!(' ', '%20')
-payload = {
-  "host" => "curatewkrprod.library.nd.edu",
-  "version" => "1.1.5",
-  "job_name" => "sipity-#{work_id}",
-  "job_state" => "success"
-}
+payload = { "host" => "curatewkrprod.library.nd.edu", "version" => "1.1.5", "job_name" => "sipity-#{work_id}", "job_state" => "success" }
 response = RestClient.post(callback_url, payload.to_json)
 puts response.body

--- a/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
+++ b/spec/forms/sipity/forms/work_submissions/core/ingest_completed_form_spec.rb
@@ -78,6 +78,10 @@ module Sipity
               expect(repository).to receive(:create_redirect_for).with(work: work, url: kind_of(String))
               subject.submit
             end
+            it 'removes registrations' do
+              expect(repository).to receive(:unregister_action_taken_on_entity_by_anyone).with(entity: work, action: 'update_file', requested_by: user)
+              subject.submit
+            end
           end
         end
       end

--- a/spec/repositories/sipity/commands/todo_list_commands_spec.rb
+++ b/spec/repositories/sipity/commands/todo_list_commands_spec.rb
@@ -23,6 +23,14 @@ module Sipity
         end
       end
 
+      context '#unregister_action_taken_on_entity_by_anyone' do
+        let(:existing_action) { 'describe' }
+        it "will call the underlying service object" do
+          expect(Services::ActionTakenOnEntity).to receive(:unregister_entity_action)
+          test_repository.unregister_action_taken_on_entity_by_anyone(entity: work, action: existing_action, requested_by: user)
+        end
+      end
+
       context '#record_processing_comment' do
         let(:entity) { Models::Processing::Entity.new(id: 1, strategy_id: strategy.id, strategy_state_id: state.id, strategy_state: state) }
         let(:actor) { Models::Processing::Actor.new(id: 2) }

--- a/spec/services/sipity/services/action_taken_on_entity_spec.rb
+++ b/spec/services/sipity/services/action_taken_on_entity_spec.rb
@@ -32,7 +32,8 @@ module Sipity
 
       [
         :register,
-        :unregister
+        :unregister,
+        :unregister_entity_action
       ].each do |method_name|
         context ".#{method_name}" do
           it "will delegate do the unerlying #initialize then ##{method_name}" do
@@ -85,6 +86,15 @@ module Sipity
         context 'with a valid action object for the given entity' do
           it 'will attempt to destroy the entry' do
             expect { subject.unregister }.to_not change { Models::Processing::EntityActionRegister.count }
+          end
+        end
+      end
+
+      context '#unregister_entity_action' do
+        context 'with a valid action object for the given entity' do
+          it 'will increment then decrement' do
+            expect { subject.register }.to change { Models::Processing::EntityActionRegister.count }.by(1)
+            expect { subject.unregister_entity_action }.to change { Models::Processing::EntityActionRegister.count }.by(-1)
           end
         end
       end

--- a/spec/support/sipity/command_repository_interface.rb
+++ b/spec/support/sipity/command_repository_interface.rb
@@ -357,6 +357,10 @@ module Sipity
     def unregister_action_taken_on_entity(entity:, action:, requested_by:, **keywords)
     end
 
+    # @see ./app/repositories/sipity/commands/todo_list_commands.rb
+    def unregister_action_taken_on_entity_by_anyone(entity:, action:, **keywords)
+    end
+
     # @see ./app/repositories/sipity/commands/redirect_commands.rb
     def update_previous_open_ended_redirects_for(work:, as_of:)
     end


### PR DESCRIPTION
DAS-3027 (Related to https://github.com/ndlib/sipity/pull/1306) 

After a file is replaced and re-ingested, the "Replace File" to-do item was marked as complete, and the "Reingest File" action button is active. 

Since file replacement can be repeated multiple times, this problem is solved by removing the Entity Action Registration for "replace file" once the ingest is complete as part of the callback from batch ingest. 